### PR TITLE
fix(build): don't attempt to delete zero tags

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -333,7 +333,9 @@ publish_artifacts() {
                 curl -q -s -S --fail -X DELETE -u ${GITHUB_USERNAME}:${GITHUB_ACCESS_TOKEN} ${release_url}
             fi
         done
-        git push --delete origin ${versions_to_discard}
+        if [ -n "${versions_to_discard}" ]; then
+          git push --delete origin ${versions_to_discard}
+        fi
     fi
 
     local upload_url=$(curl -q -s -S --fail \


### PR DESCRIPTION
[skip ci]

When we try to delete old (11th and older) snapshot tag we should not
try to delete if there aren't any tags to delete, i.e. when there are
less than 10 snapshot tags in the repository. This adds a check before
`git push --delete origin` to make sure we're not trying to pass an
empty list of tags to that command.