### PR TITLE
fix(build): perform a `git fetch --tags --prune`

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -208,6 +208,11 @@ check_git_clean() {
        git status
        exit 1
     fi
+
+    # we need to remove tags removed at origin so we can push tags that have been
+    # removed, root cause is when we do `git push` an error is reported
+    # `fatal: remote part of refspec is not a valid name in :...`
+    git fetch --tags --prune
 }
 
 update_pom_versions() {


### PR DESCRIPTION
Seems that stale tags are preventing us from pushing new tags in the
release:

```
==== Pushing to GitHub
* Pushing 1.10.0-20200426
To https://****@github.com/syndesisio/syndesis.git
 * [new tag]         1.10.0-20200426 -> 1.10.0-20200426
fatal: remote part of refspec is not a valid name in :1.10.0-20200410
1.10.0-20200411
1.10.0-20200412
1.10.0-20200413
```

This adds `git fetch --tags --prune` to remove tags from local clone
that have been removed at origin.