### PR TITLE
[closes #8348] Move integration labels to deployment data

### DIFF
--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/camelk/CamelKPublishHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/camelk/CamelKPublishHandler.java
@@ -231,8 +231,8 @@ public class CamelKPublishHandler extends BaseCamelKHandler implements StateChan
         result.getMetadata().getLabels().put(OpenShiftService.USERNAME_LABEL, Labels.sanitize(username));
         result.getMetadata().getLabels().put(OpenShiftService.COMPONENT_LABEL, "integration");
         result.getMetadata().getLabels().put(OpenShiftService.INTEGRATION_NAME_LABEL, Labels.sanitize(integration.getName()));
-        result.getMetadata().getLabels().put(OpenShiftService.INTEGRATION_TYPE_LABEL, "integration");
-        result.getMetadata().getLabels().put(OpenShiftService.INTEGRATION_APP_LABEL, "syndesis");
+        result.getMetadata().getLabels().put(OpenShiftService.INTEGRATION_TYPE_LABEL, OpenShiftService.INTEGRATION_TYPE_LABEL_VALUE);
+        result.getMetadata().getLabels().put(OpenShiftService.INTEGRATION_APP_LABEL, OpenShiftService.INTEGRATION_APP_LABEL_VALUE);
         result.getMetadata().setAnnotations(new HashMap<>());
         result.getMetadata().getAnnotations().put(OpenShiftService.INTEGRATION_NAME_ANNOTATION, integration.getName());
         result.getMetadata().getAnnotations().put(OpenShiftService.INTEGRATION_ID_LABEL, integrationId);

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
@@ -15,17 +15,6 @@
  */
 package io.syndesis.server.controller.integration.online;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.IntegrationDeployment;
 import io.syndesis.common.model.integration.IntegrationDeploymentError;
@@ -42,9 +31,21 @@ import io.syndesis.server.dao.IntegrationDao;
 import io.syndesis.server.dao.IntegrationDeploymentDao;
 import io.syndesis.server.openshift.DeploymentData;
 import io.syndesis.server.openshift.OpenShiftService;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 
 @Qualifier("s2i")
 @Component()
@@ -140,6 +141,8 @@ public class PublishHandler extends BaseOnlineHandler implements StateChangeHand
         String version = Integer.toString(integrationDeployment.getVersion());
         final DeploymentData.Builder deploymentDataBuilder = DeploymentData.builder()
             .withVersion(integrationDeployment.getVersion())
+            .addLabel(OpenShiftService.INTEGRATION_TYPE_LABEL, OpenShiftService.INTEGRATION_TYPE_LABEL_VALUE)
+            .addLabel(OpenShiftService.INTEGRATION_APP_LABEL, OpenShiftService.INTEGRATION_APP_LABEL_VALUE)
             .addLabel(OpenShiftService.INTEGRATION_ID_LABEL, Labels.validate(integrationId))
             .addLabel(OpenShiftService.DEPLOYMENT_VERSION_LABEL, version)
             .addLabel(OpenShiftService.USERNAME_LABEL, Labels.sanitize(username))
@@ -148,7 +151,7 @@ public class PublishHandler extends BaseOnlineHandler implements StateChangeHand
             .addAnnotation(OpenShiftService.DEPLOYMENT_VERSION_LABEL, version)
             .addSecretEntry("application.properties", propsToString(applicationProperties));
 
-        integration.getConfiguredProperties().forEach((k, v) -> deploymentDataBuilder.addProperty(k, v));
+        integration.getConfiguredProperties().forEach(deploymentDataBuilder::addProperty);
 
         DeploymentData data = deploymentDataBuilder.build();
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
@@ -44,7 +44,9 @@ public interface OpenShiftService {
     String INTEGRATION_ID_LABEL = "syndesis.io/integration-id";
     String INTEGRATION_NAME_LABEL = "syndesis.io/integration";
     String INTEGRATION_TYPE_LABEL = "syndesis.io/type";
+    String INTEGRATION_TYPE_LABEL_VALUE = "integration";
     String INTEGRATION_APP_LABEL = "syndesis.io/app";
+    String INTEGRATION_APP_LABEL_VALUE = "syndesis";
     String DEPLOYMENT_VERSION_LABEL = "syndesis.io/deployment-version";
     String USERNAME_LABEL = "syndesis.io/username";
     String COMPONENT_LABEL = "syndesis.io/component";
@@ -109,7 +111,6 @@ public interface OpenShiftService {
      * @param timeUnit of the time
      */
     void scale(String name, Map<String, String> labels, int desiredReplicas, long amount, TimeUnit timeUnit) throws InterruptedException;
-
 
     /**
      * Checks if the deployment (Deployment and Build configurations, Image Streams etc) is scaled.

--- a/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
+++ b/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
@@ -15,6 +15,22 @@
  */
 package io.syndesis.server.openshift;
 
+import static io.syndesis.server.openshift.OpenShiftServiceImpl.openshiftName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static io.fabric8.kubernetes.client.utils.Serialization.asJson;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -38,21 +54,6 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.slf4j.bridge.SLF4JBridgeHandler;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import static io.fabric8.kubernetes.client.utils.Serialization.asJson;
-import static io.syndesis.server.openshift.OpenShiftServiceImpl.openshiftName;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 import okhttp3.mockwebserver.RecordedRequest;
 
 public class OpenShiftServiceImplTest {
@@ -469,7 +470,6 @@ public class OpenShiftServiceImplTest {
                 .withName(openshiftName(name))
                 .addToAnnotations(deploymentData.getAnnotations())
                 .addToLabels(deploymentData.getLabels())
-                .addToLabels(OpenShiftServiceImpl.defaultLabels())
             .endMetadata()
             .withNewSpec()
                 .withReplicas(1)
@@ -486,7 +486,6 @@ public class OpenShiftServiceImplTest {
                     .withNewMetadata()
                         .addToLabels("syndesis.io/integration", openshiftName(name))
                         .addToLabels(OpenShiftServiceImpl.COMPONENT_LABEL, "integration")
-                        .addToLabels(OpenShiftServiceImpl.defaultLabels())
                         .addToLabels(deploymentData.getLabels())
                         .addToAnnotations(deploymentData.getAnnotations())
                         .addToAnnotations("prometheus.io/scrape", "true")


### PR DESCRIPTION
This moves the integration labels to `DeploymentData` labels, that are later copied to all resources of the integration