### PR TITLE
Revert "Use the Tag instead of Image for database image" (1.10.x branch)

### DIFF
--- a/install/operator/pkg/cmd/internal/install/generator/generator.go
+++ b/install/operator/pkg/cmd/internal/install/generator/generator.go
@@ -27,7 +27,7 @@ type config struct {
 	Syndesis struct {
 		Components struct {
 			Database struct {
-				Tag string `yaml:"Tag"`
+				Image string `yaml:"Image"`
 			} `yaml:"Database"`
 		} `yaml:"Components"`
 	} `yaml:"Syndesis"`
@@ -49,7 +49,7 @@ func main() {
 	code := fmt.Sprintf(`package install
 
 const defaultDatabaseImage = "%s"
-`, c.Syndesis.Components.Database.Tag)
+`, c.Syndesis.Components.Database.Image)
 
 	err = ioutil.WriteFile("install_defaults.go", []byte(code), 0644)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 821340efa7c15e91753514e86d461145fffebff2.