### PR TITLE
fix(build): quay.io transfer for dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ quay_transfer: &quay_transfer
   run:
     name: Trigger image transfer to quay.io
     command: |
-      if [ -n "${CIRCLE_PR_NUMBER}" ]; then
+      if [ -n "${CI_PULL_REQUEST}" ]; then
         curl -vs "https://ci.fabric8.io/generic-webhook-trigger/invoke?token=syndesis-circleci-to-quay&build_number=$CIRCLE_BUILD_NUM"
       else
         echo "Skip transfer to quay.io for non PR build"


### PR DESCRIPTION
Dependabot creates branches and then pull requests for those. Same as in
#8310 we can't rely on `CIRCLE_PR_NUMBER` for pull requests that are not
created from forks, and `CI_PULL_REQUEST` seems to be defined on both
pull requests from branches and pull requests from forks.

Fixes #8366

(cherry picked from commit 8aa0a786007b28ae9e3e305c1c388204ceca4c14)

Backport of #8372 to `1.10.x`, we might need this if backport action starts working