### PR TITLE
fix(atlasmap+itest): previous mappings were lost on following steps

### DIFF
--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/capture/OutMessageCaptureProcessor.java
@@ -17,11 +17,11 @@ package io.syndesis.integration.runtime.capture;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import io.syndesis.integration.runtime.logging.IntegrationLoggingConstants;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.camel.converter.stream.InputStreamCache;
 import org.apache.camel.support.MessageSupport;
 
 /**
@@ -42,6 +42,13 @@ public class OutMessageCaptureProcessor implements Processor {
             Map<String, Message> outMessagesMap = getCapturedMessageMap(exchange);
             if (copy instanceof MessageSupport && copy.getExchange() == null) {
                 ((MessageSupport) copy).setExchange(message.getExchange());
+            }
+
+            //If it is a stream cache, it can only be read once
+            //We are going to read it more than once
+            //to reuse variables from previous steps
+            if(copy.getBody() instanceof InputStreamCache) {
+                copy.setBody(copy.getBody(String.class));
             }
 
             outMessagesMap.put(id, copy);

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSimpleTemplate.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSimpleTemplate.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.test.itest.webhook;
+
+import static com.consol.citrus.http.actions.HttpActionBuilder.http;
+
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.http.actions.HttpClientActionBuilder;
+import com.consol.citrus.http.client.HttpClient;
+import com.consol.citrus.http.client.HttpClientBuilder;
+import io.syndesis.test.SyndesisTestEnvironment;
+import io.syndesis.test.container.integration.SyndesisIntegrationRuntimeContainer;
+import io.syndesis.test.itest.SyndesisIntegrationTestSupport;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author María Arias de Reyna
+ */
+@ContextConfiguration(classes = WebHookSimpleTemplate.EndpointConfig.class)
+public class WebHookSimpleTemplate extends SyndesisIntegrationTestSupport {
+
+    @Autowired
+    private HttpClient webHookClient;
+
+    /**
+     * This integration provides a webhook that expects a POST request and apply a couple of templates with
+     * data mappings. Used to check basic data mapping with atlasmap.
+     */
+    @ClassRule
+    public static SyndesisIntegrationRuntimeContainer integrationContainer =
+        new SyndesisIntegrationRuntimeContainer.Builder()
+            .name("webhook-simple-template")
+            .fromExport(WebHookSimpleTemplate.class.getResource("WebhookSimpleTemplate"))
+            .enableDebug()
+            .build()
+            .withExposedPorts(SyndesisTestEnvironment.getServerPort(),
+                SyndesisTestEnvironment.getManagementPort());
+
+
+    @Test
+    @CitrusTest
+    public void templateWebhook(@CitrusResource TestCaseRunner runner) {
+        runner.when(http().client(webHookClient)
+                        .send()
+                        .post()
+                        .payload(payload("A",
+                            "B")));
+
+        final HttpClientActionBuilder.HttpClientReceiveActionBuilder receive =
+            http().client(webHookClient).receive();
+
+        runner.then(receive.response(HttpStatus.NO_CONTENT));
+
+    }
+
+    private static String payload(String astring, String bstring) {
+        return String.format("{\n \"astring\": \"" + astring + "\",\n \"anotherstring\": \"" + bstring + "\"\n }",
+            astring,
+            bstring);
+    }
+
+    @Configuration
+    public static class EndpointConfig {
+        @Bean
+        public HttpClient webHookClient() {
+            return new HttpClientBuilder()
+                       .requestUrl(String.format("http://localhost:%s/webhook/why-do-you-fail",
+                           integrationContainer.getServerPort()))
+                       .build();
+        }
+    }
+}

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/webhook/WebhookSimpleTemplate/model-info.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/webhook/WebhookSimpleTemplate/model-info.json
@@ -1,0 +1,1 @@
+{"schemaVersion":41}

--- a/app/test/integration-test/src/test/resources/io/syndesis/test/itest/webhook/WebhookSimpleTemplate/model.json
+++ b/app/test/integration-test/src/test/resources/io/syndesis/test/itest/webhook/WebhookSimpleTemplate/model.json
@@ -1,0 +1,795 @@
+{
+  "connections": {
+    ":webhook": {
+      "connector": {
+        "actions": [
+          {
+            "actionType": "connector",
+            "description": "Start an integration from a Webhook",
+            "descriptor": {
+              "componentScheme": "servlet",
+              "configuredProperties": {
+                "headerFilterStrategy": "syndesisHeaderStrategy",
+                "httpMethodRestrict": "GET,POST"
+              },
+              "connectorCustomizers": [
+                "io.syndesis.connector.webhook.WebhookConnectorCustomizer"
+              ],
+              "exceptionHandler": "io.syndesis.connector.webhook.WebhookOnExceptionHandler",
+              "inputDataShape": {
+                "kind": "none"
+              },
+              "outputDataShape": {
+                "kind": "any"
+              },
+              "propertyDefinitionSteps": [
+                {
+                  "description": "Webhook Configuration",
+                  "name": "configuration",
+                  "properties": {
+                    "contextPath": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The Webhook token that will be set as final part of the URL",
+                      "displayName": "Webhook Token",
+                      "generator": "alphanum:50",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "order": 0,
+                      "required": true,
+                      "secret": false,
+                      "tags": [
+                        "context-path"
+                      ],
+                      "type": "string"
+                    },
+                    "defaultResponse": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "displayName": "Default Response",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "order": 1,
+                      "required": false,
+                      "secret": false,
+                      "type": "legend"
+                    },
+                    "errorHandling": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "displayName": "Error Handling",
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "order": 3,
+                      "required": false,
+                      "secret": false,
+                      "type": "legend"
+                    },
+                    "errorResponseCodes": {
+                      "componentProperty": false,
+                      "defaultValue": "{}",
+                      "deprecated": false,
+                      "description": "The return code to set according to different error situations",
+                      "displayName": "Error Response Codes",
+                      "extendedProperties": "{ \"mapsetValueDefinition\": {   \"enum\" : [{\"label\":\"400 Bad Request\",\"value\":\"400\"},{\"label\":\"404 Not Found\",\"value\":\"404\"},{\"label\":\"405 Method Not Allowed\",\"value\":\"405\"},{\"label\":\"409 Conflict\",\"value\":\"409\"},{\"label\":\"500 Server Error\",\"value\":\"500\"},{\"label\":\"501 Not Implemented\",\"value\":\"501\"},{\"label\":\"503 Service Unavailable\",\"value\":\"503\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                      "javaType": "Map",
+                      "kind": "parameter",
+                      "order": 5,
+                      "required": false,
+                      "secret": false,
+                      "type": "mapset"
+                    },
+                    "httpResponseCode": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "description": "The return code to set in the HTTP response",
+                      "displayName": "Return Code",
+                      "enum": [
+                        {
+                          "label": "200 OK",
+                          "value": "200"
+                        },
+                        {
+                          "label": "201 Created",
+                          "value": "201"
+                        },
+                        {
+                          "label": "202 Accepted",
+                          "value": "202"
+                        },
+                        {
+                          "label": "204 No Content",
+                          "value": "204"
+                        }
+                      ],
+                      "javaType": "String",
+                      "kind": "parameter",
+                      "order": 2,
+                      "required": true,
+                      "secret": false,
+                      "type": "select"
+                    },
+                    "returnBody": {
+                      "componentProperty": false,
+                      "deprecated": false,
+                      "displayName": "Include error message in the return body",
+                      "javaType": "Boolean",
+                      "kind": "parameter",
+                      "order": 4,
+                      "required": false,
+                      "secret": false,
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ],
+              "standardizedErrors": [
+                {
+                  "displayName": "ServerError",
+                  "name": "SERVER_ERROR"
+                }
+              ]
+            },
+            "id": "io.syndesis:webhook-incoming",
+            "metadata": {
+              "serverBasePath": "/webhook"
+            },
+            "name": "Incoming Webhook",
+            "pattern": "From",
+            "tags": [
+              "expose"
+            ]
+          }
+        ],
+        "dependencies": [
+          {
+            "id": "io.syndesis.connector:connector-webhook:2.0-SNAPSHOT",
+            "type": "MAVEN"
+          }
+        ],
+        "description": "Create direct connections with external systems through Webhooks",
+        "icon": "assets:webhook.svg",
+        "id": "webhook",
+        "metadata": {
+          "hide-from-connection-pages": "true"
+        },
+        "name": "Webhook",
+        "version": 16
+      },
+      "connectorId": "webhook",
+      "description": "Create direct connections with external systems through Webhooks",
+      "icon": "assets:webhook.svg",
+      "id": "webhook",
+      "isDerived": false,
+      "metadata": {
+        "hide-from-connection-pages": "true"
+      },
+      "name": "Webhook",
+      "uses": 0
+    }
+  },
+  "connectors": {
+    ":webhook": {
+      "actions": [
+        {
+          "actionType": "connector",
+          "description": "Start an integration from a Webhook",
+          "descriptor": {
+            "componentScheme": "servlet",
+            "configuredProperties": {
+              "headerFilterStrategy": "syndesisHeaderStrategy",
+              "httpMethodRestrict": "GET,POST"
+            },
+            "connectorCustomizers": [
+              "io.syndesis.connector.webhook.WebhookConnectorCustomizer"
+            ],
+            "exceptionHandler": "io.syndesis.connector.webhook.WebhookOnExceptionHandler",
+            "inputDataShape": {
+              "kind": "none"
+            },
+            "outputDataShape": {
+              "kind": "any"
+            },
+            "propertyDefinitionSteps": [
+              {
+                "description": "Webhook Configuration",
+                "name": "configuration",
+                "properties": {
+                  "contextPath": {
+                    "componentProperty": false,
+                    "deprecated": false,
+                    "description": "The Webhook token that will be set as final part of the URL",
+                    "displayName": "Webhook Token",
+                    "generator": "alphanum:50",
+                    "javaType": "String",
+                    "kind": "parameter",
+                    "order": 0,
+                    "required": true,
+                    "secret": false,
+                    "tags": [
+                      "context-path"
+                    ],
+                    "type": "string"
+                  },
+                  "defaultResponse": {
+                    "componentProperty": false,
+                    "deprecated": false,
+                    "displayName": "Default Response",
+                    "javaType": "String",
+                    "kind": "parameter",
+                    "order": 1,
+                    "required": false,
+                    "secret": false,
+                    "type": "legend"
+                  },
+                  "errorHandling": {
+                    "componentProperty": false,
+                    "deprecated": false,
+                    "displayName": "Error Handling",
+                    "javaType": "String",
+                    "kind": "parameter",
+                    "order": 3,
+                    "required": false,
+                    "secret": false,
+                    "type": "legend"
+                  },
+                  "errorResponseCodes": {
+                    "componentProperty": false,
+                    "defaultValue": "{}",
+                    "deprecated": false,
+                    "description": "The return code to set according to different error situations",
+                    "displayName": "Error Response Codes",
+                    "extendedProperties": "{ \"mapsetValueDefinition\": {   \"enum\" : [{\"label\":\"400 Bad Request\",\"value\":\"400\"},{\"label\":\"404 Not Found\",\"value\":\"404\"},{\"label\":\"405 Method Not Allowed\",\"value\":\"405\"},{\"label\":\"409 Conflict\",\"value\":\"409\"},{\"label\":\"500 Server Error\",\"value\":\"500\"},{\"label\":\"501 Not Implemented\",\"value\":\"501\"},{\"label\":\"503 Service Unavailable\",\"value\":\"503\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                    "javaType": "Map",
+                    "kind": "parameter",
+                    "order": 5,
+                    "required": false,
+                    "secret": false,
+                    "type": "mapset"
+                  },
+                  "httpResponseCode": {
+                    "componentProperty": false,
+                    "deprecated": false,
+                    "description": "The return code to set in the HTTP response",
+                    "displayName": "Return Code",
+                    "enum": [
+                      {
+                        "label": "200 OK",
+                        "value": "200"
+                      },
+                      {
+                        "label": "201 Created",
+                        "value": "201"
+                      },
+                      {
+                        "label": "202 Accepted",
+                        "value": "202"
+                      },
+                      {
+                        "label": "204 No Content",
+                        "value": "204"
+                      }
+                    ],
+                    "javaType": "String",
+                    "kind": "parameter",
+                    "order": 2,
+                    "required": true,
+                    "secret": false,
+                    "type": "select"
+                  },
+                  "returnBody": {
+                    "componentProperty": false,
+                    "deprecated": false,
+                    "displayName": "Include error message in the return body",
+                    "javaType": "Boolean",
+                    "kind": "parameter",
+                    "order": 4,
+                    "required": false,
+                    "secret": false,
+                    "type": "boolean"
+                  }
+                }
+              }
+            ],
+            "standardizedErrors": [
+              {
+                "displayName": "ServerError",
+                "name": "SERVER_ERROR"
+              }
+            ]
+          },
+          "id": "io.syndesis:webhook-incoming",
+          "metadata": {
+            "serverBasePath": "/webhook"
+          },
+          "name": "Incoming Webhook",
+          "pattern": "From",
+          "tags": [
+            "expose"
+          ]
+        }
+      ],
+      "dependencies": [
+        {
+          "id": "io.syndesis.connector:connector-webhook:2.0-SNAPSHOT",
+          "type": "MAVEN"
+        }
+      ],
+      "description": "Create direct connections with external systems through Webhooks",
+      "icon": "assets:webhook.svg",
+      "id": "webhook",
+      "metadata": {
+        "hide-from-connection-pages": "true"
+      },
+      "name": "Webhook",
+      "version": 16
+    }
+  },
+  "integrations": {
+    ":i-M4yEs28lCY5ii3d0hYGz": {
+      "createdAt": 1586961023177,
+      "flows": [
+        {
+          "id": "-M4yDz8Hqo1w5KT5YvY7",
+          "steps": [
+            {
+              "action": {
+                "actionType": "connector",
+                "description": "Start an integration from a Webhook",
+                "descriptor": {
+                  "componentScheme": "servlet",
+                  "configuredProperties": {
+                    "headerFilterStrategy": "syndesisHeaderStrategy",
+                    "httpMethodRestrict": "GET,POST"
+                  },
+                  "connectorCustomizers": [
+                    "io.syndesis.connector.webhook.WebhookConnectorCustomizer"
+                  ],
+                  "exceptionHandler": "io.syndesis.connector.webhook.WebhookOnExceptionHandler",
+                  "inputDataShape": {
+                    "kind": "none"
+                  },
+                  "outputDataShape": {
+                    "kind": "json-instance",
+                    "metadata": {
+                      "userDefined": "true"
+                    },
+                    "name": "BoringStrings",
+                    "specification": "{\n \"astring\": \"something\",\n \"anotherstring\": \"whatever\"\n }"
+                  },
+                  "propertyDefinitionSteps": [
+                    {
+                      "description": "Webhook Configuration",
+                      "name": "configuration",
+                      "properties": {
+                        "contextPath": {
+                          "componentProperty": false,
+                          "defaultValue": "xuKmVUQJzrtoCTRHz5qbTv9MqP2A7NempJBtEN9TAYUHK9ABHc",
+                          "deprecated": false,
+                          "description": "The Webhook token that will be set as final part of the URL",
+                          "displayName": "Webhook Token",
+                          "generator": "alphanum:50",
+                          "javaType": "String",
+                          "kind": "parameter",
+                          "order": 0,
+                          "required": true,
+                          "secret": false,
+                          "tags": [
+                            "context-path"
+                          ],
+                          "type": "string"
+                        },
+                        "defaultResponse": {
+                          "componentProperty": false,
+                          "deprecated": false,
+                          "displayName": "Default Response",
+                          "javaType": "String",
+                          "kind": "parameter",
+                          "order": 1,
+                          "required": false,
+                          "secret": false,
+                          "type": "legend"
+                        },
+                        "errorHandling": {
+                          "componentProperty": false,
+                          "deprecated": false,
+                          "displayName": "Error Handling",
+                          "javaType": "String",
+                          "kind": "parameter",
+                          "order": 3,
+                          "required": false,
+                          "secret": false,
+                          "type": "legend"
+                        },
+                        "errorResponseCodes": {
+                          "componentProperty": false,
+                          "defaultValue": "{}",
+                          "deprecated": false,
+                          "description": "The return code to set according to different error situations",
+                          "displayName": "Error Response Codes",
+                          "extendedProperties": "{ \"mapsetValueDefinition\": {   \"enum\" : [{\"label\":\"400 Bad Request\",\"value\":\"400\"},{\"label\":\"404 Not Found\",\"value\":\"404\"},{\"label\":\"405 Method Not Allowed\",\"value\":\"405\"},{\"label\":\"409 Conflict\",\"value\":\"409\"},{\"label\":\"500 Server Error\",\"value\":\"500\"},{\"label\":\"501 Not Implemented\",\"value\":\"501\"},{\"label\":\"503 Service Unavailable\",\"value\":\"503\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                          "javaType": "Map",
+                          "kind": "parameter",
+                          "order": 5,
+                          "required": false,
+                          "secret": false,
+                          "type": "mapset"
+                        },
+                        "httpResponseCode": {
+                          "componentProperty": false,
+                          "deprecated": false,
+                          "description": "The return code to set in the HTTP response",
+                          "displayName": "Return Code",
+                          "enum": [
+                            {
+                              "label": "200 OK",
+                              "value": "200"
+                            },
+                            {
+                              "label": "201 Created",
+                              "value": "201"
+                            },
+                            {
+                              "label": "202 Accepted",
+                              "value": "202"
+                            },
+                            {
+                              "label": "204 No Content",
+                              "value": "204"
+                            }
+                          ],
+                          "javaType": "String",
+                          "kind": "parameter",
+                          "order": 2,
+                          "required": true,
+                          "secret": false,
+                          "type": "select"
+                        },
+                        "returnBody": {
+                          "componentProperty": false,
+                          "deprecated": false,
+                          "displayName": "Include error message in the return body",
+                          "javaType": "Boolean",
+                          "kind": "parameter",
+                          "order": 4,
+                          "required": false,
+                          "secret": false,
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  ],
+                  "standardizedErrors": [
+                    {
+                      "displayName": "ServerError",
+                      "name": "SERVER_ERROR"
+                    }
+                  ]
+                },
+                "id": "io.syndesis:webhook-incoming",
+                "metadata": {
+                  "serverBasePath": "/webhook"
+                },
+                "name": "Incoming Webhook",
+                "pattern": "From",
+                "tags": [
+                  "expose"
+                ]
+              },
+              "configuredProperties": {
+                "contextPath": "why-do-you-fail",
+                "errorResponseCodes": "{}",
+                "httpResponseCode": "200",
+                "returnBody": "true"
+              },
+              "connection": {
+                "connector": {
+                  "actions": [
+                    {
+                      "actionType": "connector",
+                      "description": "Start an integration from a Webhook",
+                      "descriptor": {
+                        "componentScheme": "servlet",
+                        "configuredProperties": {
+                          "headerFilterStrategy": "syndesisHeaderStrategy",
+                          "httpMethodRestrict": "GET,POST"
+                        },
+                        "connectorCustomizers": [
+                          "io.syndesis.connector.webhook.WebhookConnectorCustomizer"
+                        ],
+                        "exceptionHandler": "io.syndesis.connector.webhook.WebhookOnExceptionHandler",
+                        "inputDataShape": {
+                          "kind": "none"
+                        },
+                        "outputDataShape": {
+                          "kind": "any"
+                        },
+                        "propertyDefinitionSteps": [
+                          {
+                            "description": "Webhook Configuration",
+                            "name": "configuration",
+                            "properties": {
+                              "contextPath": {
+                                "componentProperty": false,
+                                "deprecated": false,
+                                "description": "The Webhook token that will be set as final part of the URL",
+                                "displayName": "Webhook Token",
+                                "generator": "alphanum:50",
+                                "javaType": "String",
+                                "kind": "parameter",
+                                "order": 0,
+                                "required": true,
+                                "secret": false,
+                                "tags": [
+                                  "context-path"
+                                ],
+                                "type": "string"
+                              },
+                              "defaultResponse": {
+                                "componentProperty": false,
+                                "deprecated": false,
+                                "displayName": "Default Response",
+                                "javaType": "String",
+                                "kind": "parameter",
+                                "order": 1,
+                                "required": false,
+                                "secret": false,
+                                "type": "legend"
+                              },
+                              "errorHandling": {
+                                "componentProperty": false,
+                                "deprecated": false,
+                                "displayName": "Error Handling",
+                                "javaType": "String",
+                                "kind": "parameter",
+                                "order": 3,
+                                "required": false,
+                                "secret": false,
+                                "type": "legend"
+                              },
+                              "errorResponseCodes": {
+                                "componentProperty": false,
+                                "defaultValue": "{}",
+                                "deprecated": false,
+                                "description": "The return code to set according to different error situations",
+                                "displayName": "Error Response Codes",
+                                "extendedProperties": "{ \"mapsetValueDefinition\": {   \"enum\" : [{\"label\":\"400 Bad Request\",\"value\":\"400\"},{\"label\":\"404 Not Found\",\"value\":\"404\"},{\"label\":\"405 Method Not Allowed\",\"value\":\"405\"},{\"label\":\"409 Conflict\",\"value\":\"409\"},{\"label\":\"500 Server Error\",\"value\":\"500\"},{\"label\":\"501 Not Implemented\",\"value\":\"501\"},{\"label\":\"503 Service Unavailable\",\"value\":\"503\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                "javaType": "Map",
+                                "kind": "parameter",
+                                "order": 5,
+                                "required": false,
+                                "secret": false,
+                                "type": "mapset"
+                              },
+                              "httpResponseCode": {
+                                "componentProperty": false,
+                                "deprecated": false,
+                                "description": "The return code to set in the HTTP response",
+                                "displayName": "Return Code",
+                                "enum": [
+                                  {
+                                    "label": "200 OK",
+                                    "value": "200"
+                                  },
+                                  {
+                                    "label": "201 Created",
+                                    "value": "201"
+                                  },
+                                  {
+                                    "label": "202 Accepted",
+                                    "value": "202"
+                                  },
+                                  {
+                                    "label": "204 No Content",
+                                    "value": "204"
+                                  }
+                                ],
+                                "javaType": "String",
+                                "kind": "parameter",
+                                "order": 2,
+                                "required": true,
+                                "secret": false,
+                                "type": "select"
+                              },
+                              "returnBody": {
+                                "componentProperty": false,
+                                "deprecated": false,
+                                "displayName": "Include error message in the return body",
+                                "javaType": "Boolean",
+                                "kind": "parameter",
+                                "order": 4,
+                                "required": false,
+                                "secret": false,
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        ],
+                        "standardizedErrors": [
+                          {
+                            "displayName": "ServerError",
+                            "name": "SERVER_ERROR"
+                          }
+                        ]
+                      },
+                      "id": "io.syndesis:webhook-incoming",
+                      "metadata": {
+                        "serverBasePath": "/webhook"
+                      },
+                      "name": "Incoming Webhook",
+                      "pattern": "From",
+                      "tags": [
+                        "expose"
+                      ]
+                    }
+                  ],
+                  "dependencies": [
+                    {
+                      "id": "io.syndesis.connector:connector-webhook:2.0-SNAPSHOT",
+                      "type": "MAVEN"
+                    }
+                  ],
+                  "description": "Create direct connections with external systems through Webhooks",
+                  "icon": "assets:webhook.svg",
+                  "id": "webhook",
+                  "metadata": {
+                    "hide-from-connection-pages": "true"
+                  },
+                  "name": "Webhook",
+                  "version": 16
+                },
+                "connectorId": "webhook",
+                "description": "Create direct connections with external systems through Webhooks",
+                "icon": "assets:webhook.svg",
+                "id": "webhook",
+                "isDerived": false,
+                "metadata": {
+                  "hide-from-connection-pages": "true"
+                },
+                "name": "Webhook",
+                "uses": 0
+              },
+              "id": "-M4yE00lqo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "stepKind": "endpoint"
+            },
+            {
+              "action": {
+                "actionType": "step",
+                "descriptor": {
+                  "inputDataShape": {
+                    "kind": "any",
+                    "name": "All preceding outputs"
+                  },
+                  "outputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"stringa\":{\"description\":\"Identifier for the symbol stringa\",\"type\":\"string\"},\"stringb\":{\"description\":\"Identifier for the symbol stringb\",\"type\":\"string\"}}}"
+                  }
+                }
+              },
+              "configuredProperties": {
+                "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yE00lqo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yE00lqo1w5KT5YvY7\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yEf-jqo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yEf-jqo1w5KT5YvY7\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.776601\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"anotherstring\",\"path\":\"/anotherstring\",\"fieldType\":\"STRING\",\"docId\":\"-M4yE00lqo1w5KT5YvY7\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"stringa\",\"path\":\"/stringa\",\"fieldType\":\"STRING\",\"docId\":\"-M4yEf-jqo1w5KT5YvY7\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.171748\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"astring\",\"path\":\"/astring\",\"fieldType\":\"STRING\",\"docId\":\"-M4yE00lqo1w5KT5YvY7\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"stringb\",\"path\":\"/stringb\",\"fieldType\":\"STRING\",\"docId\":\"-M4yEf-jqo1w5KT5YvY7\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+              },
+              "id": "-M4yEkUwqo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "name": "Data Mapper",
+              "stepKind": "mapper"
+            },
+            {
+              "action": {
+                "actionType": "step",
+                "descriptor": {
+                  "inputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"stringa\":{\"description\":\"Identifier for the symbol stringa\",\"type\":\"string\"},\"stringb\":{\"description\":\"Identifier for the symbol stringb\",\"type\":\"string\"}}}"
+                  },
+                  "outputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"message\":{\"description\":\"Identifier for the symbol message\",\"type\":\"string\"}}}"
+                  }
+                },
+                "id": "-M4yEf-iqo1w5KT5YvY7",
+                "name": "Template"
+              },
+              "configuredProperties": {
+                "language": "mustache",
+                "template": "Try to get {{stringa}} and {{stringb}}."
+              },
+              "id": "-M4yEf-jqo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "name": "Template",
+              "stepKind": "template"
+            },
+            {
+              "action": {
+                "actionType": "step",
+                "descriptor": {
+                  "inputDataShape": {
+                    "kind": "any",
+                    "name": "All preceding outputs"
+                  },
+                  "outputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"fillme\":{\"description\":\"Identifier for the symbol fillme\",\"type\":\"string\"}}}"
+                  }
+                }
+              },
+              "configuredProperties": {
+                "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yE00lqo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yE00lqo1w5KT5YvY7\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yEkUwqo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yEkUwqo1w5KT5YvY7\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yEf-jqo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yEf-jqo1w5KT5YvY7\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-M4yEkU8qo1w5KT5YvY7\",\"uri\":\"atlas:json:-M4yEkU8qo1w5KT5YvY7\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.797244\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"anotherstring\",\"path\":\"/anotherstring\",\"fieldType\":\"STRING\",\"docId\":\"-M4yE00lqo1w5KT5YvY7\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"fillme\",\"path\":\"/fillme\",\"fieldType\":\"STRING\",\"docId\":\"-M4yEkU8qo1w5KT5YvY7\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+              },
+              "id": "-M4yEme7qo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "name": "Data Mapper",
+              "stepKind": "mapper"
+            },
+            {
+              "action": {
+                "actionType": "step",
+                "descriptor": {
+                  "inputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"fillme\":{\"description\":\"Identifier for the symbol fillme\",\"type\":\"string\"}}}"
+                  },
+                  "outputDataShape": {
+                    "kind": "json-schema",
+                    "name": "Template JSON Schema",
+                    "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"Template JSON Schema\",\"type\":\"object\",\"properties\":{\"message\":{\"description\":\"Identifier for the symbol message\",\"type\":\"string\"}}}"
+                  }
+                },
+                "id": "-M4yEkU7qo1w5KT5YvY7",
+                "name": "Template"
+              },
+              "configuredProperties": {
+                "language": "mustache",
+                "template": "Are you sure you can use previous strings?  {{fillme}}"
+              },
+              "id": "-M4yEkU8qo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "name": "Template",
+              "stepKind": "template"
+            },
+            {
+              "configuredProperties": {
+                "bodyLoggingEnabled": "true",
+                "contextLoggingEnabled": "true"
+              },
+              "id": "-M4yE1J6qo1w5KT5YvY7",
+              "metadata": {
+                "configured": "true"
+              },
+              "name": "Log",
+              "stepKind": "log"
+            }
+          ],
+          "tags": [
+            "timer",
+            "webhook"
+          ],
+          "type": "PRIMARY"
+        }
+      ],
+      "id": "i-M4yEs28lCY5ii3d0hYGz",
+      "name": "why-do-you-fail",
+      "tags": [
+        "webhook"
+      ],
+      "updatedAt": 0,
+      "version": 1
+    }
+  }
+}


### PR DESCRIPTION
So this is a possible fix on the bug I was hunting on the integration tests. I'm not quite convinced this is the proper solution. Let's discuss :)

I reduced the problem to the usage of a `org.apache.camel.StreamCache` when extracting data from previous steps. First time you extract the data, no problems. Further attempts to extract the data lead to an empty/exhausted StreamCache returning an empty value/string.

So when you use the data coming from the immediate previous step, everything is fine. But if you try to reuse older data, empty strings.

I am not sure if we used StreamCache previously or why it is failing now. 

So, my solution is: read once on the `io.syndesis.integration.runtime.capture.OutMessageCaptureProcessor` and pass that read value to AtlasMap. No StreamCache on AtlasMap.

This leads to issues because I suspect:
 a) Not all InputStreamCache can be easily converted to String.
 b) What about the rest of the StreamCache types? I know this one usecase, but there has to be more for sure!

Also added a very dummy integration test for this usecase.