### PR TITLE
fix: move the special classname to the dropdown item so the logout entry is hidden

### DIFF
--- a/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
+++ b/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
@@ -134,6 +134,7 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
                           className="pf-u-display-none-on-lg"
                         />,
                         <DropdownItem
+                          className={'pf-u-display-none-on-lg'}
                           key={`mobile-${logoutItem.key}`}
                           onClick={logoutItem.onClick}
                         >
@@ -142,9 +143,7 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
                             role="menuitem"
                             id={`mobile-${logoutItem.id}`}
                             data-testid={`mobile-${logoutItem.id}`}
-                            className={`${
-                              logoutItem.className
-                            } pf-u-display-none-on-lg`}
+                            className={logoutItem.className}
                           >
                             {logoutItem.children}
                           </button>


### PR DESCRIPTION
fixes [ENTESB-13404](https://issues.redhat.com/browse/ENTESB-13404)

![image](https://user-images.githubusercontent.com/351660/80491279-7d30b100-8930-11ea-947d-4f77e80d956f.png)

Hard to screenshot but see there's less whitespace underneath the "About" entry.