### PR TITLE
fix(test): testcontainers on CI

### DIFF
--- a/app/s2i/src/main/docker/Dockerfile
+++ b/app/s2i/src/main/docker/Dockerfile
@@ -2,21 +2,13 @@ FROM fabric8/s2i-java:3.0-java8
 
 ENV AB_JOLOKIA_HTTPS="true"
 
-USER 0
 # Setting local+remote repositories needed for building the sample projects
-ADD settings.xml /tmp/settings.xml
+ADD --chown=0 settings.xml /tmp/settings.xml
 
 # Copy over all local dependencies to docker maven repo
 # The integration expects all dependencies in /tmp/artifacts/m2
 # so you cannot change the location of the local repo!
-ADD repository /tmp/artifacts/m2
-
-RUN chgrp -R 0 /tmp/artifacts/m2 \
- && chmod -R g=u /tmp/artifacts/m2
+ADD --chown=1000 repository /tmp/artifacts/m2
 
 # Copy licenses
-RUN mkdir -p /opt/ipaas/
-ADD licenses* /opt/ipaas/
-
-USER 1000
-
+ADD --chown=0 licenses* /opt/ipaas/

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -16,7 +16,6 @@
 
 package io.syndesis.test.itest.sheets;
 
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
@@ -51,7 +50,7 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -16,7 +16,6 @@
 
 package io.syndesis.test.itest.sheets;
 
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
@@ -51,7 +50,7 @@ public class DBToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -16,7 +16,6 @@
 
 package io.syndesis.test.itest.sheets;
 
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.TestCaseRunner;
@@ -52,7 +51,7 @@ public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -16,6 +16,7 @@
 
 package io.syndesis.test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -142,9 +143,11 @@ public final class SyndesisTestEnvironment {
                 System.getenv(SYNDESIS_DEBUG_PORT_ENV) : SYNDESIS_DEBUG_PORT_DEFAULT));
     }
 
-    public static int getContainerStartupTimeout() {
-        return Integer.parseInt(System.getProperty(SYNDESIS_CONTAINER_STARTUP_TIMEOUT, System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) != null ?
+    public static Duration getContainerStartupTimeout() {
+        final int seconds = Integer.parseInt(System.getProperty(SYNDESIS_CONTAINER_STARTUP_TIMEOUT, System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) != null ?
                 System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) : SYNDESIS_CONTAINER_STARTUP_TIMEOUT_DEFAULT));
+
+        return Duration.ofSeconds(seconds);
     }
 
     public static String getOutputDirectory() {

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -132,7 +132,7 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
         private boolean enableDebug = SyndesisTestEnvironment.isDebugEnabled();
         private boolean enableS2IBuild = SyndesisTestEnvironment.isS2iBuildEnabled();
 
-        private Duration startupTimeout = Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout());
+        private Duration startupTimeout = SyndesisTestEnvironment.getContainerStartupTimeout();
 
         private ProjectBuilder projectBuilder;
         private IntegrationSource integrationSource;

--- a/app/test/test-support/src/main/resources/testcontainers.properties
+++ b/app/test/test-support/src/main/resources/testcontainers.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ryuk.container.privileged=true

--- a/app/test/test-support/src/test/resources/logback-test.xml
+++ b/app/test/test-support/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (C) 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%-15.15thread] %-5level %-30.30logger - %msg%n</pattern>
+    </encoder>
+    <file>target/test.log</file>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
This should fix issues with running testcontainers on CI where SELinux
is enabled. This solves the issue by adding the files of the integration
to the image at image build time instead of mounting the volume at
container runtime. When adding the files as a part of the build we can
control permissions whereas when mounting a volume we need to make sure
that the SELinux context is preserved and that the permissions on files
are sufficient enough taking into account the permissions of the user
running the container.

Also configures that the Ryuk container runs as privileged, this is
required so it can access the Docker socket mounted from host in
environments where SELinux is enabled.

This also contains small cleanup in 2eba92c

