### PR TITLE
fix(operator): nil pointer dereference in upgrade

### DIFF
--- a/install/operator/pkg/syndesis/upgrade/backup.go
+++ b/install/operator/pkg/syndesis/upgrade/backup.go
@@ -33,7 +33,7 @@ type backup struct {
 
 func newBackup(base step, s *v1beta1.Syndesis) (*backup, error) {
 
-	bkp, err := sbackup.NewBackup(base.context, nil, s,
+	bkp, err := sbackup.NewBackup(base.context, base.clientTools, s,
 		strings.Join([]string{"/tmp/", strconv.FormatInt(time.Now().Unix(), 10)}, ""))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Upgrade fails with:

```
E0506 11:48:31.790954       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1517 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x18ebcc0, 0x2c6daf0)
	/home/zregvart/tmp/syndesis-master/install/operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/zregvart/tmp/syndesis-master/install/operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x18ebcc0, 0x2c6daf0)
	/usr/lib/golang/src/runtime/panic.go:969 +0x166
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/clienttools.(*ClientTools).RuntimeClient(0x0, 0xc000bd2690, 0x1b03cb3, 0x4, 0xc000b435f8)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/clienttools/clienttools.go:50 +0x26
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/backup.(*Backup).backupResources(0xc000147560, 0x0, 0x0)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/backup/backup.go:340 +0x363
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/backup.(*Backup).Run(0xc000147560, 0x0, 0x0)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/backup/backup.go:193 +0xf2
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/upgrade.(*backup).run(0xc0001ea770, 0x1, 0x0)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/upgrade/backup.go:60 +0x34
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/upgrade.(*upgrade).Upgrade(0xc0001ea700, 0x1b2467b, 0x1c)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/upgrade/upgrade.go:100 +0x255
github.com/syndesisio/syndesis/install/operator/pkg/syndesis/action.(*upgradeAction).Execute(0xc0009b4140, 0x1edd500, 0xc000046060, 0xc000e76400, 0x2, 0x2)
	/home/zregvart/tmp/syndesis-master/install/operator/pkg/syndesis/action/upgrade.go:63 +0x1e7
github.com/syndesisio/syndesis/install/operator/pkg/controller/syndesis.(*ReconcileSyndesis).Reconcile(0xc0009408f0, 0xc0008839f0, 0xb, 0xc0008839e0, 0x3, 0x0, 0xbfa4c6e166c77d22, 0xc000235050, 0xc000234f38)
```

This makes sure that the `clientTools` is passed from the base step to
the backup step when performing upgrade.