### PR TITLE
Revert "Use the Tag instead of Image for database image"

### DIFF
--- a/install/operator/pkg/cmd/internal/install/generator/generator.go
+++ b/install/operator/pkg/cmd/internal/install/generator/generator.go
@@ -28,7 +28,7 @@ type config struct {
 	Syndesis struct {
 		Components struct {
 			Database struct {
-				Tag string `yaml:"Tag"`
+				Image string `yaml:"Image"`
 			} `yaml:"Database"`
 		} `yaml:"Components"`
 	} `yaml:"Syndesis"`
@@ -50,7 +50,7 @@ func main() {
 	code := fmt.Sprintf(`package install
 
 const defaultDatabaseImage = "%s"
-`, c.Syndesis.Components.Database.Tag)
+`, c.Syndesis.Components.Database.Image)
 
 	err = ioutil.WriteFile("install_defaults.go", []byte(code), 0644)
 	if err != nil {


### PR DESCRIPTION
Following https://github.com/syndesisio/syndesis/pull/8441
This reverts commit 155455af732a91631d2a4e349f02907e37a53eda.