### PR TITLE
[operator] Fix for ops addon

### DIFF
--- a/install/operator/go.mod
+++ b/install/operator/go.mod
@@ -38,7 +38,6 @@ require (
 	k8s.io/gengo v0.0.0-20191010091904-7fa3014cb28f
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/kubectl v0.0.0
-
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/install/operator/pkg/generator/generator.go
+++ b/install/operator/pkg/generator/generator.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -131,14 +132,16 @@ func Render(filePath string, context interface{}) ([]unstructured.Unstructured, 
 
 	// We can load plain yml files..
 	if strings.HasSuffix(filePath, ".yml") || strings.HasSuffix(filePath, ".yaml") {
-		fileData, err := AssetAsBytes(filePath)
-		if err != nil {
-			return nil, err
-		}
+		if !skipFile(filePath, context) {
+			fileData, err := AssetAsBytes(filePath)
+			if err != nil {
+				return nil, err
+			}
 
-		err = util.UnmarshalYaml(fileData, &obj)
-		if err != nil {
-			return nil, errors.Errorf("%s:\n%s\n", err, string(fileData))
+			err = util.UnmarshalYaml(fileData, &obj)
+			if err != nil {
+				return nil, errors.Errorf("%s:\n%s\n", err, string(fileData))
+			}
 		}
 	}
 
@@ -190,4 +193,19 @@ func Render(filePath string, context interface{}) ([]unstructured.Unstructured, 
 	}
 
 	return response, nil
+}
+
+// Skip file if conditions are met
+func skipFile(file string, config interface{}) bool {
+	if x, ok := config.(*configuration.Config); ok {
+		if x.Syndesis.Components.Database.ExternalDbURL != "" {
+			for _, wfile := range []string{"addon-ops-db-alerting-rules.yml", "addon-ops-db-dashboard.yml"} {
+				if wfile == filepath.Base(file) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/install/operator/pkg/generator/generator_test.go
+++ b/install/operator/pkg/generator/generator_test.go
@@ -2,6 +2,7 @@ package generator_test
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -190,6 +191,33 @@ func TestDockerImagesSHAorTag(t *testing.T) {
 			}
 			assert.True(t, checks == len(tt.args.imageableResources), "checks missing", "got", checks, "want", len(tt.args.imageableResources))
 		})
+	}
+}
+
+// Run test related with Ops addon
+func TestOpsAddon(t *testing.T) {
+	syndesis := &v1beta1.Syndesis{}
+	baseDir := "./addons/ops/"
+
+	conf, err := configuration.GetProperties("../../build/conf/config-test.yaml", context.TODO(), nil, syndesis)
+	if err != nil {
+
+	}
+	for _, file := range []string{"addon-ops-db-alerting-rules.yml", "addon-ops-db-dashboard.yml"} {
+		resources, err := generator.Render(filepath.Join(baseDir, file), conf)
+		require.NoError(t, err)
+		assert.True(t, len(resources) != 0, "Monitoring resources for database should be created when no external db url is defined")
+	}
+
+	syndesis.Spec.Components.Database.ExternalDbURL = "1234"
+	conf, err = configuration.GetProperties("../../build/conf/config-test.yaml", context.TODO(), nil, syndesis)
+	if err != nil {
+
+	}
+	for _, file := range []string{"addon-ops-db-alerting-rules.yml", "addon-ops-db-dashboard.yml"} {
+		resources, err := generator.Render(filepath.Join(baseDir, file), conf)
+		require.NoError(t, err)
+		assert.True(t, len(resources) == 0, "Monitoring resources for database should not be created when there is a external db url defined")
 	}
 }
 

--- a/install/operator/vendor/modules.txt
+++ b/install/operator/vendor/modules.txt
@@ -337,7 +337,7 @@ gopkg.in/fsnotify.v1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
-# k8s.io/api v0.18.0 => k8s.io/api v0.0.0-20191016110408-35e52d86657a
+# k8s.io/api v0.18.1 => k8s.io/api v0.0.0-20191016110408-35e52d86657a
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -379,7 +379,7 @@ k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apimachinery v0.17.2 => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
+# k8s.io/apimachinery v0.18.1 => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
@@ -507,7 +507,7 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
-# k8s.io/code-generator v0.18.0 => k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894
+# k8s.io/code-generator v0.18.1 => k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args
 k8s.io/code-generator/cmd/client-gen/generators


### PR DESCRIPTION
Generate the monitoring resources for database only if there is no external database defined

Fixes https://issues.redhat.com/browse/ENTESB-13532
Fixes https://github.com/syndesisio/syndesis/issues/8289