### PR TITLE
S2I and integration test fixes

### DIFF
--- a/app/s2i/src/main/docker/Dockerfile
+++ b/app/s2i/src/main/docker/Dockerfile
@@ -2,13 +2,20 @@ FROM fabric8/s2i-java:3.0-java8
 
 ENV AB_JOLOKIA_HTTPS="true"
 
+USER 0
+
 # Setting local+remote repositories needed for building the sample projects
-ADD --chown=0 settings.xml /tmp/settings.xml
+ADD settings.xml /tmp/settings.xml
+RUN chown 0 /tmp/settings.xml
 
 # Copy over all local dependencies to docker maven repo
 # The integration expects all dependencies in /tmp/artifacts/m2
 # so you cannot change the location of the local repo!
-ADD --chown=1000 repository /tmp/artifacts/m2
+ADD repository /tmp/artifacts/m2
+RUN chown -R 1000 /tmp/artifacts/m2
 
 # Copy licenses
-ADD --chown=0 licenses* /opt/ipaas/
+ADD licenses* /opt/ipaas/
+RUN chown -R 0 /opt/ipaas/
+
+USER 1000

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
@@ -48,8 +48,9 @@ public class S2iProjectBuilder implements ProjectBuilder {
                 .map(Objects::toString)
                 .orElse("s2i-assembly");
 
-        SyndesisS2iAssemblyContainer syndesisS2iAssemblyContainer = new SyndesisS2iAssemblyContainer(integrationName, projectDir, imageTag);
-        syndesisS2iAssemblyContainer.start();
+        final SyndesisS2iAssemblyContainer s2i = new SyndesisS2iAssemblyContainer(integrationName, projectDir, imageTag);
+        s2i.setCommand("sh", "-c", SyndesisS2iAssemblyContainer.S2I_ASSEMBLE_SCRIPT + " && sleep infinity");
+        s2i.start();
 
         // The S2I assembly container result need to be copied to the local host
         // to be used by S2I integration containers
@@ -57,7 +58,7 @@ public class S2iProjectBuilder implements ProjectBuilder {
         Path fatJar = target.resolve("project-0.1-SNAPSHOT.jar");
         try {
             Files.createDirectories(target);
-            syndesisS2iAssemblyContainer.copyFileFromContainer(
+            s2i.copyFileFromContainer(
                 "/tmp/src/target/project-0.1-SNAPSHOT.jar",
                 fatJar.toAbsolutePath().toString()
             );

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
@@ -36,7 +36,7 @@ import org.testcontainers.images.builder.dockerfile.statement.MultiArgsStatement
  */
 public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAssemblyContainer> {
 
-    private static final String S2I_ASSEMBLE_SCRIPT = "/usr/local/s2i/assemble";
+    static final String S2I_ASSEMBLE_SCRIPT = "/usr/local/s2i/assemble";
     private static final String SRC_DIR = "/tmp/src";
 
     public SyndesisS2iAssemblyContainer(String integrationName, Path projectDir, String imageTag) {

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
@@ -43,7 +43,10 @@ public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAs
         super(new ImageFromDockerfile(integrationName + "-s2i", true)
             .withFileFromPath(SRC_DIR, projectDir)
             .withDockerfileFromBuilder(builder -> builder.from(String.format("syndesis/syndesis-s2i:%s", imageTag))
-                .withStatement(new MultiArgsStatement("ADD --chown=1000", SRC_DIR, SRC_DIR))
+                .withStatement(new MultiArgsStatement("ADD", SRC_DIR, SRC_DIR))
+                .user("0")
+                .run("chown", "-R", "1000", SRC_DIR)
+                .user("1000")
                 .cmd(S2I_ASSEMBLE_SCRIPT)
                 .build()));
 


### PR DESCRIPTION
Originally motivated to help with backward compatibility with OpenShift 3.11 this was implemented:

refactor(s2i): replace `ADD --chown` in Dockerfile (609208c)

Seems that the Dockerfile build on OpenShift 3.11 fails if the
`ADD --chown` syntax is used, this reverts to using `ADD` + `RUN chown`
instead to be backward compatible.

A race condition in test-support for integration tests was found and fixed in:

fix(test): copy project jar race condition (e1fa833)

The S2I test container is considered started when the output of the
container shows `... done`, that also coincides with the
`/usr/local/s2i/assemble` script finishing and the process stopping,
stopping the container with it. Using
`GenericContainer::copyFileFromContainer` on a stopped container fails
with `IllegalStateException: copyFileFromContainer can only be used when the Container is created`
so the container needs to be running at the point we reach to copy the
files outside of it.

This adds a `&& sleep infinity`, so that after the `assemble` script
finishes the `sh` process in the container remains running so we can
guarantee that `copyFileFromContainer` can be performed afterwards.

The container is stopped when test finishies and/or ryuk garbage
collects spawned containers.