### PR TITLE
chore: Use no-transfer-progress option on integration-test builds [ci skip]

### DIFF
--- a/tools/bin/commands/integration-test
+++ b/tools/bin/commands/integration-test
@@ -25,7 +25,7 @@ integration-test::run() {
 }
 
 maven_args() {
-    local args=""
+    local args=" --no-transfer-progress"
 
     if [ "$(hasflag --clean -c)" ]; then
         args="$args clean"


### PR DESCRIPTION
This should shrink the amount of log output on CircleCI significantly. We have reached log output limits of CircleCI before.