### PR TITLE
fix(build): remove quotes around tags to delete

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -333,7 +333,7 @@ publish_artifacts() {
                 curl -q -s -S --fail -X DELETE -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} ${release_url}
             fi
         done
-        git push --delete origin "${versions_to_discard}"
+        git push --delete origin ${versions_to_discard}
     fi
 
     local upload_url=$(curl -q -s -S --fail \


### PR DESCRIPTION
Having quotes around the tags that are to be deleted makes those tags a
single argument, i.e. single tag that needs to be deleted rather than
multiple tags, failing the build when there are more than one tag to
delete.