### PR TITLE
BACKPORT: fix(ENTESB-13518): Fix upgrading syndesis installed with an external db

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -214,8 +214,8 @@ build_image()
         echo Building image with S2I
         echo ======================================================
         if [ -z "$(oc get bc -o name | grep ${S2I_STREAM_NAME})" ]; then
-            echo "Creating BuildConfig ${S2I_STREAM_NAME}"
-            oc new-build --strategy=docker --binary=true --name ${S2I_STREAM_NAME}
+            echo "Creating BuildConfig ${S2I_STREAM_NAME} with tag ${OPERATOR_IMAGE_TAG}"
+            oc new-build --strategy=docker --binary=true --to=${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG} --name ${S2I_STREAM_NAME}
         fi
         local arch="$(mktemp -t ${S2I_STREAM_NAME}-dockerXXX).tar"
         echo $arch

--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -103,10 +103,6 @@ func (a *installAction) Execute(ctx context.Context, syndesis *v1beta1.Syndesis)
 	}
 	config.OpenShiftOauthClientSecret = token
 
-	if err := config.ExternalDatabase(ctx, a.client, syndesis); err != nil {
-		return err
-	}
-
 	// Render the route resource...
 	all, err := generator.RenderDir("./route/", config)
 	if err != nil {
@@ -256,7 +252,9 @@ func (a *installAction) Execute(ctx context.Context, syndesis *v1beta1.Syndesis)
 
 		a.log.Info("Syndesis resource installed", "name", target.Name)
 	} else if syndesis.Status.Phase == v1beta1.SyndesisPhasePostUpgradeRun {
-		a.removePostgresUpgradeTrigger(ctx, syndesis)
+		if len(syndesis.Spec.Components.Database.ExternalDbURL) <= 0 {
+			a.removePostgresUpgradeTrigger(ctx, syndesis)
+		}
 
 		// Installation completed, set the next state
 		target.Status.Phase = v1beta1.SyndesisPhasePostUpgradeRunSucceed

--- a/install/operator/pkg/syndesis/backup/backup.go
+++ b/install/operator/pkg/syndesis/backup/backup.go
@@ -542,9 +542,6 @@ func (b *Backup) backupDatabase() error {
 	if err != nil {
 		return err
 	}
-	if err = sc.ExternalDatabase(b.context, b.client, b.syndesis); err != nil {
-		return err
-	}
 
 	dbURL, err := url.Parse(sc.Syndesis.Components.Database.URL)
 	if err != nil {
@@ -617,9 +614,6 @@ func (b *Backup) RestoreDb() (err error) {
 	// Load configuration to to use as context for generator pkg
 	sc, err := configuration.GetProperties(configuration.TemplateConfig, b.context, b.client, b.syndesis)
 	if err != nil {
-		return err
-	}
-	if err = sc.ExternalDatabase(b.context, b.client, b.syndesis); err != nil {
 		return err
 	}
 

--- a/install/operator/pkg/syndesis/configuration/configuration.go
+++ b/install/operator/pkg/syndesis/configuration/configuration.go
@@ -330,6 +330,10 @@ func GetProperties(file string, ctx context.Context, client client.Client, synde
 	}
 
 	if client == nil || len(syndesis.Spec.Components.Database.ExternalDbURL) > 0 {
+		if err := configuration.externalDatabase(ctx, client, syndesis); err != nil {
+			return nil, err
+		}
+
 		return configuration, nil
 	}
 
@@ -458,7 +462,7 @@ func (config *Config) SetRoute(ctx context.Context, client client.Client, syndes
 }
 
 // When an external database is defined, reset connection parameters
-func (config *Config) ExternalDatabase(ctx context.Context, client client.Client, syndesis *v1beta1.Syndesis) error {
+func (config *Config) externalDatabase(ctx context.Context, client client.Client, syndesis *v1beta1.Syndesis) error {
 	// Handle an external database being defined
 	if syndesis.Spec.Components.Database.ExternalDbURL != "" {
 


### PR DESCRIPTION
* configuration.go
 * GetProperties is the essential function called for initialising a
   configuration object. However, ExternalDatabase is crucial for checking
   if the db is external. Instead of calling this separately, include it as
   part of GetProperties

* install.go
 * ExternalDatabase function removed as now internal
 * No need to try and call removePostgresUpgradeTrigger() since this is
   only for internal db

* .lib.sh
 * Fixes naming/tagging of operator imagestream