### PR TITLE
(backport-1.10.x)[PF4 migration] Added DataTestIds to DataVirtualization pages

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
@@ -70,6 +70,7 @@ export const PublishStatusWithProgress: React.FunctionComponent<IPublishStatusWi
         <Label
           className={'publish-status-with-progress_Label'}
           style={getLabelClass()}
+          data-testid={'virtualization-publish-status-with-progress'}
         >
           {props.i18nPublishState}
         </Label>
@@ -91,6 +92,7 @@ export const PublishStatusWithProgress: React.FunctionComponent<IPublishStatusWi
       <span className={'publish-status-with-progress_text'}>
         <Label
           className={'publish-status-with-progress_Label'}
+          data-testid={'virtualization-publish-status-with-progress'}
           style={getLabelClass()}
         >
           {props.i18nPublishState}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
@@ -60,6 +60,7 @@ export const ConnectionSchemaListItem: React.FunctionComponent<IConnectionSchema
             <DataListToggle
               isExpanded={isExpanded}
               id="connection-schema-list-item-expand"
+              data-testid={'connection-schema-list-item-expand'}
               aria-controls="connection-schema-list-item-expand"
               onClick={() => setExpanded(!isExpanded)}
             />

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewListItem.tsx
@@ -119,7 +119,7 @@ export const ViewListItem: React.FC<IViewListItemProps> = ({
                 </div>
               </DataListCell>,
               <DataListCell key={'secondary content'} width={4}>
-                <div className={'view-list-item__invalid-view'}>
+                <div className={'view-list-item__invalid-view'} data-testid={'view-list-item-invalid-view'}>
                   {isValid ? '' : i18nInvalid}
                 </div>
               </DataListCell>,

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
@@ -115,15 +115,17 @@ export const VirtualizationListItem: React.FunctionComponent<
               </DataListCell>,
               <DataListCell key={'primary content'} width={4}>
                 <div className={'virtualization-list-item__text-wrapper'}>
-                  <b>{props.virtualizationName}</b>
+                  <b data-testid={'virtualization-list-item-name'}>{props.virtualizationName}</b>
                   <br />
-                  {props.virtualizationDescription
-                    ? props.virtualizationDescription
-                    : ''}
+                  <p data-testid={'virtualization-list-item-description'}>
+                    {props.virtualizationDescription
+                      ? props.virtualizationDescription
+                      : ''}
+                  </p>
                 </div>
               </DataListCell>,
               <DataListCell key={'used-by content'} width={4}>
-                <div className={'virtualization-list-item__used-by'}>
+                <div className={'virtualization-list-item__used-by'} data-testid={'virtualization-list-item__used-by'}>
                   {props.usedBy.length > 0 ? (
                     props.i18nInUseText
                   ) : (


### PR DESCRIPTION
Backport of https://github.com/syndesisio/syndesis/pull/8319 to 1.10.x