### PR TITLE
fix(test): explicit copy of S2I assembly project

### DIFF
--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
@@ -16,6 +16,9 @@
 
 package io.syndesis.test.container.s2i;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,7 +51,19 @@ public class S2iProjectBuilder implements ProjectBuilder {
         SyndesisS2iAssemblyContainer syndesisS2iAssemblyContainer = new SyndesisS2iAssemblyContainer(integrationName, projectDir, imageTag);
         syndesisS2iAssemblyContainer.start();
 
-        Path fatJar = projectDir.resolve("target").resolve("project-0.1-SNAPSHOT.jar");
+        // The S2I assembly container result need to be copied to the local host
+        // to be used by S2I integration containers
+        Path target = projectDir.resolve("target");
+        Path fatJar = target.resolve("project-0.1-SNAPSHOT.jar");
+        try {
+            Files.createDirectories(target);
+            syndesisS2iAssemblyContainer.copyFileFromContainer(
+                "/tmp/src/target/project-0.1-SNAPSHOT.jar",
+                fatJar.toAbsolutePath().toString()
+            );
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
         return new Project.Builder()
             .projectPath(projectDir)


### PR DESCRIPTION
Added an explicit step to copy S2I assembly phase. As of 1b3a19c003576caffa25202543dc92fedf4fa6b7 we're no longer sharing the filesystem so we need to copy the result of a container to be used by other containers.

Fixes #8403

Locally all tests are passing again:
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 54, Failures: 0, Errors: 0, Skipped: 0
```
Looking forward to see if CI/CD are also working.