### PR TITLE
kafka-connector-mf update for TLS option

### DIFF
--- a/doc/modules/connecting/proc-creating-kafka-connections.adoc
+++ b/doc/modules/connecting/proc-creating-kafka-connections.adoc
@@ -9,25 +9,26 @@ or publish data to a Kafka topic,
 create a connection to Kafka and then add that connection to an 
 integration.
 
-[IMPORTANT]
-In this release, connections to Kafka do not support SSL. 
-It is expected that this will change in a future release.
-
 .Prerequisites
 
 * You enabled auto-discovery of Kafka brokers in the cluster.
 Or, you know the URI for the Kafka broker that you want to connect to. 
+* If you want to use Transport Layer Security (TLS) to encrypt your data, you have the Kafka broker’s PEM certificate text. Typically, you obtain the broker certificate text from your Kafka server administrator.
 
 .Procedure
 
 . In {prodname}, in the left panel, click *Connections* to
 display any available connections.
-. In the upper right, click *Create Connection* to display
+. Click *Create Connection* to display
 connectors.  
 . Click the *Kafka* connector.
 . In the *Kafka broker URIs* field, select the broker that you want 
 this connection to access, or enter a comma separated list
 of Kafka broker URIs. Each URI should be in the form _host:port_.
+. For the *Transport Protocol* field, select one of the following options:
+* If you want to encrypt your data to protect it in transit, select *TLS* (Transport Layer Security).
+* If you do not want to encrypt your data, select *Plain* and then skip to Step 7.
+. If you selected *TLS* in Step 5, then in the *Broker certificate* field, paste the Kafka broker’s PEM certificate text.
 . Click *Validate*. {prodname} immediately tries to validate the 
 connection and displays a message that indicates whether 
 validation is successful. If validation fails, revise the input 

--- a/doc/modules/connecting/proc-creating-kafka-connections.adoc
+++ b/doc/modules/connecting/proc-creating-kafka-connections.adoc
@@ -11,7 +11,8 @@ integration.
 
 .Prerequisites
 
-* You enabled auto-discovery of Kafka brokers in the cluster.
+* You enabled auto-discovery of Kafka brokers in the cluster as described in 
+link:{LinkFuseOnlineConnectorGuide}#enabling-auto-discovery-of-kafka-brokers_kafka[Enabling auto-discovery of Kafka brokers/AMQ Streams]. 
 Or, you know the URI for the Kafka broker that you want to connect to. 
 * If you want to use Transport Layer Security (TLS) to encrypt your data, you have the Kafka broker’s PEM certificate text. Typically, you obtain the broker certificate text from your Kafka server administrator.
 
@@ -21,7 +22,7 @@ Or, you know the URI for the Kafka broker that you want to connect to.
 display any available connections.
 . Click *Create Connection* to display
 connectors.  
-. Click the *Kafka* connector.
+. Click the *Kafka Message Broker* connector.
 . In the *Kafka broker URIs* field, select the broker that you want 
 this connection to access, or enter a comma separated list
 of Kafka broker URIs. Each URI should be in the form _host:port_.


### PR DESCRIPTION
This doc update is ready for review.
It is an update to the Kafka Connector documentation - it updates the steps for creating a connection to a Kafka broker to include the options for specifying TLS as a Transfer Protocol and a broker certificate.