### PR TITLE
refactor(server): remove dead database code

### DIFF
--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
@@ -115,14 +115,6 @@ public class ActivityTrackingController implements BackendController, Closeable 
             String dbName = x.getConnection().getMetaData().getDatabaseProductName();
             databaseKind = SqlJsonDB.DatabaseKind.valueOf(dbName);
 
-            // CockroachDB uses the PostgreSQL driver.. so need to look a little
-            // closer.
-            if (databaseKind == SqlJsonDB.DatabaseKind.PostgreSQL) {
-                String version = x.createQuery("SELECT VERSION()").mapTo(String.class).first();
-                if (version.startsWith("CockroachDB")) {
-                    databaseKind = SqlJsonDB.DatabaseKind.CockroachDB;
-                }
-            }
             return null;
         });
     }


### PR DESCRIPTION
We're not supporting SQLite and CockroachDB, so this removes the dead
code dealing with those. We might support H2 so that code has been left
as is.