### PR TITLE
chore: turn down parallelism to 1 for CI

### DIFF
--- a/app/ui-react/packages/.storybook/webpack.config.js
+++ b/app/ui-react/packages/.storybook/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 module.exports = ({ config, mode }) => {
   config.module.rules.push({
     test: /\.tsx?$/,
@@ -24,5 +25,8 @@ module.exports = ({ config, mode }) => {
   config.node = {
     fs: 'empty',
   };
+  config.optimization.minimizer = [ new TerserPlugin({
+    parallel: 1
+  })];
   return config;
 };

--- a/app/ui-react/syndesis/craco.config.js
+++ b/app/ui-react/syndesis/craco.config.js
@@ -10,7 +10,7 @@ module.exports = function({ env, paths }) {
           ...webpackConfig.optimization,
           minimizer: [
             new TerserPlugin({
-              parallel: 2,
+              parallel: 1,
             }),
           ],
         },


### PR DESCRIPTION
Found when working with the DV folks that this setting is better set at 1 to avoid memory issues on CI nodes, should fix issues with the `ui` and `ui-doc` jobs.