### PR TITLE
Fix to prevent className in the name field on a standardizedError configuration.

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
@@ -19,8 +19,8 @@ package io.syndesis.common.model;
  * This class is used to track the current model schema version.
  */
 public final class Schema {
-    // changing this will reset all the DB data.
-    public static final int VERSION = 41;
+    // changing this kick of migration of the DB data to this version.
+    public static final int VERSION = 42;
 
     private Schema() {
       // quasi utility class

--- a/app/common/util/src/main/java/io/syndesis/common/util/CamelCase.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/CamelCase.java
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.syndesis.connector.sql.customizer;
+package io.syndesis.common.util;
 
-public final class SqlErrorCategory {
+public final class CamelCase {
 
-    public static final String SQL_CONNECTOR_ERROR        = "SQL_CONNECTOR_ERROR";
-    public static final String SQL_DATA_ACCESS_ERROR      = "SQL_DATA_ACCESS_ERROR";
-    public static final String SQL_ENTITY_NOT_FOUND_ERROR = "SQL_ENTITY_NOT_FOUND_ERROR";
+    private CamelCase() {}
 
-    private SqlErrorCategory() {
-        // holds constants
+    /** Convert CamelCase to Underscore
+     * for example 'MyCoolName' becomes 'my_cool_name'
+     * @param text containing the string using Camel Case
+     * @return text using an underscore for each Camel Case
+     */
+    public static String toUnderscore(final String text) {
+        return text.replaceAll("([^_A-Z])([A-Z])", "$1_$2");
     }
 }

--- a/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
@@ -15,11 +15,145 @@
  */
 package io.syndesis.common.util;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 public final class ErrorCategory {
 
-    public static final String SERVER_ERROR = "SERVER_ERROR";
+    //Sydesis Categories
+    public static final String SERVER_ERROR           = "SERVER_ERROR";
+    public static final String CONNECTOR_ERROR        = "CONNECTOR_ERROR";
+    public static final String ENTITY_NOT_FOUND_ERROR = "ENTITY_NOT_FOUND_ERROR";
 
-    private ErrorCategory() {
-        // quasi utility class
+    //Spring RuntimeExceptions Categories
+    public static final String DATA_ACCESS_ERROR               = "DATA_ACCESS_ERROR";
+    public static final String NON_TRANSIENT_DATA_ACCESS_ERROR = "NON_TRANSIENT_DATA_ACCESS_ERROR";
+    public static final String DATA_INTEGRITY_VIOLATION_ERROR  = "DATA_INTEGRITY_VIOLATION_ERROR";
+    public static final String DUPLICATE_KEY_ERROR             = "DUPLICATE_KEY_ERROR";
+    public static final String TRANSIENT_DATA_ACCESS_ERROR     = "TRANSIENT_DATA_ACCESS_ERROR";
+
+    public static final Map<String,String> RUNTIME_EXCEPTION_CATEGORY_MAP = initExceptionCategoryMap();
+    public static final Map<String,String> CATEGORY_HIERACHY_MAP = initCategoryHierachyMap();
+
+    private ErrorCategory() {}
+
+    //Mapping Categories to their Parent
+    private static Map<String,String> initCategoryHierachyMap() {
+        Map<String,String> map = new HashMap<>();
+        map.put(NON_TRANSIENT_DATA_ACCESS_ERROR, DATA_ACCESS_ERROR);
+        map.put(DATA_INTEGRITY_VIOLATION_ERROR, NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put(DUPLICATE_KEY_ERROR, DATA_INTEGRITY_VIOLATION_ERROR);
+        map.put(TRANSIENT_DATA_ACCESS_ERROR, DATA_ACCESS_ERROR);
+        return Collections.unmodifiableMap(map);
     }
+
+    //Mapping RuntimeExceptions to Categories
+    private static Map<String,String> initExceptionCategoryMap() {
+        Map<String,String> map = new HashMap<>();
+        //DataAccessExceptions
+        map.put("org.springframework.dao.DataAccessException", DATA_ACCESS_ERROR);
+        //  NonTransientDataAccessExceptions
+        map.put("org.springframework.dao.NonTransientDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.CleanupFailureDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.DataIntegrityViolationException", DATA_INTEGRITY_VIOLATION_ERROR);
+        map.put("org.springframework.dao.DuplicateKeyException", DUPLICATE_KEY_ERROR);
+        map.put("org.springframework.dao.DataRetrievalFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.IncorrectResultSetColumnCountException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.IncorrectResultSizeDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.LobRetrievalFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.ObjectRetrievalFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.hibernate5.HibernateObjectRetrievalFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.jpa.JpaObjectRetrievalFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.datasource.lookup.DataSourceLookupFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.InvalidDataAccessApiUsageException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.support.xml.SqlXmlFeatureNotImplementedException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.BadSqlGrammarException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.CciOperationNotSupportedException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.hibernate5.HibernateQueryException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.IncorrectUpdateSemanticsDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.JdbcUpdateAffectedIncorrectNumberOfRowsException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.InvalidResultSetAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.InvalidResultSetAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.RecordTypeNotSupportedException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.TypeMismatchDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.NonTransientDataAccessResourceException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.DataAccessResourceFailureException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.CannotCreateRecordException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.CannotGetCciConnectionException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.CannotGetJdbcConnectionException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.PermissionDeniedDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.UncategorizedDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.hibernate5.HibernateJdbcException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.hibernate5.HibernateSystemException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.jpa.JpaSystemException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.SQLWarningException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.UncategorizedSQLException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.InvalidDataAccessResourceUsageException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.BadSqlGrammarException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.CciOperationNotSupportedException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.orm.hibernate5.HibernateQueryException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.IncorrectUpdateSemanticsDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.InvalidResultSetAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.jca.cci.RecordTypeNotSupportedException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.TypeMismatchDataAccessException", NON_TRANSIENT_DATA_ACCESS_ERROR);
+
+        // Recoverable Exception
+        map.put("org.springframework.dao.RecoverableDataAccessException", DATA_ACCESS_ERROR);
+
+        // Script Exceptions
+        map.put("org.springframework.jdbc.datasource.init.ScriptException", DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.datasource.init.CannotReadScriptException", DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.datasource.init.ScriptParseException", DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.datasource.init.ScriptStatementFailedException", DATA_ACCESS_ERROR);
+        map.put("org.springframework.jdbc.datasource.init.UncategorizedScriptException", DATA_ACCESS_ERROR);
+
+        //  TransientDataAccessExceptions
+        map.put("org.springframework.dao.TransientDataAccessException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.ConcurrencyFailureException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.OptimisticLockingFailureException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.PessimisticLockingFailureException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.CannotAcquireLockException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.CannotSerializeTransactionException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.DeadlockLoserDataAccessException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.QueryTimeoutException", TRANSIENT_DATA_ACCESS_ERROR);
+        map.put("org.springframework.dao.TransientDataAccessResourceException", TRANSIENT_DATA_ACCESS_ERROR);
+
+        return Collections.unmodifiableMap(map);
+    }
+
+    public static boolean isCategorized(Throwable exception) {
+        return ErrorCategory.RUNTIME_EXCEPTION_CATEGORY_MAP.containsKey(exception.getClass().getSimpleName());
+    }
+    /**
+     *
+     * @param exception
+     * @param integrationCategories
+     * @return
+     */
+    public static String getCategory(Throwable exception, Set<String> integrationCategories) {
+        if (isCategorized(exception)) {
+            String category = ErrorCategory.RUNTIME_EXCEPTION_CATEGORY_MAP.get(exception.getClass().getSimpleName());
+            if (integrationCategories.contains(category)) {
+                return category;
+            }
+            while (hasParentCategory(category)) {
+                category = getParentCategory(category);
+                if (integrationCategories.contains(category)) {
+                    return category;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasParentCategory(final String category) {
+        return CATEGORY_HIERACHY_MAP.containsKey(category);
+    }
+
+    private static String getParentCategory(final String category) {
+        return CATEGORY_HIERACHY_MAP.get(category);
+    }
+
 }

--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderOnExceptionHandler.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderOnExceptionHandler.java
@@ -32,7 +32,7 @@ public class ApiProviderOnExceptionHandler implements Processor, Properties {
     private static final String HTTP_ERROR_RESPONSE_CODES_PROPERTY = "errorResponseCodes";
     private static final String ERROR_RESPONSE_BODY                = "returnBody";
 
-    Map<String, String> errorResponseCodeMappings;
+    Map<String, Integer> errorResponseCodeMappings;
     Boolean isReturnBody;
     Integer httpResponseStatus;
 
@@ -41,7 +41,7 @@ public class ApiProviderOnExceptionHandler implements Processor, Properties {
         Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
         ErrorStatusInfo statusInfo =
                 ErrorMapper.mapError(cause, errorResponseCodeMappings, httpResponseStatus);
-        exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getResponseCode());
+        exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getHttpResponseCode());
         if (isReturnBody) {
             exchange.getIn().setBody(statusInfo.toJson());
         } else {

--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
@@ -71,7 +71,7 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
             }
         }
 
-        Map<String, String> errorResponseCodeMappings = ErrorMapper.jsonToMap(
+        Map<String, Integer> errorResponseCodeMappings = ErrorMapper.jsonToMap(
                 ConnectorOptions.extractOptionAndMap(options, HTTP_ERROR_RESPONSE_CODES_PROPERTY, String::valueOf, ""));
         Boolean isReturnBody =
                 ConnectorOptions.extractOptionAndMap(options, ERROR_RESPONSE_BODY, Boolean::valueOf, false);
@@ -81,13 +81,13 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
         component.setAfterProducer(statusCodeUpdater(httpResponseStatus, errorResponseCodeMappings, isReturnBody));
     }
 
-    private static Processor statusCodeUpdater(Integer responseCode, Map<String, String> errorResponseCodeMappings,
+    private static Processor statusCodeUpdater(Integer responseCode, Map<String, Integer> errorResponseCodeMappings,
             Boolean isReturnBody) {
         return exchange -> {
             if (exchange.getException() != null) {
                 ErrorStatusInfo statusInfo =
                         ErrorMapper.mapError(exchange.getException(), errorResponseCodeMappings, responseCode);
-                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getResponseCode());
+                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getHttpResponseCode());
                 if (isReturnBody) {
                     exchange.getIn().setBody(statusInfo.toJson());
                 } else {

--- a/app/connector/api-provider/src/main/resources/META-INF/syndesis/connector/api-provider.json
+++ b/app/connector/api-provider/src/main/resources/META-INF/syndesis/connector/api-provider.json
@@ -48,6 +48,10 @@
         "componentScheme": "bean",
         "standardizedErrors": [
           {
+            "name": "TRANSIENT_DATA_ACCESS_ERROR",
+            "displayName": "TransientDataAccessError"
+          },
+          {
             "name": "SERVER_ERROR",
             "displayName": "ServerError"
           }

--- a/app/connector/api-provider/src/test/java/io/syndesis/connector/apiprovider/OnExceptionHandlerTest.java
+++ b/app/connector/api-provider/src/test/java/io/syndesis/connector/apiprovider/OnExceptionHandlerTest.java
@@ -35,7 +35,7 @@ public class OnExceptionHandlerTest {
     private static final String ERROR_RESPONSE_BODY                = "returnBody";
 
 
-    static final String ERROR_RESPONSE_CODES = "{\"SQL_CONNECTOR_ERROR\":\"500\",\"SERVER_ERROR\":\"500\",\"SQL_DATA_ACCESS_ERROR\":\"400\",\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\"}";
+    static final String ERROR_RESPONSE_CODES = "{\"CONNECTOR_ERROR\":\"500\",\"SERVER_ERROR\":\"500\",\"DATA_ACCESS_ERROR\":\"400\",\"ENTITY_NOT_FOUND_ERROR\":\"404\"}";
 
     @Test
     public void testEmptyResponseBodyOnError() {
@@ -46,7 +46,7 @@ public class OnExceptionHandlerTest {
         configuredProperties.put(ERROR_RESPONSE_BODY               , "false");
 
         Exception e = new SyndesisConnectorException(
-                "SQL_CONNECTOR_ERROR", "error msg test");
+                "CONNECTOR_ERROR", "error msg test");
 
         CamelContext context = new DefaultCamelContext();
         Exchange exchange = new ExchangeBuilder(context).build();
@@ -64,7 +64,7 @@ public class OnExceptionHandlerTest {
     @Test
     public void testErrorStatusInfoResponse() {
  
-        String expectedBody = "{\"responseCode\":404,\"category\":\"SQL_ENTITY_NOT_FOUND_ERROR\",\"message\":\"entity not found\"}";
+        String expectedBody = "{\"httpResponseCode\":404,\"category\":\"ENTITY_NOT_FOUND_ERROR\",\"message\":\"entity not found\",\"error\":\"syndesis_connector_error\"}";
 
         Map<String,String> configuredProperties = new HashMap<>();
         configuredProperties.put(HTTP_RESPONSE_CODE_PROPERTY       , "200");
@@ -72,7 +72,7 @@ public class OnExceptionHandlerTest {
         configuredProperties.put(ERROR_RESPONSE_BODY               , "true");
 
         Exception e = new SyndesisConnectorException(
-                "SQL_ENTITY_NOT_FOUND_ERROR", "entity not found");
+                "ENTITY_NOT_FOUND_ERROR", "entity not found");
 
         Exchange exchange = new ExchangeBuilder(new DefaultCamelContext()).build();
         exchange.setProperty(Exchange.EXCEPTION_CAUGHT, e);

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -217,6 +217,14 @@
 
     <plugins>
       <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.apache.camel:camel-sql:jar</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <delimiters>

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlConnectorCustomizer.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.SqlParameterValue;
 
+import io.syndesis.common.util.ErrorCategory;
 import io.syndesis.common.util.SyndesisConnectorException;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.connector.sql.common.DbMetaDataHelper;
@@ -78,7 +79,7 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
                 try {
                     jsonBeans = JsonUtils.arrayToJsonBeans(JsonUtils.reader().readTree(body));
                 } catch (IOException e) {
-                    throw SyndesisConnectorException.wrap(SqlErrorCategory.SQL_DATA_ACCESS_ERROR, e);
+                    throw SyndesisConnectorException.wrap(ErrorCategory.DATA_ACCESS_ERROR, e);
                 }
             } else if (JsonUtils.isJson(body)) {
                 jsonBeans = Collections.singletonList(body);
@@ -106,7 +107,7 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
 
         if (exchange.getException()!=null) {
             throw SyndesisConnectorException.wrap(
-                    SqlErrorCategory.SQL_CONNECTOR_ERROR, exchange.getException());
+                    ErrorCategory.CONNECTOR_ERROR, exchange.getException());
         }
         final Message in = exchange.getIn();
         //converting SQL Map or List results to JSON Beans
@@ -121,7 +122,7 @@ public final class SqlConnectorCustomizer implements ComponentProxyCustomizer {
         }
         if (isRaiseErrorOnNotFound && !isRecordsFound(in))  {
             String detailedMsg = "SQL " + statementType.name() + " did not " + statementType +  " any records";
-            throw new SyndesisConnectorException(SqlErrorCategory.SQL_ENTITY_NOT_FOUND_ERROR, detailedMsg);
+            throw new SyndesisConnectorException(ErrorCategory.ENTITY_NOT_FOUND_ERROR, detailedMsg);
         }
     }
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/customizer/SqlStartConnectorCustomizer.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 import javax.sql.DataSource;
 
 import io.syndesis.connector.sql.common.DbMetaDataHelper;
-
+import io.syndesis.common.util.ErrorCategory;
 import io.syndesis.common.util.SyndesisConnectorException;
 
 import io.syndesis.connector.sql.common.JSONBeanUtil;
@@ -68,7 +68,7 @@ public final class SqlStartConnectorCustomizer implements ComponentProxyCustomiz
     private void doAfterProducer(Exchange exchange) {
         Exception e = exchange.getException();
         if (e != null) {
-            throw SyndesisConnectorException.wrap(SqlErrorCategory.SQL_CONNECTOR_ERROR, e);
+            throw SyndesisConnectorException.wrap(ErrorCategory.CONNECTOR_ERROR, e);
         }
         final Message in = exchange.getIn();
         List<String> list = null;

--- a/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
+++ b/app/connector/sql/src/main/resources/META-INF/syndesis/connector/sql.json
@@ -7,20 +7,20 @@
         "componentScheme": "sql",
         "standardizedErrors": [
           {
-            "name": "SQL_DATA_ACCESS_ERROR",
-            "displayName": "SqlDataAccessError"
+            "name": "DATA_ACCESS_ERROR",
+            "displayName": "DataAccessError"
           },
           {
-            "name": "SQL_ENTITY_NOT_FOUND_ERROR",
-            "displayName": "SqlEntityNotFoundError"
+            "name": "ENTITY_NOT_FOUND_ERROR",
+            "displayName": "EntityNotFoundError"
           },
           {
-            "name": "org.springframework.dao.DuplicateKeyException",
-            "displayName": "SqlDuplicateKeyError"
+            "name": "DUPLICATE_KEY_ERROR",
+            "displayName": "DuplicateKeyError"
           },
           {
-            "name": "SQL_CONNECTOR_ERROR",
-            "displayName": "SqlConnectorError"
+            "name": "CONNECTOR_ERROR",
+            "displayName": "ConnectorError"
           }
         ],
         "connectorCustomizers": [

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlConnectorQueryTest.java
@@ -105,7 +105,7 @@ public class SqlConnectorQueryTest extends SqlConnectorTestSupport {
 									private static final long serialVersionUID = 1L;
 									{
                         				put("EXCEPTION_MESSAGE", "SQL SELECT did not SELECT any records" );
-                        				put("EXCEPTION_CATEGORY", "SQL_ENTITY_NOT_FOUND_ERROR");
+                        				put("EXCEPTION_CATEGORY", ErrorCategory.ENTITY_NOT_FOUND_ERROR);
                         			}
                         		}
                         	),

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/ErrorStatusInfo.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/ErrorStatusInfo.java
@@ -23,24 +23,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class ErrorStatusInfo {
 
-    private Integer responseCode;
+    private Integer httpResponseCode;
     private String category;
     private String message;
+    private String error;
 
     private static final Logger LOG = LoggerFactory.getLogger(ErrorStatusInfo.class);
 
-    public ErrorStatusInfo(Integer responseCode, String category, String message) {
-        this.responseCode = responseCode;
+    public ErrorStatusInfo(Integer httpResponseCode, String category, String message, String error) {
+        this.httpResponseCode = httpResponseCode;
         this.message = message;
         this.category = category;
+        this.error = error;
     }
 
-    public Integer getResponseCode() {
-        return responseCode;
+    public Integer getHttpResponseCode() {
+        return httpResponseCode;
     }
 
-    public void setResponseCode(Integer responseCode) {
-        this.responseCode = responseCode;
+    public void setHttpResponseCode(Integer httpResponseCode) {
+        this.httpResponseCode = httpResponseCode;
     }
 
     public String getCategory() {
@@ -66,5 +68,13 @@ public class ErrorStatusInfo {
             LOG.warn(e.getMessage());
             return "";
         }
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
     }
 }

--- a/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookOnExceptionHandler.java
+++ b/app/connector/webhook/src/main/java/io/syndesis/connector/webhook/WebhookOnExceptionHandler.java
@@ -32,7 +32,7 @@ public class WebhookOnExceptionHandler implements Processor, Properties {
     private static final String HTTP_ERROR_RESPONSE_CODES_PROPERTY = "errorResponseCodes";
     private static final String ERROR_RESPONSE_BODY                = "returnBody";
 
-    Map<String, String> errorResponseCodeMappings;
+    Map<String, Integer> errorResponseCodeMappings;
     Boolean isReturnBody;
     Integer httpResponseStatus;
 
@@ -41,7 +41,7 @@ public class WebhookOnExceptionHandler implements Processor, Properties {
         ErrorStatusInfo statusInfo =
                 ErrorMapper.mapError(exchange.getException(), errorResponseCodeMappings, httpResponseStatus);
         exchange.getOut().removeHeaders("*");
-        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getResponseCode());
+        exchange.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, statusInfo.getHttpResponseCode());
         if (isReturnBody) {
             exchange.getOut().setBody(statusInfo.toJson());
         } else {

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -658,6 +658,11 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
 

--- a/app/server/runtime/src/main/resources/migrations/up-42.js
+++ b/app/server/runtime/src/main/resources/migrations/up-42.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+console.log("Migrating to schema 42 ...");
+console.log("This migration will update standardizedError keys and names");
+
+var migrateConnector = function(connector) {
+    if (!connector) {
+        return false;
+    }
+    var changed = false;
+    if (connector.id === "sql") {
+        console.log("Migrating connector: " + connector.id);
+        connector.actions.forEach(function (action) {
+            migrateSqlAction(action);
+            changed = true;
+        });
+    }
+    return changed;
+}
+
+var migrateSqlAction = function(action) {
+    if (!action || (! (action.id === 'sql-connector' || action.id === 'sql-start-connector'
+    	|| action.id === 'sql-stored-connector' || action.id === 'sql-stored-start-connector'))) {
+        return false;
+    }
+    console.log("Migrating action: " + action.id);
+
+    action.descriptor.standardizedErrors = [
+        {
+          "name": "DATA_ACCESS_ERROR",
+          "displayName": "DataAccessError"
+        },
+        {
+          "name": "ENTITY_NOT_FOUND_ERROR",
+          "displayName": "EntityNotFoundError"
+        },
+        {
+          "name": "DUPLICATE_KEY_ERROR",
+          "displayName": "DuplicateKeyError"
+        },
+        {
+          "name": "CONNECTOR_ERROR",
+          "displayName": "ConnectorError"
+        }
+    ];
+    return true
+}
+
+var migrateConnection = function(connection) {
+    if (!connection) {
+        return false;
+    }
+
+    if (migrateConnector(connection.connector)) {
+        return true
+    }
+
+    return false
+}
+
+var migrateStep = function(step) {
+    if (!step) {
+        return false;
+    }
+
+    var done = false;
+    done |=  migrateSqlAction(step.action);
+    done |=  migrateConnection(step.connection);
+
+    if (step.configuredProperties) {
+        for (property in step.configuredProperties) {
+            if (property === 'errorResponseCodes') {
+                json = step.configuredProperties[property];
+                json = json.replace(/SQL_/g, '');
+                json = json.replace(/org.springframework.dao.DuplicateKeyException/g, 'DUPLICATE_KEY_ERROR');
+                step.configuredProperties[property] = json;
+                done |= true;
+            }
+        }
+    }
+    return done;
+}
+
+migrate("connectors", "/connectors", migrateConnector);
+migrate("connections", "/connections", function(connection) {
+    return migrateConnector(connection.connector);
+});
+
+migrate("integrations", "/integrations", function(integration) {
+    var done = true;
+
+    if (integration.steps) {
+        integration.steps.forEach(function (step) {
+            console.log("")
+            done |= migrateStep(step)
+        });
+    }
+
+    if (integration.flows) {
+        integration.flows.forEach(function (flow) {
+            
+            flow.steps.forEach(function (step) {
+                console.log("flow " + flow.id + " : step " + step.id);
+                done |= migrateStep(step)
+            });
+        });
+    }
+
+    return done;
+});
+
+console.log("Migration to schema 42 completed");

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/MigrationsHelper.java
@@ -39,7 +39,7 @@ final class MigrationsHelper {
 
                 items.add(item);
             } catch (final IOException e) {
-                throw new RuntimeException();
+                throw new RuntimeException(e);
             }
         });
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion42Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion42Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.runtime.migrations;
+
+import static io.syndesis.server.runtime.migrations.MigrationsHelper.load;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.action.ConnectorDescriptor.StandardizedError;
+import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.server.jsondb.CloseableJsonDB;
+import io.syndesis.server.jsondb.dao.Migrator;
+import io.syndesis.server.jsondb.impl.MemorySqlJsonDB;
+import io.syndesis.server.runtime.DefaultMigrator;
+
+public class UpgradeVersion42Test {
+
+    @Test
+    public void shouldPerformSchemaUpgrade() throws IOException {
+        try (CloseableJsonDB jsondb = MemorySqlJsonDB.create(Collections.emptyList());
+            InputStream is = UpgradeVersion42Test.class.getResourceAsStream("/migrations/42/integration.json")) {
+            jsondb.push("/integrations", is);
+
+            final Migrator migrator = new DefaultMigrator(new DefaultResourceLoader());
+            migrator.migrate(jsondb, 42);
+
+            final List<Integration> integrations = load(jsondb, "/integrations", Integration.class);
+
+            // integrations
+            assertThat(integrations).hasSize(1);
+
+            final Integration integration = integrations.get(0);
+            for (Flow flow : integration.getFlows()) {
+                for (Step step : flow.getSteps()) {
+                    if (step.getAction().isPresent() && step.getAction().get().getDescription() !=null) {
+                        if (step.getAction().get().getDescriptor() instanceof ConnectorDescriptor) {
+                            List<StandardizedError> standardizedErrors = ((ConnectorDescriptor)step.getAction().get().getDescriptor()).getStandardizedErrors();
+                            for (StandardizedError error : standardizedErrors) {
+                                assertThat(error.name().startsWith("SQL_")).isFalse();
+                            }
+                        }
+                    }
+                    if (step.getConfiguredProperties().containsKey("errorResponseCodes")) {
+                        String json = step.getConfiguredProperties().get("errorResponseCodes");
+                        assertThat(json.contains("SQL_")).isFalse();
+                        assertThat(json.contains("org.springframework.dao.DuplicateKeyException")).isFalse();
+                    }
+                }
+            }
+        }
+    } 
+
+}

--- a/app/server/runtime/src/test/resources/migrations/42/integration.json
+++ b/app/server/runtime/src/test/resources/migrations/42/integration.json
@@ -1,0 +1,5419 @@
+
+  {
+    "createdAt": 1580318846030,
+    "flows": [
+      {
+        "description": "GET /",
+        "id": "i-LzmKKuAdexCgwPv3VhKz",
+        "metadata": {
+          "default-return-code": "200",
+          "excerpt": "200 All is good",
+          "openapi-operationid": "fetch-all-tasks",
+          "return-code-edited": "true"
+        },
+        "name": "List all tasks",
+        "steps": [
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Start a Syndesis integration from a provided API",
+              "descriptor": {
+                "componentScheme": "direct",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "name": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The operation ID as defined in the API spec",
+                        "displayName": "Operation ID",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "required": true,
+                        "secret": false,
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-start",
+              "metadata": {
+                "serverBasePath": "/"
+              },
+              "name": "Provided API",
+              "pattern": "From",
+              "tags": [
+                "expose",
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "name": "fetch-all-tasks"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKu-dexCgwPv3VhIz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Invoke SQL to obtain, store, update, or delete data.",
+              "descriptor": {
+                "componentScheme": "sql",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none",
+                  "type": "SQL_PARAM_IN"
+                },
+                "outputDataShape": {
+                  "description": "Result of SQL [SELECT * FROM TODO]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "collection"
+                  },
+                  "name": "SQL Result",
+                  "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}}",
+                  "type": "SQL_PARAM_OUT"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                    "name": "SQL statement",
+                    "properties": {
+                      "batch": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Batch update",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "dataList": [
+                          "SELECT * FROM TODO"
+                        ],
+                        "defaultValue": "SELECT * FROM TODO",
+                        "deprecated": false,
+                        "displayName": "SQL statement",
+                        "group": "common",
+                        "javaType": "java.lang.String",
+                        "kind": "path",
+                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                        "order": 1,
+                        "placeholder": "for example ':#MYPARAMNAME'",
+                        "required": true,
+                        "secret": false,
+                        "type": "dataList"
+                      },
+                      "raiseErrorOnNotFound": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Raise error when record not found",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Error when no records are selected, updated or deleted",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "SqlDataAccessError",
+                    "name": "SQL_DATA_ACCESS_ERROR"
+                  },
+                  {
+                    "displayName": "SqlEntityNotFoundError",
+                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  },
+                  {
+                    "displayName": "SqlConnectorError",
+                    "name": "SQL_CONNECTOR_ERROR"
+                  }
+                ]
+              },
+              "id": "sql-connector",
+              "name": "Invoke SQL",
+              "pattern": "To",
+              "tags": [
+                "dynamic"
+              ]
+            },
+            "configuredProperties": {
+              "batch": "false",
+              "query": "SELECT * FROM TODO",
+              "raiseErrorOnNotFound": "false"
+            },
+            "connection": {
+              "configuredProperties": {
+                "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                "schema": "sampledb",
+                "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                "user": "sampledb"
+              },
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "batch": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Batch update",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                              "order": 1,
+                              "placeholder": "for example ':#MYPARAMNAME'",
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "raiseErrorOnNotFound": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Raise error when record not found",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Error when no records are selected, updated or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "SqlDataAccessError",
+                          "name": "SQL_DATA_ACCESS_ERROR"
+                        },
+                        {
+                          "displayName": "SqlEntityNotFoundError",
+                          "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                        },
+                        {
+                          "displayName": "SqlConnectorError",
+                          "name": "SQL_CONNECTOR_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "sql-connector",
+                    "name": "Invoke SQL",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke SQL to obtain data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that returns results, such as SELECT.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "isRaiseErrorOnNotFound": {
+                              "deprecated": false,
+                              "displayName": "Raise NotFoundError",
+                              "group": "consumer",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "parameter",
+                              "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed.",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-start-connector",
+                    "name": "Periodic SQL invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "property",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": false,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored procedure template to perform.",
+                              "required": false,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-connector",
+                    "name": "Invoke stored procedure",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored Procedure template to perform.",
+                              "required": true,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-start-connector",
+                    "name": "Periodic stored procedure invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  }
+                ],
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "jdbc-driver",
+                    "type": "EXTENSION_TAG"
+                  }
+                ],
+                "description": "Invoke SQL to obtain, store, update, or delete data.",
+                "icon": "assets:sql.svg",
+                "id": "sql",
+                "name": "Database",
+                "properties": {
+                  "password": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Password",
+                    "group": "security",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common,security",
+                    "labelHint": "Password for the database connection.",
+                    "order": 3,
+                    "required": true,
+                    "secret": true,
+                    "type": "string"
+                  },
+                  "schema": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Schema",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common",
+                    "labelHint": "Database schema.",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "url": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Connection URL",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "JDBC URL of the database.",
+                    "order": 1,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "user": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Username",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "Username for the database connection.",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  }
+                },
+                "tags": [
+                  "verifier"
+                ],
+                "version": 1
+              },
+              "connectorId": "sql",
+              "description": "Connection to SampleDB",
+              "icon": "assets:sql.svg",
+              "id": "5",
+              "isDerived": false,
+              "name": "PostgresDB",
+              "tags": [
+                "sampledb"
+              ],
+              "uses": 0
+            },
+            "id": "-LzmKo_efTAdq4stfbU-",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}}"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmKo_efTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmKo_efTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKu8dexCgwPv3VhJz\",\"uri\":\"atlas:json:i-LzmKKu8dexCgwPv3VhJz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.324856\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.167891\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.472896\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/<>/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body<>/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmKod9fTAdq4stfbU-",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "End action of Syndesis integrations that start from a provided API",
+              "descriptor": {
+                "componentScheme": "bean",
+                "configuredProperties": {
+                  "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                  "method": "process"
+                },
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}}"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Return Path Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "defaultResponse": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Default Response",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 0,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorHandling": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Error Handling",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorResponseCodes": {
+                        "componentProperty": false,
+                        "defaultValue": "{}",
+                        "deprecated": false,
+                        "description": "The return code to set according to different error situations",
+                        "displayName": "Error Response Codes",
+                        "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                        "javaType": "Map",
+                        "kind": "parameter",
+                        "order": 4,
+                        "required": false,
+                        "secret": false,
+                        "type": "mapset"
+                      },
+                      "httpResponseCode": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The return code to set in the HTTP response",
+                        "displayName": "Return Code",
+                        "enum": [
+                          {
+                            "label": "200 All is good",
+                            "value": "200"
+                          },
+                          {
+                            "label": "500 Server Error",
+                            "value": "500"
+                          }
+                        ],
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 1,
+                        "required": true,
+                        "secret": false,
+                        "type": "select"
+                      },
+                      "returnBody": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Include error message in the return body",
+                        "javaType": "Boolean",
+                        "kind": "parameter",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "ServerError",
+                    "name": "SERVER_ERROR"
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-end",
+              "name": "Provided API Return Path",
+              "pattern": "To",
+              "tags": [
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "errorResponseCodes": "{}",
+              "httpResponseCode": "200",
+              "returnBody": "false"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKu8dexCgwPv3VhJz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          }
+        ],
+        "tags": [
+          "5",
+          "api-provider"
+        ],
+        "type": "API_PROVIDER"
+      },
+      {
+        "description": "POST /",
+        "id": "i-LzmKKuCdexCgwPv3VhNz",
+        "metadata": {
+          "default-return-code": "201",
+          "excerpt": "201 All is good",
+          "openapi-operationid": "create-task",
+          "return-code-edited": "true"
+        },
+        "name": "Create new task",
+        "steps": [
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Start a Syndesis integration from a provided API",
+              "descriptor": {
+                "componentScheme": "direct",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "description": "API request payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Request",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "name": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The operation ID as defined in the API spec",
+                        "displayName": "Operation ID",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "required": true,
+                        "secret": false,
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-start",
+              "metadata": {
+                "serverBasePath": "/"
+              },
+              "name": "Provided API",
+              "pattern": "From",
+              "tags": [
+                "expose",
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "name": "create-task"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKuCdexCgwPv3VhLz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "Parameters of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhLz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhLz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL3kqfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL3kqfTAdq4stfbU-\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.762827\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.45448\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.237428\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmL5GrfTAdq4stfbU-",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Invoke SQL to obtain, store, update, or delete data.",
+              "descriptor": {
+                "componentScheme": "sql",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "Parameters of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                },
+                "outputDataShape": {
+                  "description": "Result of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "collection"
+                  },
+                  "name": "SQL Result",
+                  "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}}",
+                  "type": "SQL_PARAM_OUT"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                    "name": "SQL statement",
+                    "properties": {
+                      "batch": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Batch update",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "dataList": [
+                          "INSERT INTO TODO VALUES (:#id, :#task, :#completed)"
+                        ],
+                        "defaultValue": "INSERT INTO TODO VALUES (:#id, :#task, :#completed)",
+                        "deprecated": false,
+                        "displayName": "SQL statement",
+                        "group": "common",
+                        "javaType": "java.lang.String",
+                        "kind": "path",
+                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                        "order": 1,
+                        "placeholder": "for example ':#MYPARAMNAME'",
+                        "required": true,
+                        "secret": false,
+                        "type": "dataList"
+                      },
+                      "raiseErrorOnNotFound": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Raise error when record not found",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Error when no records are selected, updated or deleted",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "SqlDataAccessError",
+                    "name": "SQL_DATA_ACCESS_ERROR"
+                  },
+                  {
+                    "displayName": "SqlEntityNotFoundError",
+                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  },
+                  {
+                    "displayName": "SqlConnectorError",
+                    "name": "SQL_CONNECTOR_ERROR"
+                  }
+                ]
+              },
+              "id": "sql-connector",
+              "name": "Invoke SQL",
+              "pattern": "To",
+              "tags": [
+                "dynamic"
+              ]
+            },
+            "configuredProperties": {
+              "batch": "false",
+              "query": "INSERT INTO TODO VALUES (:#id, :#task, :#completed)",
+              "raiseErrorOnNotFound": "false"
+            },
+            "connection": {
+              "configuredProperties": {
+                "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                "schema": "sampledb",
+                "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                "user": "sampledb"
+              },
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "batch": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Batch update",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                              "order": 1,
+                              "placeholder": "for example ':#MYPARAMNAME'",
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "raiseErrorOnNotFound": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Raise error when record not found",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Error when no records are selected, updated or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "SqlDataAccessError",
+                          "name": "SQL_DATA_ACCESS_ERROR"
+                        },
+                        {
+                          "displayName": "SqlEntityNotFoundError",
+                          "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                        },
+                        {
+                          "displayName": "SqlConnectorError",
+                          "name": "SQL_CONNECTOR_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "sql-connector",
+                    "name": "Invoke SQL",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke SQL to obtain data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that returns results, such as SELECT.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "isRaiseErrorOnNotFound": {
+                              "deprecated": false,
+                              "displayName": "Raise NotFoundError",
+                              "group": "consumer",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "parameter",
+                              "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed.",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-start-connector",
+                    "name": "Periodic SQL invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "property",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": false,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored procedure template to perform.",
+                              "required": false,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-connector",
+                    "name": "Invoke stored procedure",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored Procedure template to perform.",
+                              "required": true,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-start-connector",
+                    "name": "Periodic stored procedure invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  }
+                ],
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "jdbc-driver",
+                    "type": "EXTENSION_TAG"
+                  }
+                ],
+                "description": "Invoke SQL to obtain, store, update, or delete data.",
+                "icon": "assets:sql.svg",
+                "id": "sql",
+                "name": "Database",
+                "properties": {
+                  "password": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Password",
+                    "group": "security",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common,security",
+                    "labelHint": "Password for the database connection.",
+                    "order": 3,
+                    "required": true,
+                    "secret": true,
+                    "type": "string"
+                  },
+                  "schema": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Schema",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common",
+                    "labelHint": "Database schema.",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "url": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Connection URL",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "JDBC URL of the database.",
+                    "order": 1,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "user": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Username",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "Username for the database connection.",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  }
+                },
+                "tags": [
+                  "verifier"
+                ],
+                "version": 1
+              },
+              "connectorId": "sql",
+              "description": "Connection to SampleDB",
+              "icon": "assets:sql.svg",
+              "id": "5",
+              "isDerived": false,
+              "name": "PostgresDB",
+              "tags": [
+                "sampledb"
+              ],
+              "uses": 0
+            },
+            "id": "-LzmL3kqfTAdq4stfbU-",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhLz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhLz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL5GrfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL5GrfTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL3kqfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL3kqfTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhMz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhMz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.191136\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.200510\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.843803\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmL81QfTAdq4stfbU0",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "End action of Syndesis integrations that start from a provided API",
+              "descriptor": {
+                "componentScheme": "bean",
+                "configuredProperties": {
+                  "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                  "method": "process"
+                },
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Return Path Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "defaultResponse": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Default Response",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 0,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorHandling": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Error Handling",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorResponseCodes": {
+                        "componentProperty": false,
+                        "defaultValue": "{}",
+                        "deprecated": false,
+                        "description": "The return code to set according to different error situations",
+                        "displayName": "Error Response Codes",
+                        "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"201 All is good\",\"value\":\"201\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                        "javaType": "Map",
+                        "kind": "parameter",
+                        "order": 4,
+                        "required": false,
+                        "secret": false,
+                        "type": "mapset"
+                      },
+                      "httpResponseCode": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The return code to set in the HTTP response",
+                        "displayName": "Return Code",
+                        "enum": [
+                          {
+                            "label": "201 All is good",
+                            "value": "201"
+                          },
+                          {
+                            "label": "500 Server Error",
+                            "value": "500"
+                          }
+                        ],
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 1,
+                        "required": true,
+                        "secret": false,
+                        "type": "select"
+                      },
+                      "returnBody": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Include error message in the return body",
+                        "javaType": "Boolean",
+                        "kind": "parameter",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "ServerError",
+                    "name": "SERVER_ERROR"
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-end",
+              "name": "Provided API Return Path",
+              "pattern": "To",
+              "tags": [
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "errorResponseCodes": "{}",
+              "httpResponseCode": "201",
+              "returnBody": "false"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKuCdexCgwPv3VhMz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          }
+        ],
+        "tags": [
+          "5",
+          "api-provider"
+        ],
+        "type": "API_PROVIDER"
+      },
+      {
+        "description": "GET /{id}",
+        "id": "i-LzmKKurdexCgwPv3VhQz",
+        "metadata": {
+          "default-return-code": "200",
+          "excerpt": "200 All is good",
+          "openapi-operationid": "fetch-task",
+          "return-code-edited": "true"
+        },
+        "name": "Fetches task by given identifier",
+        "steps": [
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Start a Syndesis integration from a provided API",
+              "descriptor": {
+                "componentScheme": "direct",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "description": "API request payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Request",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}}}}"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "name": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The operation ID as defined in the API spec",
+                        "displayName": "Operation ID",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "required": true,
+                        "secret": false,
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-start",
+              "metadata": {
+                "serverBasePath": "/"
+              },
+              "name": "Provided API",
+              "pattern": "From",
+              "tags": [
+                "expose",
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "name": "fetch-task"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKurdexCgwPv3VhOz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "Parameters of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhOz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhOz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLISvfTAdq4stfbU0\",\"uri\":\"atlas:json:-LzmLISvfTAdq4stfbU0\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.483154\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhOz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmLJqmfTAdq4stfbU1",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Invoke SQL to obtain, store, update, or delete data.",
+              "descriptor": {
+                "componentScheme": "sql",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "Parameters of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                },
+                "outputDataShape": {
+                  "description": "Result of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "collection"
+                  },
+                  "name": "SQL Result",
+                  "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}}",
+                  "type": "SQL_PARAM_OUT"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                    "name": "SQL statement",
+                    "properties": {
+                      "batch": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Batch update",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "dataList": [
+                          "SELECT * FROM TODO WHERE ID=:#id"
+                        ],
+                        "defaultValue": "SELECT * FROM TODO WHERE ID=:#id",
+                        "deprecated": false,
+                        "displayName": "SQL statement",
+                        "group": "common",
+                        "javaType": "java.lang.String",
+                        "kind": "path",
+                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                        "order": 1,
+                        "placeholder": "for example ':#MYPARAMNAME'",
+                        "required": true,
+                        "secret": false,
+                        "type": "dataList"
+                      },
+                      "raiseErrorOnNotFound": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Raise error when record not found",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Error when no records are selected, updated or deleted",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "SqlDataAccessError",
+                    "name": "SQL_DATA_ACCESS_ERROR"
+                  },
+                  {
+                    "displayName": "SqlEntityNotFoundError",
+                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  },
+                  {
+                    "displayName": "SqlConnectorError",
+                    "name": "SQL_CONNECTOR_ERROR"
+                  }
+                ]
+              },
+              "id": "sql-connector",
+              "name": "Invoke SQL",
+              "pattern": "To",
+              "tags": [
+                "dynamic"
+              ]
+            },
+            "configuredProperties": {
+              "batch": "false",
+              "query": "SELECT * FROM TODO WHERE ID=:#id",
+              "raiseErrorOnNotFound": "true"
+            },
+            "connection": {
+              "configuredProperties": {
+                "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                "schema": "sampledb",
+                "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                "user": "sampledb"
+              },
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "batch": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Batch update",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                              "order": 1,
+                              "placeholder": "for example ':#MYPARAMNAME'",
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "raiseErrorOnNotFound": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Raise error when record not found",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Error when no records are selected, updated or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "SqlDataAccessError",
+                          "name": "SQL_DATA_ACCESS_ERROR"
+                        },
+                        {
+                          "displayName": "SqlEntityNotFoundError",
+                          "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                        },
+                        {
+                          "displayName": "SqlConnectorError",
+                          "name": "SQL_CONNECTOR_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "sql-connector",
+                    "name": "Invoke SQL",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke SQL to obtain data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that returns results, such as SELECT.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "isRaiseErrorOnNotFound": {
+                              "deprecated": false,
+                              "displayName": "Raise NotFoundError",
+                              "group": "consumer",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "parameter",
+                              "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed.",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-start-connector",
+                    "name": "Periodic SQL invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "property",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": false,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored procedure template to perform.",
+                              "required": false,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-connector",
+                    "name": "Invoke stored procedure",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored Procedure template to perform.",
+                              "required": true,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-start-connector",
+                    "name": "Periodic stored procedure invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  }
+                ],
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "jdbc-driver",
+                    "type": "EXTENSION_TAG"
+                  }
+                ],
+                "description": "Invoke SQL to obtain, store, update, or delete data.",
+                "icon": "assets:sql.svg",
+                "id": "sql",
+                "name": "Database",
+                "properties": {
+                  "password": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Password",
+                    "group": "security",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common,security",
+                    "labelHint": "Password for the database connection.",
+                    "order": 3,
+                    "required": true,
+                    "secret": true,
+                    "type": "string"
+                  },
+                  "schema": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Schema",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common",
+                    "labelHint": "Database schema.",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "url": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Connection URL",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "JDBC URL of the database.",
+                    "order": 1,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "user": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Username",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "Username for the database connection.",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  }
+                },
+                "tags": [
+                  "verifier"
+                ],
+                "version": 1
+              },
+              "connectorId": "sql",
+              "description": "Connection to SampleDB",
+              "icon": "assets:sql.svg",
+              "id": "5",
+              "isDerived": false,
+              "name": "PostgresDB",
+              "tags": [
+                "sampledb"
+              ],
+              "uses": 0
+            },
+            "id": "-LzmLISvfTAdq4stfbU0",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhOz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhOz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLJqmfTAdq4stfbU1\",\"uri\":\"atlas:json:-LzmLJqmfTAdq4stfbU1\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLISvfTAdq4stfbU0\",\"uri\":\"atlas:json:-LzmLISvfTAdq4stfbU0\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhPz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhPz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.785424\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.448689\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.757114\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/<>/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmLM2dfTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "End action of Syndesis integrations that start from a provided API",
+              "descriptor": {
+                "componentScheme": "bean",
+                "configuredProperties": {
+                  "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                  "method": "process"
+                },
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Return Path Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "defaultResponse": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Default Response",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 0,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorHandling": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Error Handling",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorResponseCodes": {
+                        "componentProperty": false,
+                        "defaultValue": "{}",
+                        "deprecated": false,
+                        "description": "The return code to set according to different error situations",
+                        "displayName": "Error Response Codes",
+                        "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"404 No task with provided identifier found\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                        "javaType": "Map",
+                        "kind": "parameter",
+                        "order": 4,
+                        "required": false,
+                        "secret": false,
+                        "type": "mapset"
+                      },
+                      "httpResponseCode": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The return code to set in the HTTP response",
+                        "displayName": "Return Code",
+                        "enum": [
+                          {
+                            "label": "200 All is good",
+                            "value": "200"
+                          },
+                          {
+                            "label": "404 No task with provided identifier found",
+                            "value": "404"
+                          },
+                          {
+                            "label": "500 Server Error",
+                            "value": "500"
+                          }
+                        ],
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 1,
+                        "required": true,
+                        "secret": false,
+                        "type": "select"
+                      },
+                      "returnBody": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Include error message in the return body",
+                        "javaType": "Boolean",
+                        "kind": "parameter",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "ServerError",
+                    "name": "SERVER_ERROR"
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-end",
+              "name": "Provided API Return Path",
+              "pattern": "To",
+              "tags": [
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "errorResponseCodes": "{\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\",\"org.springframework.dao.DuplicateKeyException\":\"404\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SERVER_ERROR\":\"500\"}",
+              "httpResponseCode": "200",
+              "returnBody": "false"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKurdexCgwPv3VhPz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          }
+        ],
+        "tags": [
+          "5",
+          "api-provider"
+        ],
+        "type": "API_PROVIDER"
+      },
+      {
+        "description": "PUT /{id}",
+        "id": "i-LzmKKuudexCgwPv3VhTz",
+        "metadata": {
+          "default-return-code": "200",
+          "excerpt": "200 All is good",
+          "openapi-operationid": "update-task",
+          "return-code-edited": "true"
+        },
+        "name": "Update task",
+        "steps": [
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Start a Syndesis integration from a provided API",
+              "descriptor": {
+                "componentScheme": "direct",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "description": "API request payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Request",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "name": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The operation ID as defined in the API spec",
+                        "displayName": "Operation ID",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "required": true,
+                        "secret": false,
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-start",
+              "metadata": {
+                "serverBasePath": "/"
+              },
+              "name": "Provided API",
+              "pattern": "From",
+              "tags": [
+                "expose",
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "name": "update-task"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKutdexCgwPv3VhRz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "Parameters of SQL [UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true},\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKutdexCgwPv3VhRz\",\"uri\":\"atlas:json:i-LzmKKutdexCgwPv3VhRz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLb5PfTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmLb5PfTAdq4stfbU2\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.615600\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.900648\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.909361\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmLb8PfTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Invoke SQL to obtain, store, update, or delete data.",
+              "descriptor": {
+                "componentScheme": "sql",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "Parameters of SQL [UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true},\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                },
+                "outputDataShape": {
+                  "kind": "none",
+                  "type": "SQL_PARAM_OUT"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                    "name": "SQL statement",
+                    "properties": {
+                      "batch": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Batch update",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "dataList": [
+                          "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id"
+                        ],
+                        "defaultValue": "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id",
+                        "deprecated": false,
+                        "displayName": "SQL statement",
+                        "group": "common",
+                        "javaType": "java.lang.String",
+                        "kind": "path",
+                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                        "order": 1,
+                        "placeholder": "for example ':#MYPARAMNAME'",
+                        "required": true,
+                        "secret": false,
+                        "type": "dataList"
+                      },
+                      "raiseErrorOnNotFound": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Raise error when record not found",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Error when no records are selected, updated or deleted",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "SqlDataAccessError",
+                    "name": "SQL_DATA_ACCESS_ERROR"
+                  },
+                  {
+                    "displayName": "SqlEntityNotFoundError",
+                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  },
+                  {
+                    "displayName": "SqlConnectorError",
+                    "name": "SQL_CONNECTOR_ERROR"
+                  }
+                ]
+              },
+              "id": "sql-connector",
+              "name": "Invoke SQL",
+              "pattern": "To",
+              "tags": [
+                "dynamic"
+              ]
+            },
+            "configuredProperties": {
+              "batch": "false",
+              "query": "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id",
+              "raiseErrorOnNotFound": "true"
+            },
+            "connection": {
+              "configuredProperties": {
+                "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                "schema": "sampledb",
+                "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                "user": "sampledb"
+              },
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "batch": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Batch update",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                              "order": 1,
+                              "placeholder": "for example ':#MYPARAMNAME'",
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "raiseErrorOnNotFound": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Raise error when record not found",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Error when no records are selected, updated or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "SqlDataAccessError",
+                          "name": "SQL_DATA_ACCESS_ERROR"
+                        },
+                        {
+                          "displayName": "SqlEntityNotFoundError",
+                          "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                        },
+                        {
+                          "displayName": "SqlConnectorError",
+                          "name": "SQL_CONNECTOR_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "sql-connector",
+                    "name": "Invoke SQL",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke SQL to obtain data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that returns results, such as SELECT.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "isRaiseErrorOnNotFound": {
+                              "deprecated": false,
+                              "displayName": "Raise NotFoundError",
+                              "group": "consumer",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "parameter",
+                              "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed.",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-start-connector",
+                    "name": "Periodic SQL invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "property",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": false,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored procedure template to perform.",
+                              "required": false,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-connector",
+                    "name": "Invoke stored procedure",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored Procedure template to perform.",
+                              "required": true,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-start-connector",
+                    "name": "Periodic stored procedure invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  }
+                ],
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "jdbc-driver",
+                    "type": "EXTENSION_TAG"
+                  }
+                ],
+                "description": "Invoke SQL to obtain, store, update, or delete data.",
+                "icon": "assets:sql.svg",
+                "id": "sql",
+                "name": "Database",
+                "properties": {
+                  "password": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Password",
+                    "group": "security",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common,security",
+                    "labelHint": "Password for the database connection.",
+                    "order": 3,
+                    "required": true,
+                    "secret": true,
+                    "type": "string"
+                  },
+                  "schema": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Schema",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common",
+                    "labelHint": "Database schema.",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "url": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Connection URL",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "JDBC URL of the database.",
+                    "order": 1,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "user": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Username",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "Username for the database connection.",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  }
+                },
+                "tags": [
+                  "verifier"
+                ],
+                "version": 1
+              },
+              "connectorId": "sql",
+              "description": "Connection to SampleDB",
+              "icon": "assets:sql.svg",
+              "id": "5",
+              "isDerived": false,
+              "name": "PostgresDB",
+              "tags": [
+                "sampledb"
+              ],
+              "uses": 0
+            },
+            "id": "-LzmLb5PfTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKutdexCgwPv3VhRz\",\"uri\":\"atlas:json:i-LzmKKutdexCgwPv3VhRz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLb8PfTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmLb8PfTAdq4stfbU2\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuudexCgwPv3VhSz\",\"uri\":\"atlas:json:i-LzmKKuudexCgwPv3VhSz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.648240\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.928587\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.467324\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmLteyfTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "End action of Syndesis integrations that start from a provided API",
+              "descriptor": {
+                "componentScheme": "bean",
+                "configuredProperties": {
+                  "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                  "method": "process"
+                },
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "API response payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Response",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Return Path Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "defaultResponse": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Default Response",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 0,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorHandling": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Error Handling",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorResponseCodes": {
+                        "componentProperty": false,
+                        "defaultValue": "{}",
+                        "deprecated": false,
+                        "description": "The return code to set according to different error situations",
+                        "displayName": "Error Response Codes",
+                        "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"404 No Record with this ID\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                        "javaType": "Map",
+                        "kind": "parameter",
+                        "order": 4,
+                        "required": false,
+                        "secret": false,
+                        "type": "mapset"
+                      },
+                      "httpResponseCode": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The return code to set in the HTTP response",
+                        "displayName": "Return Code",
+                        "enum": [
+                          {
+                            "label": "200 All is good",
+                            "value": "200"
+                          },
+                          {
+                            "label": "404 No Record with this ID",
+                            "value": "404"
+                          },
+                          {
+                            "label": "500 Server Error",
+                            "value": "500"
+                          }
+                        ],
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 1,
+                        "required": true,
+                        "secret": false,
+                        "type": "select"
+                      },
+                      "returnBody": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Include error message in the return body",
+                        "javaType": "Boolean",
+                        "kind": "parameter",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "ServerError",
+                    "name": "SERVER_ERROR"
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-end",
+              "name": "Provided API Return Path",
+              "pattern": "To",
+              "tags": [
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "errorResponseCodes": "{\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SERVER_ERROR\":\"500\"}",
+              "httpResponseCode": "200",
+              "returnBody": "false"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKuudexCgwPv3VhSz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          }
+        ],
+        "tags": [
+          "5",
+          "api-provider"
+        ],
+        "type": "API_PROVIDER"
+      },
+      {
+        "description": "DELETE /{id}",
+        "id": "i-LzmKKuudexCgwPv3VhWz",
+        "metadata": {
+          "default-return-code": "204",
+          "excerpt": "204 Task deleted",
+          "openapi-operationid": "delete-task",
+          "return-code-edited": "true"
+        },
+        "name": "Delete task",
+        "steps": [
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Start a Syndesis integration from a provided API",
+              "descriptor": {
+                "componentScheme": "direct",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "description": "API request payload",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "unified": "true"
+                  },
+                  "name": "Request",
+                  "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier to delete\"}}}}}"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "name": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The operation ID as defined in the API spec",
+                        "displayName": "Operation ID",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "required": true,
+                        "secret": false,
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-start",
+              "metadata": {
+                "serverBasePath": "/"
+              },
+              "name": "Provided API",
+              "pattern": "From",
+              "tags": [
+                "expose",
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "name": "delete-task"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKuudexCgwPv3VhUz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "step",
+              "descriptor": {
+                "inputDataShape": {
+                  "kind": "any",
+                  "name": "All preceding outputs"
+                },
+                "outputDataShape": {
+                  "description": "Parameters of SQL [DELETE FROM TODO WHERE ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                }
+              }
+            },
+            "configuredProperties": {
+              "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuudexCgwPv3VhUz\",\"uri\":\"atlas:json:i-LzmKKuudexCgwPv3VhUz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmM7T2fTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmM7T2fTAdq4stfbU2\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.891997\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhUz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmM7T2fTAdq4stfbU2\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+            },
+            "id": "-LzmNqm1fTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "name": "Data Mapper",
+            "stepKind": "mapper"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "Invoke SQL to obtain, store, update, or delete data.",
+              "descriptor": {
+                "componentScheme": "sql",
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                ],
+                "inputDataShape": {
+                  "description": "Parameters of SQL [DELETE FROM TODO WHERE ID=:#id]",
+                  "kind": "json-schema",
+                  "metadata": {
+                    "variant": "element"
+                  },
+                  "name": "SQL Parameter",
+                  "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                  "type": "SQL_PARAM_IN"
+                },
+                "outputDataShape": {
+                  "kind": "none",
+                  "type": "SQL_PARAM_OUT"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                    "name": "SQL statement",
+                    "properties": {
+                      "batch": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Batch update",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "dataList": [
+                          "DELETE FROM TODO WHERE ID=:#id"
+                        ],
+                        "defaultValue": "DELETE FROM TODO WHERE ID=:#id",
+                        "deprecated": false,
+                        "displayName": "SQL statement",
+                        "group": "common",
+                        "javaType": "java.lang.String",
+                        "kind": "path",
+                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                        "order": 1,
+                        "placeholder": "for example ':#MYPARAMNAME'",
+                        "required": true,
+                        "secret": false,
+                        "type": "dataList"
+                      },
+                      "raiseErrorOnNotFound": {
+                        "defaultValue": "false",
+                        "deprecated": false,
+                        "displayName": "Raise error when record not found",
+                        "group": "common",
+                        "javaType": "java.lang.Boolean",
+                        "kind": "property",
+                        "labelHint": "Error when no records are selected, updated or deleted",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "SqlDataAccessError",
+                    "name": "SQL_DATA_ACCESS_ERROR"
+                  },
+                  {
+                    "displayName": "SqlEntityNotFoundError",
+                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  },
+                  {
+                    "displayName": "SqlConnectorError",
+                    "name": "SQL_CONNECTOR_ERROR"
+                  }
+                ]
+              },
+              "id": "sql-connector",
+              "name": "Invoke SQL",
+              "pattern": "To",
+              "tags": [
+                "dynamic"
+              ]
+            },
+            "configuredProperties": {
+              "batch": "false",
+              "query": "DELETE FROM TODO WHERE ID=:#id",
+              "raiseErrorOnNotFound": "true"
+            },
+            "connection": {
+              "configuredProperties": {
+                "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                "schema": "sampledb",
+                "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                "user": "sampledb"
+              },
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "batch": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Batch update",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                              "order": 1,
+                              "placeholder": "for example ':#MYPARAMNAME'",
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "raiseErrorOnNotFound": {
+                              "defaultValue": "false",
+                              "deprecated": false,
+                              "displayName": "Raise error when record not found",
+                              "group": "common",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "property",
+                              "labelHint": "Error when no records are selected, updated or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "SqlDataAccessError",
+                          "name": "SQL_DATA_ACCESS_ERROR"
+                        },
+                        {
+                          "displayName": "SqlEntityNotFoundError",
+                          "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                        },
+                        {
+                          "displayName": "SqlConnectorError",
+                          "name": "SQL_CONNECTOR_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "sql-connector",
+                    "name": "Invoke SQL",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke SQL to obtain data.",
+                    "descriptor": {
+                      "componentScheme": "sql",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Enter a SQL statement that returns results, such as SELECT.",
+                          "name": "SQL statement",
+                          "properties": {
+                            "isRaiseErrorOnNotFound": {
+                              "deprecated": false,
+                              "displayName": "Raise NotFoundError",
+                              "group": "consumer",
+                              "javaType": "java.lang.Boolean",
+                              "kind": "parameter",
+                              "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            },
+                            "query": {
+                              "deprecated": false,
+                              "displayName": "SQL statement",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "SQL statement to be executed.",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "dataList"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-start-connector",
+                    "name": "Periodic SQL invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "common",
+                              "javaType": "java.lang.String",
+                              "kind": "property",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": false,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored procedure template to perform.",
+                              "required": false,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-connector",
+                    "name": "Invoke stored procedure",
+                    "pattern": "To",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "Periodically invoke a stored procedure.",
+                    "descriptor": {
+                      "componentScheme": "sql-stored",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "json-schema"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "Select the stored procedure.",
+                          "name": "Procedure name",
+                          "properties": {
+                            "procedureName": {
+                              "componentProperty": true,
+                              "deprecated": false,
+                              "displayName": "Procedure name",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Name of the stored procedure.",
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "schedulerExpression": {
+                              "defaultValue": "60000",
+                              "deprecated": false,
+                              "displayName": "Period",
+                              "group": "consumer",
+                              "javaType": "long",
+                              "kind": "parameter",
+                              "labelHint": "Delay between scheduling (executing).",
+                              "required": false,
+                              "secret": false,
+                              "type": "duration"
+                            },
+                            "template": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Template",
+                              "group": "producer",
+                              "javaType": "java.lang.String",
+                              "kind": "path",
+                              "labelHint": "Stored Procedure template to perform.",
+                              "required": true,
+                              "secret": false,
+                              "type": "hidden"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "sql-stored-start-connector",
+                    "name": "Periodic stored procedure invocation",
+                    "pattern": "From",
+                    "tags": [
+                      "dynamic"
+                    ]
+                  }
+                ],
+                "connectorCustomizers": [
+                  "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "jdbc-driver",
+                    "type": "EXTENSION_TAG"
+                  }
+                ],
+                "description": "Invoke SQL to obtain, store, update, or delete data.",
+                "icon": "assets:sql.svg",
+                "id": "sql",
+                "name": "Database",
+                "properties": {
+                  "password": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Password",
+                    "group": "security",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common,security",
+                    "labelHint": "Password for the database connection.",
+                    "order": 3,
+                    "required": true,
+                    "secret": true,
+                    "type": "string"
+                  },
+                  "schema": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Schema",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "label": "common",
+                    "labelHint": "Database schema.",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "url": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Connection URL",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "JDBC URL of the database.",
+                    "order": 1,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  },
+                  "user": {
+                    "componentProperty": true,
+                    "deprecated": false,
+                    "displayName": "Username",
+                    "group": "common",
+                    "javaType": "java.lang.String",
+                    "kind": "property",
+                    "labelHint": "Username for the database connection.",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "string"
+                  }
+                },
+                "tags": [
+                  "verifier"
+                ],
+                "version": 1
+              },
+              "connectorId": "sql",
+              "description": "Connection to SampleDB",
+              "icon": "assets:sql.svg",
+              "id": "5",
+              "isDerived": false,
+              "name": "PostgresDB",
+              "tags": [
+                "sampledb"
+              ],
+              "uses": 0
+            },
+            "id": "-LzmM7T2fTAdq4stfbU2",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          },
+          {
+            "action": {
+              "actionType": "connector",
+              "description": "End action of Syndesis integrations that start from a provided API",
+              "descriptor": {
+                "componentScheme": "bean",
+                "configuredProperties": {
+                  "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                  "method": "process"
+                },
+                "connectorCustomizers": [
+                  "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                ],
+                "inputDataShape": {
+                  "kind": "none"
+                },
+                "outputDataShape": {
+                  "kind": "none"
+                },
+                "propertyDefinitionSteps": [
+                  {
+                    "description": "API Provider Return Path Configuration",
+                    "name": "configuration",
+                    "properties": {
+                      "defaultResponse": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Default Response",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 0,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorHandling": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Error Handling",
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 2,
+                        "required": false,
+                        "secret": false,
+                        "type": "legend"
+                      },
+                      "errorResponseCodes": {
+                        "componentProperty": false,
+                        "defaultValue": "{}",
+                        "deprecated": false,
+                        "description": "The return code to set according to different error situations",
+                        "displayName": "Error Response Codes",
+                        "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"204 Task deleted\",\"value\":\"204\"},{\"label\":\"404 No Record found with this ID\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                        "javaType": "Map",
+                        "kind": "parameter",
+                        "order": 4,
+                        "required": false,
+                        "secret": false,
+                        "type": "mapset"
+                      },
+                      "httpResponseCode": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "description": "The return code to set in the HTTP response",
+                        "displayName": "Return Code",
+                        "enum": [
+                          {
+                            "label": "204 Task deleted",
+                            "value": "204"
+                          },
+                          {
+                            "label": "404 No Record found with this ID",
+                            "value": "404"
+                          },
+                          {
+                            "label": "500 Server Error",
+                            "value": "500"
+                          }
+                        ],
+                        "javaType": "String",
+                        "kind": "parameter",
+                        "order": 1,
+                        "required": true,
+                        "secret": false,
+                        "type": "select"
+                      },
+                      "returnBody": {
+                        "componentProperty": false,
+                        "deprecated": false,
+                        "displayName": "Include error message in the return body",
+                        "javaType": "Boolean",
+                        "kind": "parameter",
+                        "order": 3,
+                        "required": false,
+                        "secret": false,
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                ],
+                "standardizedErrors": [
+                  {
+                    "displayName": "ServerError",
+                    "name": "SERVER_ERROR"
+                  }
+                ]
+              },
+              "id": "io.syndesis:api-provider-end",
+              "name": "Provided API Return Path",
+              "pattern": "To",
+              "tags": [
+                "locked-action"
+              ]
+            },
+            "configuredProperties": {
+              "errorResponseCodes": "{\"SERVER_ERROR\":\"500\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\"}",
+              "httpResponseCode": "204",
+              "returnBody": "false"
+            },
+            "connection": {
+              "connector": {
+                "actions": [
+                  {
+                    "actionType": "connector",
+                    "description": "Start a Syndesis integration from a provided API",
+                    "descriptor": {
+                      "componentScheme": "direct",
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "none"
+                      },
+                      "outputDataShape": {
+                        "kind": "any"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "name": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The operation ID as defined in the API spec",
+                              "displayName": "Operation ID",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "required": true,
+                              "secret": false,
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-start",
+                    "name": "Provided API",
+                    "pattern": "From",
+                    "tags": [
+                      "expose"
+                    ]
+                  },
+                  {
+                    "actionType": "connector",
+                    "description": "End action of Syndesis integrations that start from a provided API",
+                    "descriptor": {
+                      "componentScheme": "bean",
+                      "configuredProperties": {
+                        "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                        "method": "process"
+                      },
+                      "connectorCustomizers": [
+                        "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                      ],
+                      "inputDataShape": {
+                        "kind": "any"
+                      },
+                      "outputDataShape": {
+                        "kind": "none"
+                      },
+                      "propertyDefinitionSteps": [
+                        {
+                          "description": "API Provider Return Path Configuration",
+                          "name": "configuration",
+                          "properties": {
+                            "defaultResponse": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Default Response",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 0,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorHandling": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Error Handling",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 2,
+                              "required": false,
+                              "secret": false,
+                              "type": "legend"
+                            },
+                            "errorResponseCodes": {
+                              "componentProperty": false,
+                              "defaultValue": "{}",
+                              "deprecated": false,
+                              "description": "The return code to set according to different error situations",
+                              "displayName": "Error Response Codes",
+                              "javaType": "Map",
+                              "kind": "parameter",
+                              "order": 4,
+                              "required": false,
+                              "secret": false,
+                              "type": "mapset"
+                            },
+                            "httpResponseCode": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "description": "The return code to set in the HTTP response",
+                              "displayName": "Return Code",
+                              "javaType": "String",
+                              "kind": "parameter",
+                              "order": 1,
+                              "required": true,
+                              "secret": false,
+                              "type": "select"
+                            },
+                            "returnBody": {
+                              "componentProperty": false,
+                              "deprecated": false,
+                              "displayName": "Include error message in the return body",
+                              "javaType": "Boolean",
+                              "kind": "parameter",
+                              "order": 3,
+                              "required": false,
+                              "secret": false,
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      ],
+                      "standardizedErrors": [
+                        {
+                          "displayName": "ServerError",
+                          "name": "SERVER_ERROR"
+                        }
+                      ]
+                    },
+                    "id": "io.syndesis:api-provider-end",
+                    "name": "Provided API Return Path",
+                    "pattern": "To"
+                  }
+                ],
+                "dependencies": [
+                  {
+                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  },
+                  {
+                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                    "type": "MAVEN"
+                  }
+                ],
+                "description": "Expose Restful APIs",
+                "icon": "assets:api-provider.svg",
+                "id": "api-provider",
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "API Provider",
+                "version": 1
+              },
+              "connectorId": "api-provider",
+              "description": "Expose Restful APIs",
+              "icon": "assets:api-provider.svg",
+              "id": "api-provider",
+              "isDerived": false,
+              "metadata": {
+                "hide-from-connection-pages": "true"
+              },
+              "name": "API Provider",
+              "uses": 0
+            },
+            "id": "i-LzmKKuudexCgwPv3VhVz",
+            "metadata": {
+              "configured": "true"
+            },
+            "stepKind": "endpoint"
+          }
+        ],
+        "tags": [
+          "5",
+          "api-provider"
+        ],
+        "type": "API_PROVIDER"
+      }
+    ],
+    "id": "i-LzmKylDdexCgwPv3VhYz",
+    "name": "Task API",
+    "resources": [
+      {
+        "id": "i-LzmKKvDdexCgwPv3VhXz",
+        "kind": "open-api"
+      }
+    ],
+    "tags": [
+      "api-provider",
+      "sql"
+    ],
+    "updatedAt": 1580319626623,
+    "version": 5
+  }
+

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiprovider/TodoOpenApiV3-export/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/apiprovider/TodoOpenApiV3-export/model.json
@@ -72,16 +72,16 @@
               ],
               "standardizedErrors": [
                 {
-                  "displayName": "SqlDataAccessError",
-                  "name": "SQL_DATA_ACCESS_ERROR"
+                  "displayName": "DataAccessError",
+                  "name": "DATA_ACCESS_ERROR"
                 },
                 {
-                  "displayName": "SqlEntityNotFoundError",
-                  "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                  "displayName": "EntityNotFoundError",
+                  "name": "ENTITY_NOT_FOUND_ERROR"
                 },
                 {
-                  "displayName": "SqlConnectorError",
-                  "name": "SQL_CONNECTOR_ERROR"
+                  "displayName": "ConnectorError",
+                  "name": "CONNECTOR_ERROR"
                 }
               ]
             },
@@ -774,16 +774,16 @@
             ],
             "standardizedErrors": [
               {
-                "displayName": "SqlDataAccessError",
-                "name": "SQL_DATA_ACCESS_ERROR"
+                "displayName": "DataAccessError",
+                "name": "DATA_ACCESS_ERROR"
               },
               {
-                "displayName": "SqlEntityNotFoundError",
-                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                "displayName": "EntityNotFoundError",
+                "name": "ENTITY_NOT_FOUND_ERROR"
               },
               {
-                "displayName": "SqlConnectorError",
-                "name": "SQL_CONNECTOR_ERROR"
+                "displayName": "ConnectorError",
+                "name": "CONNECTOR_ERROR"
               }
             ]
           },
@@ -1395,16 +1395,16 @@
                   ],
                   "standardizedErrors": [
                     {
-                      "displayName": "SqlDataAccessError",
-                      "name": "SQL_DATA_ACCESS_ERROR"
+                      "displayName": "DataAccessError",
+                      "name": "DATA_ACCESS_ERROR"
                     },
                     {
-                      "displayName": "SqlEntityNotFoundError",
-                      "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                      "displayName": "EntityNotFoundError",
+                      "name": "ENTITY_NOT_FOUND_ERROR"
                     },
                     {
-                      "displayName": "SqlConnectorError",
-                      "name": "SQL_CONNECTOR_ERROR"
+                      "displayName": "ConnectorError",
+                      "name": "CONNECTOR_ERROR"
                     }
                   ]
                 },
@@ -1492,16 +1492,16 @@
                         ],
                         "standardizedErrors": [
                           {
-                            "displayName": "SqlDataAccessError",
-                            "name": "SQL_DATA_ACCESS_ERROR"
+                            "displayName": "DataAccessError",
+                            "name": "DATA_ACCESS_ERROR"
                           },
                           {
-                            "displayName": "SqlEntityNotFoundError",
-                            "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                            "displayName": "EntityNotFoundError",
+                            "name": "ENTITY_NOT_FOUND_ERROR"
                           },
                           {
-                            "displayName": "SqlConnectorError",
-                            "name": "SQL_CONNECTOR_ERROR"
+                            "displayName": "ConnectorError",
+                            "name": "CONNECTOR_ERROR"
                           }
                         ]
                       },
@@ -2502,16 +2502,16 @@
                   ],
                   "standardizedErrors": [
                     {
-                      "displayName": "SqlDataAccessError",
-                      "name": "SQL_DATA_ACCESS_ERROR"
+                      "displayName": "DataAccessError",
+                      "name": "DATA_ACCESS_ERROR"
                     },
                     {
-                      "displayName": "SqlEntityNotFoundError",
-                      "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                      "displayName": "EntityNotFoundError",
+                      "name": "ENTITY_NOT_FOUND_ERROR"
                     },
                     {
-                      "displayName": "SqlConnectorError",
-                      "name": "SQL_CONNECTOR_ERROR"
+                      "displayName": "ConnectorError",
+                      "name": "CONNECTOR_ERROR"
                     }
                   ]
                 },
@@ -2599,16 +2599,16 @@
                         ],
                         "standardizedErrors": [
                           {
-                            "displayName": "SqlDataAccessError",
-                            "name": "SQL_DATA_ACCESS_ERROR"
+                            "displayName": "DataAccessError",
+                            "name": "DATA_ACCESS_ERROR"
                           },
                           {
-                            "displayName": "SqlEntityNotFoundError",
-                            "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                            "displayName": "EntityNotFoundError",
+                            "name": "ENTITY_NOT_FOUND_ERROR"
                           },
                           {
-                            "displayName": "SqlConnectorError",
-                            "name": "SQL_CONNECTOR_ERROR"
+                            "displayName": "ConnectorError",
+                            "name": "CONNECTOR_ERROR"
                           }
                         ]
                       },
@@ -3609,16 +3609,16 @@
                   ],
                   "standardizedErrors": [
                     {
-                      "displayName": "SqlDataAccessError",
-                      "name": "SQL_DATA_ACCESS_ERROR"
+                      "displayName": "DataAccessError",
+                      "name": "DATA_ACCESS_ERROR"
                     },
                     {
-                      "displayName": "SqlEntityNotFoundError",
-                      "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                      "displayName": "EntityNotFoundError",
+                      "name": "ENTITY_NOT_FOUND_ERROR"
                     },
                     {
-                      "displayName": "SqlConnectorError",
-                      "name": "SQL_CONNECTOR_ERROR"
+                      "displayName": "ConnectorError",
+                      "name": "CONNECTOR_ERROR"
                     }
                   ]
                 },
@@ -3706,16 +3706,16 @@
                         ],
                         "standardizedErrors": [
                           {
-                            "displayName": "SqlDataAccessError",
-                            "name": "SQL_DATA_ACCESS_ERROR"
+                            "displayName": "DataAccessError",
+                            "name": "DATA_ACCESS_ERROR"
                           },
                           {
-                            "displayName": "SqlEntityNotFoundError",
-                            "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                            "displayName": "EntityNotFoundError",
+                            "name": "ENTITY_NOT_FOUND_ERROR"
                           },
                           {
-                            "displayName": "SqlConnectorError",
-                            "name": "SQL_CONNECTOR_ERROR"
+                            "displayName": "ConnectorError",
+                            "name": "CONNECTOR_ERROR"
                           }
                         ]
                       },
@@ -4156,7 +4156,7 @@
                 ]
               },
               "configuredProperties": {
-                "errorResponseCodes": "{\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\"}",
+                "errorResponseCodes": "{\"ENTITY_NOT_FOUND_ERROR\":\"404\"}",
                 "httpResponseCode": "200",
                 "returnBody": "false"
               },
@@ -4714,16 +4714,16 @@
                   ],
                   "standardizedErrors": [
                     {
-                      "displayName": "SqlDataAccessError",
-                      "name": "SQL_DATA_ACCESS_ERROR"
+                      "displayName": "DataAccessError",
+                      "name": "DATA_ACCESS_ERROR"
                     },
                     {
-                      "displayName": "SqlEntityNotFoundError",
-                      "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                      "displayName": "EntityNotFoundError",
+                      "name": "ENTITY_NOT_FOUND_ERROR"
                     },
                     {
-                      "displayName": "SqlConnectorError",
-                      "name": "SQL_CONNECTOR_ERROR"
+                      "displayName": "ConnectorError",
+                      "name": "CONNECTOR_ERROR"
                     }
                   ]
                 },
@@ -4811,16 +4811,16 @@
                         ],
                         "standardizedErrors": [
                           {
-                            "displayName": "SqlDataAccessError",
-                            "name": "SQL_DATA_ACCESS_ERROR"
+                            "displayName": "DataAccessError",
+                            "name": "DATA_ACCESS_ERROR"
                           },
                           {
-                            "displayName": "SqlEntityNotFoundError",
-                            "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                            "displayName": "EntityNotFoundError",
+                            "name": "ENTITY_NOT_FOUND_ERROR"
                           },
                           {
-                            "displayName": "SqlConnectorError",
-                            "name": "SQL_CONNECTOR_ERROR"
+                            "displayName": "ConnectorError",
+                            "name": "CONNECTOR_ERROR"
                           }
                         ]
                       },
@@ -5815,16 +5815,16 @@
                   ],
                   "standardizedErrors": [
                     {
-                      "displayName": "SqlDataAccessError",
-                      "name": "SQL_DATA_ACCESS_ERROR"
+                      "displayName": "DataAccessError",
+                      "name": "DATA_ACCESS_ERROR"
                     },
                     {
-                      "displayName": "SqlEntityNotFoundError",
-                      "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                      "displayName": "EntityNotFoundError",
+                      "name": "ENTITY_NOT_FOUND_ERROR"
                     },
                     {
-                      "displayName": "SqlConnectorError",
-                      "name": "SQL_CONNECTOR_ERROR"
+                      "displayName": "ConnectorError",
+                      "name": "CONNECTOR_ERROR"
                     }
                   ]
                 },
@@ -5912,16 +5912,16 @@
                         ],
                         "standardizedErrors": [
                           {
-                            "displayName": "SqlDataAccessError",
-                            "name": "SQL_DATA_ACCESS_ERROR"
+                            "displayName": "DataAccessError",
+                            "name": "DATA_ACCESS_ERROR"
                           },
                           {
-                            "displayName": "SqlEntityNotFoundError",
-                            "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                            "displayName": "EntityNotFoundError",
+                            "name": "ENTITY_NOT_FOUND_ERROR"
                           },
                           {
-                            "displayName": "SqlConnectorError",
-                            "name": "SQL_CONNECTOR_ERROR"
+                            "displayName": "ConnectorError",
+                            "name": "CONNECTOR_ERROR"
                           }
                         ]
                       },

--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -35,6 +35,16 @@
       "EmptyTablePreview": "Please select one or more tables for your view. If no table is selected, a default view will be generated.",
       "EmptyTablePreviewTitle": "No tables selected",
       "Error": "Error",
+      "ErrorKeys": {
+            "SERVER_ERROR" : "Server Error",
+            "CONNECTOR_ERROR": "Connector Error",
+            "ENTITY_NOT_FOUND_ERROR": "Entity Not Found Error",
+            "DATA_ACCESS_ERROR": "Data Access Error",
+            "NON_TRANSIENT_DATA_ACCESS_ERROR": "Non Transient Error",
+            "DATA_INTEGRITY_VIOLATION_ERROR": " Data Integrity Violation Error",
+            "DUPLICATE_KEY_ERROR": "Duplicate Key Error",
+            "TRANSIENT_DATA_ACCESS_ERROR": "Transient Data Access Error"
+       },
       "Export": "Export",
       "Extension": "Extension",
       "Extensions": "Extensions",

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -164,10 +164,14 @@
     }
   },
   "errorKeys": {
-    "SqlEntityNotFoundError": "SQL Entity Not Found",
-    "SqlDataAccessError": "SQL Data Access Error",
-    "SqlConnectorError": "SQL Connector Error",
-    "ServerError": "Server Error"
+    "ServerError": "Server Error",
+    "ConnectorError": "Connector Error",
+    "EntityNotFoundError": "Entity Not Found Error",
+    "DataAccessError": "Data Access Error",
+    "NonTransientDataAccessError": "Non Transient Error",
+    "DataIntegrityViolationError": " Data Integrity Violation Error",
+    "DuplicateKeyError": "Duplicate Key Error",
+    "TransientDataAccessError": "Retryable Error"
   },
   "apiProvider": {
     "editSpecification": {


### PR DESCRIPTION
https://github.com/syndesisio/syndesis/issues/8325
Avoid putting classnames as keys in the standardizedErrors config. Ever since the i18n framework was introduced this caused issues. The classnames are now put into a hierarchical map of errors.

Also addresses: https://issues.redhat.com/browse/ENTESB-12908