### PR TITLE
fix: use a different character sequence for interpolation for template editor

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/template/useTemplate.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/template/useTemplate.tsx
@@ -134,8 +134,15 @@ export function useTemplate(props: IUseTemplateProps) {
   };
 
   const formatAnnotation = (a: any) => {
-    a.message = t(`integrations:linter:${a.message}`, a.messageContext);
-    return a;
+    const messageContext = (a.messageContext || []) as string[];
+    const message = t(`integrations:linter:${a.message}`, {
+      ...messageContext,
+      interpolation: {
+        prefix: '__',
+        suffix: '__'
+      }
+    });
+    return { ...a, message };
   };
 
   const template = (

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -257,13 +257,13 @@
     "OperationName": "Operation name"
   },
   "linter": {
-    "linter-wrong-symbol-format": "'{{0}}' does not conform to the format {{1}} at line: {{2}}, column: {{3}}",
-    "linter-illegal-open-symbol": "Illegal open symbol at line: {{0}}, column: {{1}}",
-    "linter-too-many-open-symbols": "Too many open symbols at line: {{0}}, column: {{1}}",
-    "linter-illegal-close-symbol": "Illegal close symbol at line: {{0}}, column: {{1}}",
-    "linter-too-many-close-symbols": "Too many close symbols at line: {{0}}, column: {{1}}",
-    "linter-expected-open-symbol": "Expected open symbol at line: {{0}}, column: {{1}}",
-    "linter-expected-close-symbol": "Expected close symbol at line: {{0}}, column: {{1}}",
+    "linter-wrong-symbol-format": "'__0__' does not conform to the format __1__ at line: __2__, column: __3__",
+    "linter-illegal-open-symbol": "Illegal open symbol at line: __0__, column: __1__",
+    "linter-too-many-open-symbols": "Too many open symbols at line: __0__, column: __1__",
+    "linter-illegal-close-symbol": "Illegal close symbol at line: __0__, column: __1__",
+    "linter-too-many-close-symbols": "Too many close symbols at line: __0__, column: __1__",
+    "linter-expected-open-symbol": "Expected open symbol at line: __0__, column: __1__",
+    "linter-expected-close-symbol": "Expected close symbol at line: __0__, column: __1__",
     "linter-no-symbols": "The editor contains no data-mappable symbols",
     "linter-no-content": "The editor has no content"
   },


### PR DESCRIPTION
fixes [ENTESB-11393](https://issues.redhat.com/browse/ENTESB-11393)

![image](https://user-images.githubusercontent.com/351660/80409509-fe3b6a00-8896-11ea-969d-a856315095a8.png)


