### PR TITLE
Replaced old references of CreateConnection translation

### DIFF
--- a/app/ui-react/syndesis/src/modules/connections/components/ConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/ConnectionsWithToolbar.tsx
@@ -94,7 +94,7 @@ export class ConnectionsWithToolbar extends React.Component<
                   sortTypes={sortTypes}
                   resultsCount={filteredAndSortedConnections.length}
                   {...helpers}
-                  i18nLinkCreateConnection={t('shared:CreateConnection')}
+                  i18nLinkCreateConnection={t('shared:linkCreateConnection')}
                   i18nResultsCount={t('shared:resultsCount', {
                     count: filteredAndSortedConnections.length,
                   })}

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -168,7 +168,7 @@ export const ConfigurationPage: React.FunctionComponent = () => {
             connectionsHref={resolvers.connections()}
             i18nCancel={t('shared:Cancel')}
             i18nConnections={t('shared:Connections')}
-            i18nCreateConnection={t('shared:CreateConnection')}
+            i18nCreateConnection={t('shared:linkCreateConnection')}
           />
           <WithConnectorForm connector={connector} onSave={onSave}>
             {({

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
@@ -77,7 +77,7 @@ export class ConnectorsPage extends React.Component {
                   connectionsHref={resolvers.connections()}
                   i18nCancel={t('shared:Cancel')}
                   i18nConnections={t('shared:Connections')}
-                  i18nCreateConnection={t('shared:CreateConnection')}
+                  i18nCreateConnection={t('shared:linkCreateConnection')}
                 />
                 <ConnectionCreatorLayout
                   toggle={

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
@@ -156,7 +156,7 @@ export const ReviewPage: React.FunctionComponent = () => {
                       connectionsHref={resolvers.connections()}
                       i18nCancel={t('shared:Cancel')}
                       i18nConnections={t('shared:Connections')}
-                      i18nCreateConnection={t('shared:CreateConnection')}
+                      i18nCreateConnection={t('shared:linkCreateConnection')}
                     />
                     <ConnectionCreatorLayout
                       toggle={

--- a/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
+++ b/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
@@ -296,7 +296,7 @@ export default () => (
                       }
                       i18nConnections={t('shared:Connections')}
                       i18nLinkCreateConnection={t(
-                        'shared:CreateConnection'
+                        'shared:linkCreateConnection'
                       )}
                       i18nLinkCreateIntegration={t(
                         'shared:linkCreateIntegration'

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
@@ -213,7 +213,7 @@ export const ConnectionSchemaContent: React.FunctionComponent<IConnectionSchemaC
     <ConnectionSchemaList
       i18nEmptyStateInfo={t('activeConnectionsEmptyStateInfo')}
       i18nEmptyStateTitle={t('activeConnectionsEmptyStateTitle')}
-      i18nLinkCreateConnection={t('shared:CreateConnection')}
+      i18nLinkCreateConnection={t('shared:linkCreateConnection')}
       hasListData={sortedConns.length > 0}
       linkToConnectionCreate={resolvers.connections.create.selectConnector()}
       loading={props.loading}

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnectionsWithToolbar.tsx
@@ -143,7 +143,7 @@ export const DvConnectionsWithToolbar: React.FunctionComponent<
                 sortTypes={sortTypes}
                 resultsCount={filteredAndSortedConnections.length}
                 {...helpers}
-                i18nLinkCreateConnection={t('shared:CreateConnection')}
+                i18nLinkCreateConnection={t('shared:linkCreateConnection')}
                 i18nResultsCount={t('shared:resultsCount', {
                   count: filteredAndSortedConnections.length,
                 })}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorStepsWithToolbar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorStepsWithToolbar.tsx
@@ -90,7 +90,7 @@ export class EditorStepsWithToolbar extends React.Component<
                   sortTypes={sortTypes}
                   resultsCount={filteredAndSortedEditorSteps.length}
                   {...helpers}
-                  i18nLinkCreateConnection={t('shared:CreateConnection')}
+                  i18nLinkCreateConnection={t('shared:linkCreateConnection')}
                   i18nResultsCount={t('shared:resultsCount', {
                     count: filteredAndSortedEditorSteps.length,
                   })}


### PR DESCRIPTION
After this change https://github.com/syndesisio/syndesis/commit/d2375570b29048b08b80e0e0e162292d948dbef8#diff-38d54cc1ec6b270563c94153f356a568L49 , some references to CreateConnection translation property were out of date.
![image](https://user-images.githubusercontent.com/16251792/79956573-9ba23280-8480-11ea-92bd-be29f7128180.png)
I have replaced all occurrence `shared:CreateConnection` to `shared:linkCreateConnection` in the `ui-react` package.