### PR TITLE
doc-link-attributes update for publishing

### DIFF
--- a/doc/assemblies/connecting/assembly-connecting-to-amq.adoc
+++ b/doc/assemblies/connecting/assembly-connecting-to-amq.adoc
@@ -16,7 +16,7 @@ broker of interest:
 * AMQ 6 broker
 
 To communicate with one of the following broker types, 
-link:{LinkFuseOnlineConnectorGuide}#connecting-to-amqp_amqp[use the AMQP connector] 
+link:{LinkSyndesisConnectorGuide}#connecting-to-amqp_amqp[use the AMQP connector] 
 to create a connection to the broker of interest:
 
 * Apache ActiveMQ broker that supports AMQP

--- a/doc/assemblies/connecting/assembly-connecting-to-amqp.adoc
+++ b/doc/assemblies/connecting/assembly-connecting-to-amqp.adoc
@@ -18,7 +18,7 @@ broker of interest:
 * EnMasse, which is an open source messaging platform
 
 To communicate with one of the following broker types, 
-link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_amq[use the Red Hat AMQ connector] 
+link:{LinkSyndesisConnectorGuide}#connecting-to-amq_amq[use the Red Hat AMQ connector] 
 to create a connection to the broker of interest:
 
 * Apache ActiveMQ broker that does not support AMQP

--- a/doc/assemblies/connecting/assembly-connecting-to-gmail.adoc
+++ b/doc/assemblies/connecting/assembly-connecting-to-gmail.adoc
@@ -16,7 +16,7 @@ particular Gmail account, do either of the following:
 
 The general steps for connecting to Gmail in an integration are:
 
-. link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
+. link:{LinkSyndesisConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
 . Creating a Gmail connection. When you do this you choose the Gmail account that
 the connection is authorized to access.
 . If your integration sends an email from a Gmail account, 

--- a/doc/assemblies/connecting/assembly-connecting-to-rest-apis.adoc
+++ b/doc/assemblies/connecting/assembly-connecting-to-rest-apis.adoc
@@ -9,7 +9,7 @@
 In an integration, to connect to a REST API, you must have created a
 connector for that API by uploading an OpenAPI document that
 describes the API. See 
-link:{LinkFuseOnlineIntegrationGuide}#adding-api-connectors_custom[{NameOfFuseOnlineIntegrationGuide}, Adding and managing REST API client connectors].
+link:{LinkSyndesisIntegrationGuide}#adding-api-connectors_custom[{NameOfSyndesisIntegrationGuide}, Adding and managing REST API client connectors].
 
 When a connector for the REST API you want to connect to
 is available in {prodname},

--- a/doc/assemblies/customizing/assembly-customizing.adoc
+++ b/doc/assemblies/customizing/assembly-customizing.adoc
@@ -28,7 +28,7 @@ OpenAPI document.
 +
 You upload this schema to {prodname}. {prodname} makes the
 API service available and provides the URL for API calls. This lets you 
-link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[trigger integration execution with an API call]. 
+link:{LinkSyndesisIntegrationGuide}#trigger-integrations-with-api-calls_ug[trigger integration execution with an API call]. 
 
 * A `JAR` file that implements a {prodname} extension. An extension
 can be any one of the following:  

--- a/doc/assemblies/integrating-applications/assembly-adding-api-connectors.adoc
+++ b/doc/assemblies/integrating-applications/assembly-adding-api-connectors.adoc
@@ -8,7 +8,7 @@
 
 {prodname} can create a REST API client connector from an OpenAPI
 document. For information about the content of the OpenAPI document, see
-link:{LinkFuseOnlineIntegrationGuide}#developing-rest-api-client-connectors_custom[Developing REST API client connectors]. 
+link:{LinkSyndesisIntegrationGuide}#developing-rest-api-client-connectors_custom[Developing REST API client connectors]. 
 
 The following topics provide information and instructions for adding
 and managing REST API client connectors:
@@ -19,7 +19,7 @@ and managing REST API client connectors:
 
 After you create a REST API client connector, for details about using
 that connector, see
-link:{LinkFuseOnlineConnectorGuide}#connecting-to-rest-apis_connectors[{NameOfFuseOnlineConnectorGuide}, Connecting to REST APIs]. 
+link:{LinkSyndesisConnectorGuide}#connecting-to-rest-apis_connectors[{NameOfSyndesisConnectorGuide}, Connecting to REST APIs]. 
 
 include::../../modules/integrating-applications/proc-creating-api-connectors.adoc[leveloffset=+1]
 

--- a/doc/assemblies/integrating-applications/assembly-connecting-to-applications.adoc
+++ b/doc/assemblies/integrating-applications/assembly-connecting-to-applications.adoc
@@ -17,7 +17,7 @@ The procedure for
 creating a connection varies for each application or service. The details
 for creating each kind of connection and configuring it for a particular
 integration are in 
-link:{LinkFuseOnlineConnectorGuide}[{NameOfFuseOnlineConnectorGuide}].
+link:{LinkSyndesisConnectorGuide}[{NameOfSyndesisConnectorGuide}].
 
 The following topics
 provide general information about connections:

--- a/doc/assemblies/integrating-applications/assembly-creating-integrations.adoc
+++ b/doc/assemblies/integrating-applications/assembly-creating-integrations.adoc
@@ -13,10 +13,10 @@ click *Create Integration*, {prodname} guides you
 through the procedure to create an integration.
 
 .Prerequisites
-* link:{LinkFuseOnlineIntegrationGuide}#plan_ready[Considerations for planning your integrations]
+* link:{LinkSyndesisIntegrationGuide}#plan_ready[Considerations for planning your integrations]
 * According to the kind of integration that you want to create: 
-** An understanding of the link:{LinkFuseOnlineIntegrationGuide}#workflow-overview_ready[general workflow for creating a simple integration]
-** An understanding of the link:{LinkFuseOnlineIntegrationGuide}#overview-benefit-api-provider-integrations_api-provider[general workflow for creating an API provider integration]
+** An understanding of the link:{LinkSyndesisIntegrationGuide}#workflow-overview_ready[general workflow for creating a simple integration]
+** An understanding of the link:{LinkSyndesisIntegrationGuide}#overview-benefit-api-provider-integrations_api-provider[general workflow for creating an API provider integration]
 
 The following topics provide information and instructions for creating
 an integration:

--- a/doc/assemblies/tutorials/assembly-amq2api-intro.adoc
+++ b/doc/assemblies/tutorials/assembly-amq2api-intro.adoc
@@ -29,7 +29,7 @@ ifeval::["{location}" == "downstream"]
 
 * You must be logged in to {prodname}.
 If you are not already logged in, see
-link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
+link:{LinkSyndesisTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
 
 * You are working in a {prodname} evaluation environment that is running
 on OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname}

--- a/doc/assemblies/tutorials/assembly-sf2db-intro.adoc
+++ b/doc/assemblies/tutorials/assembly-sf2db-intro.adoc
@@ -34,7 +34,7 @@ Salesforce to database sample integration.
 ifeval::["{location}" == "downstream"]
 * You must be logged in to your {prodname} environment. 
 If you are not already logged in, see 
-link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
+link:{LinkSyndesisTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.]
 * You are working in a {prodname} evaluation environment that is running on 
 OpenShift Online or OpenShift Dedicated. Or, you are working in a {prodname} 
 environment that is running in an OpenShift Container Platform project in 

--- a/doc/assemblies/tutorials/assembly-t2sf-intro.adoc
+++ b/doc/assemblies/tutorials/assembly-t2sf-intro.adoc
@@ -31,7 +31,7 @@ It takes less than two minutes to obtain a Salesforce account.
 ifeval::["{location}" == "downstream"]
 * You must be logged in to your {prodname} environment. 
 If you are not already logged in, see 
-link:{LinkFuseOnlineTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.] 
+link:{LinkSyndesisTutorials}#logging-in-and-out_tutorials[What to expect the first time that you use {prodname}.] 
 endif::[]
 
 To implement, deploy, and test this sample integration, the main steps are:

--- a/doc/customizing/master.adoc
+++ b/doc/customizing/master.adoc
@@ -36,7 +36,7 @@ OpenAPI document.
 +
 You upload this schema to Syndesis. Syndesis makes the
 API service available and provides the URL for API calls. This lets you 
-link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[trigger integration execution with an API call]. 
+link:{LinkSyndesisIntegrationGuide}#trigger-integrations-with-api-calls_ug[trigger integration execution with an API call]. 
 
 * A `JAR` file that implements a Syndesis extension. An extension
 can be any one of the following:  

--- a/doc/integrating-applications/master.adoc
+++ b/doc/integrating-applications/master.adoc
@@ -23,7 +23,7 @@ The content in this guide is organized as follows:
 * <<customizing_{context}>>
 
 To learn how to use {prodname} by creating sample integrations, see:
-link:{LinkFuseOnlineTutorials}[{NameOfFuseOnlineTutorials}].
+link:{LinkSyndesisTutorials}[{NameOfSyndesisTutorials}].
 
 include::assemblies/integrating-applications/assembly-high-level-overview.adoc[leveloffset=+1]
 

--- a/doc/modules/connecting/con-about-parameter-placeholders-and-values.adoc
+++ b/doc/modules/connecting/con-about-parameter-placeholders-and-values.adoc
@@ -30,7 +30,7 @@ to the flow before the database connection. In the data mapping
 step, map the appropriate source data fields to the target data
 fields, for example, map source data to the `:#param_1`, `:#param_2`, and
 `:#param_3` target fields. See
-link:{LinkFuseOnlineIntegrationGuide}#add-data-mapping-step_create[Adding a data mapper step].
+link:{LinkSyndesisIntegrationGuide}#add-data-mapping-step_create[Adding a data mapper step].
 
 .Batch update with a collection of parameter values 
 

--- a/doc/modules/connecting/proc-add-gmail-connection-finish-middle.adoc
+++ b/doc/modules/connecting/proc-add-gmail-connection-finish-middle.adoc
@@ -13,7 +13,7 @@ a simple integration's finish connection.
 
 * You created a Gmail connection. 
 * You are familiar with the
-link:{LinkFuseOnlineConnectorGuide}#alternative-for-populating-email-to-send_gmail[alternatives for populating an email to send]
+link:{LinkSyndesisConnectorGuide}#alternative-for-populating-email-to-send_gmail[alternatives for populating an email to send]
 and you have a plan for populating such emails. 
 * {prodname} is prompting you to add to the integration or to choose the finish 
 connection for a simple integration. 

--- a/doc/modules/connecting/proc-add-google-calendar-connection-update-event.adoc
+++ b/doc/modules/connecting/proc-add-google-calendar-connection-update-event.adoc
@@ -14,7 +14,7 @@ or as a simple integration's finish connection.
 In this release, the *Update Event* action requires a value in each event 
 field. In most if not all cases, this means that you must add a Google 
 Calendar connection that 
-link:{LinkFuseOnlineConnectorGuide}#add-google-calendar-connection-to-get-one-event_calendar[obtains the event that you want to update], 
+link:{LinkSyndesisConnectorGuide}#add-google-calendar-connection-to-get-one-event_calendar[obtains the event that you want to update], 
 then add the Google Calendar connection that updates the event, and then 
 insert a data mapper step between the two Google Calendar connections. 
 ====

--- a/doc/modules/connecting/proc-add-servicenow-connection-finish.adoc
+++ b/doc/modules/connecting/proc-add-servicenow-connection-finish.adoc
@@ -18,7 +18,7 @@ to add to the integration. Or, {prodname} is prompting you to choose a finish co
 add records to. Your ServiceNow administrator can
 help you identify the appropriate import set. If the import set 
 does not exist, see 
-link:{LinkFuseOnlineConnectorGuide}#create-servicenow-import-set_servicenow[Creating an import set in ServiceNow].
+link:{LinkSyndesisConnectorGuide}#create-servicenow-import-set_servicenow[Creating an import set in ServiceNow].
 * The ServiceNow import set is configured to handle the addition 
 of records.
 

--- a/doc/modules/connecting/proc-add-slack-connection-middle-finish.adoc
+++ b/doc/modules/connecting/proc-add-slack-connection-middle-finish.adoc
@@ -39,4 +39,4 @@ in this procedure. In the mapping step, map a string
 from a data mapping source to the Slack *message* field. This string 
 should contain the message that you want to send to the Slack
 user or channel. See
-link:{LinkFuseOnlineIntegrationGuide}#add-data-mapping-step_create[Adding a data mapper step].
+link:{LinkSyndesisIntegrationGuide}#add-data-mapping-step_create[Adding a data mapper step].

--- a/doc/modules/connecting/proc-adding-db-connection-finish-middle.adoc
+++ b/doc/modules/connecting/proc-adding-db-connection-finish-middle.adoc
@@ -66,4 +66,4 @@ the flow. If verification fails then {prodname} displays a message
 about the problem. Update your input as needed and try again.
 
 .Additional resource
-link:{LinkFuseOnlineConnectorGuide}about-parameter-placeholders-and-values_db[About parameter placeholders and values in SQL statements that update data].
+link:{LinkSyndesisConnectorGuide}about-parameter-placeholders-and-values_db[About parameter placeholders and values in SQL statements that update data].

--- a/doc/modules/connecting/proc-adding-odata-connections-write.adoc
+++ b/doc/modules/connecting/proc-adding-odata-connections-write.adoc
@@ -53,6 +53,6 @@ you added it.
 Add a data mapper step before the OData connection. You must map 
 source fields that provide the data that is required to create a new entity, 
 to update an entity, or to delete an entity. See 
-link:{LinkFuseOnlineIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].
+link:{LinkSyndesisIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].
  
  

--- a/doc/modules/connecting/proc-connecting-to-proprietary-databases.adoc
+++ b/doc/modules/connecting/proc-connecting-to-proprietary-databases.adoc
@@ -9,19 +9,19 @@ accomplished are as follows:
 
 . A developer creates a library extension that contains the JDBC driver 
 for the database that you want to access in an integration. See 
-link:{LinkFuseOnlineIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[Creating JDBC driver library extensions].
+link:{LinkSyndesisIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[Creating JDBC driver library extensions].
 
 . The developer provides a `.jar` file that contains the library extension.
 
 . You upload that `.jar` file to {prodname}. See 
-link:{LinkFuseOnlineIntegrationGuide}#making-extensions-available_add-extension[Making extensions available].
+link:{LinkSyndesisIntegrationGuide}#making-extensions-available_add-extension[Making extensions available].
 
 . You create a connection to your database by selecting the 
 {prodname} *Database* connector and specifying the connection URL
 for your database. See 
-link:{LinkFuseOnlineConnectorGuide}#create-database-connection_db[Creating a database connection].
+link:{LinkSyndesisConnectorGuide}#create-database-connection_db[Creating a database connection].
 
 . In an integration, you add the connection to your database. 
 See 
-link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-start_db[Starting an integration by accessing a database] or 
-link:{LinkFuseOnlineConnectorGuide}#adding-db-connection-finish-middle_db[Accessing a database in the middle or to complete an integration]. 
+link:{LinkSyndesisConnectorGuide}#adding-db-connection-start_db[Starting an integration by accessing a database] or 
+link:{LinkSyndesisConnectorGuide}#adding-db-connection-finish-middle_db[Accessing a database in the middle or to complete an integration]. 

--- a/doc/modules/connecting/proc-create-concur-connection.adoc
+++ b/doc/modules/connecting/proc-create-concur-connection.adoc
@@ -33,7 +33,7 @@ configured.
 If *Connect SAP Concur* does not appear, then the SAP Concur
 connector in your {prodname} environment
 is not configured.  See
-link:{LinkFuseOnlineConnectorGuide}#configure-concur-connector_concur[Configuring the SAP Concur connector]. 
+link:{LinkSyndesisConnectorGuide}#configure-concur-connector_concur[Configuring the SAP Concur connector]. 
 +
 If `redirect_uri is improper or not previously registered` appears, then 
 the SAP Concur connector configuration is incorrect. 

--- a/doc/modules/connecting/proc-create-database-connection.adoc
+++ b/doc/modules/connecting/proc-create-database-connection.adoc
@@ -21,7 +21,7 @@ connects to the database.
 is on your classpath. If you uploaded a JDBC driver library extension to 
 connect to a proprietary database, then the upload process puts the driver
 on your classpath. See 
-link:{LinkFuseOnlineIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[Creating JDBC driver library extensions]. 
+link:{LinkSyndesisIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[Creating JDBC driver library extensions]. 
 . In {prodname}, in the left panel, click *Connections* to
 display any available connections.
 . Click *Create Connection* to display
@@ -39,7 +39,7 @@ user account you want to use to access the database.
 .. In the *Schema* field, enter the name of the schema for the database.
 How you specify the database schema varies for each type of database. 
 Details are in the next section: 
-link:{LinkFuseOnlineConnectorGuide}#how-to-specify-the-schema-in-a-database-connection_db[How to specify the schema in a database connection].
+link:{LinkSyndesisConnectorGuide}#how-to-specify-the-schema-in-a-database-connection_db[How to specify the schema in a database connection].
 
 . Click *Validate*. {prodname} tries to validate the
 connection and displays a message that indicates whether

--- a/doc/modules/connecting/proc-create-gmail-connection.adoc
+++ b/doc/modules/connecting/proc-create-gmail-connection.adoc
@@ -10,7 +10,7 @@ add it to multiple integrations.
 
 .Prerequisites
 * You 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Gmail API. 
 * The {prodname} *Settings* page entry for Gmail has values for the client ID and client secret, which
 you obtained by registering {prodname} as a Google client application. 
@@ -28,7 +28,7 @@ which takes you to a *Sign in with Gmail* page.
 +
 If *Connect Gmail* does not display, your {prodname} environment
 is not registered as a Google client application. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
 When you try to create a Gmail connection and your {prodname} environment 
 is not registered as a Google client application, then {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/modules/connecting/proc-create-google-calendar-connection.adoc
+++ b/doc/modules/connecting/proc-create-google-calendar-connection.adoc
@@ -11,7 +11,7 @@ add it to multiple integrations.
 
 .Prerequisites
 * You 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Google Calendar API. 
 * The {prodname} *Settings* page entry for Google Calendar has values for the client ID and client secret, which
 you obtained by registering {prodname} as a Google client application. 
@@ -30,7 +30,7 @@ which takes you to a Google sign-in page.
 If *Connect Google Calendar* does not display, then your {prodname} environment
 is not registered as a Google client application with the Google Calendar API
 enabled. See 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application]. 
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application]. 
 When your environment is not registered with
 Google, then when you try to create a Google Calendar connection, {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/modules/connecting/proc-create-google-sheets-connection.adoc
+++ b/doc/modules/connecting/proc-create-google-sheets-connection.adoc
@@ -11,7 +11,7 @@ add it to multiple integrations.
 
 .Prerequisites
 * You 
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[registered {prodname} as a Google client application] 
 and enabled the Google Sheets API. 
 * The {prodname} *Settings* page entry for Google Sheets has values for the client ID and client secret, which
 you obtained by registering {prodname} as a Google client application. 
@@ -31,7 +31,7 @@ which takes you to a Google sign-in page.
 If *Connect Google Sheets* does not display, then your {prodname} environment
 is not registered as a Google client application with the Google Sheets API
 enabled. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
+link:{LinkSyndesisConnectorGuide}#register-with-google_google[Registering {prodname} as a Google client application].
 When your environment is not registered with
 Google, then when you try to create a Google Sheets connection, {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/modules/connecting/proc-create-s3-connection.adoc
+++ b/doc/modules/connecting/proc-create-s3-connection.adoc
@@ -9,7 +9,7 @@ Amazon S3 connection to an integration.
 
 .Prerequisites
 
-* AWS access key. See link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
+* AWS access key. See link:{LinkSyndesisConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
 
 * If the bucket that you want the connection to access already exists, 
 you must know:

--- a/doc/modules/connecting/proc-creating-amazon-dynamodb-connections.adoc
+++ b/doc/modules/connecting/proc-creating-amazon-dynamodb-connections.adoc
@@ -10,7 +10,7 @@ connect to Amazon DynamoDB in an integration.
 .Prerequisites
 
 * You must have an AWS access key. See 
-link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials for creating connections to Amazon services].
+link:{LinkSyndesisConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials for creating connections to Amazon services].
 * You must know which AWS region contains the DynamoDB table that
 you want the connection to access. 
 * You must know the name of the DynamoDB table that you want the 

--- a/doc/modules/connecting/proc-creating-amazon-sns-connections.adoc
+++ b/doc/modules/connecting/proc-creating-amazon-sns-connections.adoc
@@ -9,7 +9,7 @@ Amazon SNS connection to an integration.
 
 .Prerequisites
 
-* AWS access key. See link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
+* AWS access key. See link:{LinkSyndesisConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
 
 * You must know the region in which the SNS topic is located. 
 This is the topic that you want the SNS connection that 

--- a/doc/modules/connecting/proc-creating-amazon-sqs-connections.adoc
+++ b/doc/modules/connecting/proc-creating-amazon-sqs-connections.adoc
@@ -9,7 +9,7 @@ Amazon SQS connection to an integration.
 
 .Prerequisites
 
-* AWS access key. See link:{LinkFuseOnlineConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
+* AWS access key. See link:{LinkSyndesisConnectorGuide}#obtaining-aws-credentials_aws[Obtaining AWS credentials].
 
 * You must know the region in which the SQS queue is located. 
 This is the queue that you want the SQS connection that 

--- a/doc/modules/connecting/proc-creating-jira-connections.adoc
+++ b/doc/modules/connecting/proc-creating-jira-connections.adoc
@@ -11,7 +11,7 @@ same connection to any number of integrations.
 If the Jira server that you want to connect to uses the OAuth protocol 
 for authenticating access, you must have registered your {prodname} 
 environment as a client of the Jira server that you want to connect to. See 
-link:{LinkFuseOnlineConnectorGuide}#registering-with-jira_jira[Registering {prodname} with a Jira server that uses OAuth]. 
+link:{LinkSyndesisConnectorGuide}#registering-with-jira_jira[Registering {prodname} with a Jira server that uses OAuth]. 
 
 .Prerequisites
 * For a Jira server that uses basic authentication, you have a Jira 

--- a/doc/modules/connecting/proc-creating-kafka-connections.adoc
+++ b/doc/modules/connecting/proc-creating-kafka-connections.adoc
@@ -12,7 +12,7 @@ integration.
 .Prerequisites
 
 * You enabled auto-discovery of Kafka brokers in the cluster as described in 
-link:{LinkFuseOnlineConnectorGuide}#enabling-auto-discovery-of-kafka-brokers_kafka[Enabling auto-discovery of Kafka brokers/AMQ Streams]. 
+link:{LinkSyndesisConnectorGuide}#enabling-auto-discovery-of-kafka-brokers_kafka[Enabling auto-discovery of Kafka brokers/AMQ Streams]. 
 Or, you know the URI for the Kafka broker that you want to connect to. 
 * If you want to use Transport Layer Security (TLS) to encrypt your data, you have the Kafka broker’s PEM certificate text. Typically, you obtain the broker certificate text from your Kafka server administrator.
 

--- a/doc/modules/connecting/proc-registering-with-rest-api.adoc
+++ b/doc/modules/connecting/proc-registering-with-rest-api.adoc
@@ -13,7 +13,7 @@ authorize {prodname} to access the API.
 
 If the API you want to connect to does not use OAuth, skip this
 section and see 
-link:{LinkFuseOnlineConnectorGuide}#create-rest-api-connection_rest[Creating a REST API client connection].
+link:{LinkSyndesisConnectorGuide}#create-rest-api-connection_rest[Creating a REST API client connection].
 
 .Prerequisite
 You must know the URL for the OAuth custom application setting page for the

--- a/doc/modules/connecting/ref-how-to-specify-the-schema-in-a-database-connection.adoc
+++ b/doc/modules/connecting/ref-how-to-specify-the-schema-in-a-database-connection.adoc
@@ -32,7 +32,7 @@ a namespace. For example, you can reference the `mytable` table with `sample.myt
 *Password*: `mypw` +
 *Schema*: `sampledb`
 |Upload the driver by using the 
-link:{LinkFuseOnlineIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[extension mechanism].
+link:{LinkSyndesisIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[extension mechanism].
 Then create a connection. Connection verification fails if you have 
 not already uploaded the driver. You must specify the same schema at the end of 
 the connection URL and in the *Schema* field. 
@@ -52,7 +52,7 @@ configuration in the connection (JDBC) URL.
 *Password*: `mypw` +
 *Schema*: 
 |Use the {prodname} 
-link:{LinkFuseOnlineIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[extension mechanism].
+link:{LinkSyndesisIntegrationGuide}#creating-jdbc-driver-library-extensions_extensions[extension mechanism].
 to upload an Oracle database driver. 
 Then create the connection. Connection verification fails if the driver has 
 not been uploaded. +

--- a/doc/modules/connecting/ref-supported-connectors.adoc
+++ b/doc/modules/connecting/ref-supported-connectors.adoc
@@ -12,123 +12,123 @@
 |Name
 |Description
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-amazon-dynamodb_connectors[Amazon DynamoDB]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-amazon-dynamodb_connectors[Amazon DynamoDB]
 |Obtain, add, update, or delete data in an Amazon DynamoDB table. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-amazon-sns_connectors[Amazon Simple Notification Service (SNS)]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-amazon-sns_connectors[Amazon Simple Notification Service (SNS)]
 |Send messages to an Amazon SNS topic.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-amazon-sqs_connectors[Amazon Simple Queue Service (SQS)]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-amazon-sqs_connectors[Amazon Simple Queue Service (SQS)]
 |Retrieve messages from or send messages to an Amazon SQS queue. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-s3_connectors[Amazon Simple Storage Service (S3)]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-s3_connectors[Amazon Simple Storage Service (S3)]
 |Retrieve data from an Amazon S3 bucket or copy data into a bucket.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-amq_connectors[AMQ]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-amq_connectors[AMQ]
 |Obtain messages from a Red Hat AMQ (Apache ActiveMQ) broker or publish messages to
 a Red Hat AMQ (Apache ActiveMQ) broker.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-amqp_connectors[AMQP]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-amqp_connectors[AMQP]
 |Obtain messages from an Advanced Message Queue Protocol broker or
 publish messages to an AMQP broker.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-box_connectors[Box]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-box_connectors[Box]
 |Download files from Box or upload files to Box.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-dropbox_connectors[Dropbox]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-dropbox_connectors[Dropbox]
 |Download files from Dropbox or upload files to Dropbox.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-email-servers_connectors[Email Servers]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-email-servers_connectors[Email Servers]
 |Retrieve email from an IMAP or POP3 email server or connect to an SMTP
 email server to send email. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-fhir_connectors[FHIR]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-fhir_connectors[FHIR]
 |Obtain resources from a FHIR server or update resources on a FHIR server. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-ftp_connectors[FTP/SFTP]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-ftp_connectors[FTP/SFTP]
 |Download files from an FTP or SFTP server or upload files to an
 FTP or SFTP server.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-gmail_google[Gmail]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-gmail_google[Gmail]
 |Obtain messages sent to a particular Gmail account and send messages
 from a particular Gmail account.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-google-calendar_google[Google Calendar]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-google-calendar_google[Google Calendar]
 |Obtain events from a Google Calendar that you specify or add/update
 events in a Google Calendar that you specify.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-google-sheets_google[Google Sheets]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-google-sheets_google[Google Sheets]
 |Obtain data from a Google Sheets spreadsheet that you specify, add/update spreadsheet 
 data, create charts, or create pivot tables in a spreadsheet that you specify.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-http_connectors[HTTP/HTTPS]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-http_connectors[HTTP/HTTPS]
 |Connect to an HTTP or HTTPS endpoint and execute the
 `GET`, `PUT`, `POST`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`, OR `PATCH` method.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-irc_connectors[IRC]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-irc_connectors[IRC]
 |Receive messages that are sent to an IRC nickname or channel, or 
 send messages to an IRC nickname on a particular channel.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-jira_connectors[Jira]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-jira_connectors[Jira]
 |Obtain, create, or update issues on a Jira server. 
 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-knative-resources_connectors[Knative resources]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-knative-resources_connectors[Knative resources]
 |Obtain messages from a Knative channel, send messages to a Knative channel,
 expose a simple integration as a Knative service, or call a Knative service. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-kudu_connectors[Kudu]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-kudu_connectors[Kudu]
 |Obtain records from a table in an Apache Kudu data store
 or add records to a table in a Kudu data store.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-mongodb_connectors[MongoDB]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-mongodb_connectors[MongoDB]
 |Obtain data from a MongoDB database or update data in a MongoDB database. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-mqtt_connectors[MQTT]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-mqtt_connectors[MQTT]
 |Obtain messages from an MQ Telemetry Transport broker or publish messages
 to an MQTT broker.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-odata_connectors[OData]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-odata_connectors[OData]
 |Obtain entities from an OData service or update, create, or delete entities
 that are managed by an OData service. 
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-rest-apis_connectors[REST APIs]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-rest-apis_connectors[REST APIs]
 |Create a custom REST API client connector by uploading an OpenAPI
 document. You can then create a connection to that REST API.
 
 Create a REST API provider integration by uploading an OpenAPI document
 that defines operations that trigger integration execution. See
-link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[Creating an integration that is triggered by a REST API call]
-in {NameOfFuseOnlineIntegrationGuide}.
+link:{LinkSyndesisIntegrationGuide}#trigger-integrations-with-api-calls_ug[Creating an integration that is triggered by a REST API call]
+in {NameOfSyndesisIntegrationGuide}.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-sf_connectors[Salesforce]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-sf_connectors[Salesforce]
 |Create, update, fetch, or delete a Salesforce record.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-concur_connectors[SAP Concur]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-concur_connectors[SAP Concur]
 |Perform any one of a large variety of SAP Concur actions.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-servicenow_connectors[ServiceNow]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-servicenow_connectors[ServiceNow]
 |Obtain records from or copy records to your ServiceNow instance.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-slack_connectors[Slack]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-slack_connectors[Slack]
 |Obtain messages from a channel or send a message to a
 Slack channel or user.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-databases_connectors[SQL databases]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-databases_connectors[SQL databases]
 |Invoke a SQL statement or a SQL stored procedure on an Apache Derby,
 MySQL, or PostgreSQL database. To connect to other types of SQL databases,
 you upload a {prodname} library extension that contains a
 JDBC driver for that database.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting_to_telegram_connectors[Telegram]
+|link:{LinkSyndesisConnectorGuide}#connecting_to_telegram_connectors[Telegram]
 |Obtain messages from a chat or send messages to a chat by using
 a Telegram chat bot.
 
-|link:{LinkFuseOnlineConnectorGuide}#connecting-to-twitter_connectors[Twitter]
+|link:{LinkSyndesisConnectorGuide}#connecting-to-twitter_connectors[Twitter]
 |Trigger execution of a simple integration upon tweets that mention you or that
 contain data that you specify.
 
-|link:{LinkFuseOnlineIntegrationGuide}#triggering-integrations-with-http-requests_ug[Webhook]
+|link:{LinkSyndesisIntegrationGuide}#triggering-integrations-with-http-requests_ug[Webhook]
 |Trigger execution of simple integrations with HTTP `GET` or `POST` requests.
 
 |===
@@ -140,4 +140,4 @@ extension and creating its `.jar` file, which you upload to
 {prodname}, see:
 
 * link:{LinkToolingUserGuide}#FuseOnlineExtension[{NameOfToolingUserGuide}, how to use Fuse tooling to develop extensions]
-* link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_custom[{NameOfFuseOnlineIntegrationGuide}, how to code extensions]
+* link:{LinkSyndesisIntegrationGuide}#developing-extensions_custom[{NameOfSyndesisIntegrationGuide}, how to code extensions]

--- a/doc/modules/customizing/con-about-api-connectors.adoc
+++ b/doc/modules/customizing/con-about-api-connectors.adoc
@@ -22,7 +22,7 @@ register your {prodname} environment as a client of the REST API.
 This authorizes your {prodname} environment to access the REST API. As part
 of registration, you provide the {prodname} callback URL. 
 The details for doing this are described in
-link:{LinkFuseOnlineConnectorGuide}#register-with-rest-api_rest[{NameOfFuseOnlineConnectorGuide}, Registering {prodname} as a REST API client].
+link:{LinkSyndesisConnectorGuide}#register-with-rest-api_rest[{NameOfSyndesisConnectorGuide}, Registering {prodname} as a REST API client].
 
 For a REST API that uses OAuth, {prodname} supports only the 
 *Authorization Code* grant flow for obtaining authorization. 

--- a/doc/modules/customizing/con-about-extension-definitions.adoc
+++ b/doc/modules/customizing/con-about-extension-definitions.adoc
@@ -143,7 +143,7 @@ configuring connection actions.
 In step extensions, the `actions` object contains a `properties`
 object. The `properties` object defines a set of properties for 
 each form control for configuring the step. See also:  
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 
 * *actions* defines the operations that a connector can perform or the
 operation that a step between connections can perform. Only connector

--- a/doc/modules/customizing/con-description-kinds-extensions.adoc
+++ b/doc/modules/customizing/con-description-kinds-extensions.adoc
@@ -18,7 +18,7 @@ or service that you want to integrate. This is a connector extension.
 +
 NOTE: {prodname} can use an OpenAPI document to create a connector 
 for a REST API client. See 
-link:{LinkFuseOnlineIntegrationGuide}#developing-rest-api-client-connectors_custom[Develop a REST API client connector].
+link:{LinkSyndesisIntegrationGuide}#developing-rest-api-client-connectors_custom[Develop a REST API client connector].
 
 A business integrator shares requirements with a developer who codes the extension.
 The developer provides a `.jar` file that contains the extension.
@@ -30,4 +30,4 @@ exactly one extension.
 
 For an example of uploading and using an extension that provides a step
 that operates on data between connections, see the 
-link:{LinkFuseOnlineTutorials}#amq-to-rest-api_tutorials[AMQ to REST API sample integration tutorial].
+link:{LinkSyndesisTutorials}#amq-to-rest-api_tutorials[AMQ to REST API sample integration tutorial].

--- a/doc/modules/customizing/ref-example-camel-bean.adoc
+++ b/doc/modules/customizing/ref-example-camel-bean.adoc
@@ -96,7 +96,7 @@ exposes to the integrator who will be adding this step to an integration. In
 gets mapped to a message header that has the same name as the property. 
 In this example, the integrator will see one input field, with the
 *Log Prefix* display name. For more details, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 
 
 When you use beans, you might find it convenient to  

--- a/doc/modules/customizing/ref-example-route-builder-spring-boot.adoc
+++ b/doc/modules/customizing/ref-example-route-builder-spring-boot.adoc
@@ -56,7 +56,7 @@ public class ActionsConfiguration {
 <1> The `@Action` annotation indicates the action definition.
 <2> The `@ConfigurationProperty` annotation indicates definitions of
 user interface form controls. For details, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 <3> Register the `RouteBuilder` object as a bean. 
 <4> This is the action implementation. 
 
@@ -110,7 +110,7 @@ exposes to the integrator who will be adding this step to an integration. In
 gets mapped to a message header that has the same name as the property. 
 In this example, the integrator will see one input field, with the
 *Log Prefix* display name. For more details, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 
 
 [IMPORTANT]

--- a/doc/modules/customizing/ref-example-route-builder.adoc
+++ b/doc/modules/customizing/ref-example-route-builder.adoc
@@ -47,7 +47,7 @@ public class LogAction extends RouteBuilder {
 <1> The `@Action` annotation indicates the action definition.
 <2> The `@ConfigurationProperty` annotation indicates definitions of
 user interface form controls. For details, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 <3> This is the action implementation. 
 
 This Java code uses Syndesis annotations, which means that the
@@ -102,4 +102,4 @@ exposes to the integrator who will be adding this step to an integration. In
 gets mapped to a message header that has the same name as the property. 
 In this example, the integrator will see one input field, with the
 *Log Prefix* display name. For more information, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].

--- a/doc/modules/customizing/ref-example-route-xml-fragment.adoc
+++ b/doc/modules/customizing/ref-example-route-xml-fragment.adoc
@@ -90,7 +90,7 @@ exposes to the integrator who will be adding this step to an integration. In
 gets mapped to a message header that has the same name as the property. 
 In this example, the integrator will see one input field, with the
 *Log Prefix* display name. For more details, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
 
 
 [WARNING]

--- a/doc/modules/customizing/ref-example-step-api.adoc
+++ b/doc/modules/customizing/ref-example-step-api.adoc
@@ -152,4 +152,4 @@ like this:
 .Additional resource
 
 For details about user interface properties, see 
-link:{LinkFuseOnlineIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].
+link:{LinkSyndesisIntegrationGuide}#descriptions-of-user-interface-properties-in-extension-definitions_extensions[Descriptions of user interface properties].

--- a/doc/modules/integrating-applications/con-about-connection-validation.adoc
+++ b/doc/modules/integrating-applications/con-about-connection-validation.adoc
@@ -32,7 +32,7 @@ valid. It is possible that an item has expired or been revoked.
 If you find that an OAuth item is invalid, has expired, or been
 revoked, obtain new values and paste them into the {prodname} settings
 for the application. See the instructions in 
-link:{LinkFuseOnlineConnectorGuide}[{NameOfFuseOnlineConnectorGuide}] 
+link:{LinkSyndesisConnectorGuide}[{NameOfSyndesisConnectorGuide}] 
 for registering the application whose connection did not validate. With the
 updated settings in place, follow the instructions above to try to
 validate the updated connection. If validation is successful, and there

--- a/doc/modules/integrating-applications/con-about-creating-connections.adoc
+++ b/doc/modules/integrating-applications/con-about-creating-connections.adoc
@@ -19,6 +19,6 @@ different broker.
 
 For examples, see: 
 
-* link:{LinkFuseOnlineConnectorGuide}#create-amq-connection_amq[Create AMQ connections]
-* link:{LinkFuseOnlineConnectorGuide}#creating-http-connections_http[Create HTTP and HTTPS connections]
-* link:{LinkFuseOnlineConnectorGuide}#creating-slack-connections_slack[Create Slack connections]
+* link:{LinkSyndesisConnectorGuide}#create-amq-connection_amq[Create AMQ connections]
+* link:{LinkSyndesisConnectorGuide}#creating-http-connections_http[Create HTTP and HTTPS connections]
+* link:{LinkSyndesisConnectorGuide}#creating-slack-connections_slack[Create Slack connections]

--- a/doc/modules/integrating-applications/con-description-of-constructs.adoc
+++ b/doc/modules/integrating-applications/con-description-of-constructs.adoc
@@ -102,7 +102,7 @@ Any number of integrations and operation flows can use the same connection. A pa
 integration or flow can use the same connection more than once. 
 
 For details, see 
-link:{LinkFuseOnlineIntegrationGuide}#connecting-to-applications_ug[About connections to applications that you want to integrate].
+link:{LinkSyndesisIntegrationGuide}#connecting-to-applications_ug[About connections to applications that you want to integrate].
 
 .Actions
 
@@ -153,7 +153,7 @@ automatically provides.
 
 To operate on data between connections in a way that is not built into
 {prodname}, you can upload an extension that provides a custom step.
-See link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_custom[Developing {prodname} extensions].
+See link:{LinkSyndesisIntegrationGuide}#developing-extensions_custom[Developing {prodname} extensions].
 
 .Flow 
 A flow is a set of ordered steps that an integration executes. 
@@ -170,4 +170,4 @@ associated flow.
 In a flow, each step can operate on the data that is output from
 the previous steps. To determine the steps that you need in a flow, 
 see 
-link:{LinkFuseOnlineIntegrationGuide}#plan_ready[Considerations for planning your integrations].
+link:{LinkSyndesisIntegrationGuide}#plan_ready[Considerations for planning your integrations].

--- a/doc/modules/integrating-applications/con-preparing-to-create-an-integration.adoc
+++ b/doc/modules/integrating-applications/con-preparing-to-create-an-integration.adoc
@@ -6,7 +6,7 @@
 
 Preparation for creating an integration starts with answers to the
 questions listed in 
-link:{LinkFuseOnlineIntegrationGuide}#plan_ready[Considerations for planning your integrations].
+link:{LinkSyndesisIntegrationGuide}#plan_ready[Considerations for planning your integrations].
 After you have a plan for the
 integration, you need to do the following before you can create the
 integration:
@@ -31,5 +31,5 @@ create the connection.
 . For each application that you want to integrate, create a connection.
 
 .Additional resources
-* link:{LinkFuseOnlineIntegrationGuide}#general-procedure-for-obtaining-authorization_connections[General procedure for obtaining authorization]
-* link:{LinkFuseOnlineIntegrationGuide}#about-creating-connections_connections[About creating connections]
+* link:{LinkSyndesisIntegrationGuide}#general-procedure-for-obtaining-authorization_connections[General procedure for obtaining authorization]
+* link:{LinkSyndesisIntegrationGuide}#about-creating-connections_connections[About creating connections]

--- a/doc/modules/integrating-applications/con-workflow-overview.adoc
+++ b/doc/modules/integrating-applications/con-workflow-overview.adoc
@@ -22,4 +22,4 @@ creating a simple integration looks like this:
 image:images/integrating-applications/general-workflow.png[general workflow]
 
 .Additional resource
-link:{LinkFuseOnlineIntegrationGuide}#overview-benefit-api-provider-integrations_api-provider[Benefit, overview, and workflow for creating API provider integrations].
+link:{LinkSyndesisIntegrationGuide}#overview-benefit-api-provider-integrations_api-provider[Benefit, overview, and workflow for creating API provider integrations].

--- a/doc/modules/integrating-applications/proc-add-basic-filter-step.adoc
+++ b/doc/modules/integrating-applications/proc-add-basic-filter-step.adoc
@@ -73,4 +73,4 @@ Note that the basic filter step *matches* operator corresponds to the Simple Lan
 *regex* operator. 
 
 * If you cannot define the filter you need in a basic filter step,
-see link:{LinkFuseOnlineIntegrationGuide}#add-advanced-filter-step_create[Adding an advanced filter step].
+see link:{LinkSyndesisIntegrationGuide}#add-advanced-filter-step_create[Adding an advanced filter step].

--- a/doc/modules/integrating-applications/proc-add-custom-step.adoc
+++ b/doc/modules/integrating-applications/proc-add-custom-step.adoc
@@ -18,7 +18,7 @@ previous step(s) in the flow.
 
 .Prerequisites
 * You uploaded the custom step extension to {prodname}. See 
-link:{LinkFuseOnlineIntegrationGuide}#making-extensions-available_add-extension[Making custom features available].
+link:{LinkSyndesisIntegrationGuide}#making-extensions-available_add-extension[Making custom features available].
 * You are creating or editing a flow.
 * The flow already has all the connections that it requires.
 

--- a/doc/modules/integrating-applications/proc-add-data-mapping-step.adoc
+++ b/doc/modules/integrating-applications/proc-add-data-mapping-step.adoc
@@ -35,4 +35,4 @@ and target fields in the data mapper canvas.
 
 .Next step
 
-See  link:{LinkFuseOnlineIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].
+See  link:{LinkSyndesisIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].

--- a/doc/modules/integrating-applications/proc-add-log-step.adoc
+++ b/doc/modules/integrating-applications/proc-add-log-step.adoc
@@ -63,4 +63,4 @@ from the new log step.
 .Additional resources
 After a flow that has a log step has been executed, output from
 the log step appears in the integration's *Activity* tab. See
-link:{LinkFuseOnlineIntegrationGuide}#viewing-integration-activity-information_monitor[Viewing integration activity information].
+link:{LinkSyndesisIntegrationGuide}#viewing-integration-activity-information_monitor[Viewing integration activity information].

--- a/doc/modules/integrating-applications/proc-add-template-step.adoc
+++ b/doc/modules/integrating-applications/proc-add-template-step.adoc
@@ -121,4 +121,4 @@ A placeholder cannot contain a `.` (period).
 
 .Additional resources
 
-For details about mapping fields, see link:{LinkFuseOnlineIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].
+For details about mapping fields, see link:{LinkSyndesisIntegrationGuide}#mapping-data_ug[Mapping integration data to fields for the next connection].

--- a/doc/modules/integrating-applications/proc-applying-conditions-to-mappings.adoc
+++ b/doc/modules/integrating-applications/proc-applying-conditions-to-mappings.adoc
@@ -141,8 +141,8 @@ a transformation to.
 
 +
 For more information, see 
-link:{LinkFuseOnlineIntegrationGuide}#available-transformations_map[Descriptions of available transformations] and 
-link:{LinkFuseOnlineIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values before mapping to one target field].
+link:{LinkSyndesisIntegrationGuide}#available-transformations_map[Descriptions of available transformations] and 
+link:{LinkSyndesisIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values before mapping to one target field].
 
 +
 For example, in the same mapping presented in this procedure, in the 

--- a/doc/modules/integrating-applications/proc-combine-multiple-source-fields-into-one-target-field.adoc
+++ b/doc/modules/integrating-applications/proc-combine-multiple-source-fields-into-one-target-field.adoc
@@ -12,7 +12,7 @@ fields to the `CustomerName` field.
 For the target field, you must know what type of content is in each
 part of this compound field, the order and index of each part of the content, 
 and the separator between parts, such as a space or comma. See
-link:{LinkFuseOnlineIntegrationGuide}#example-missing-unwanted-data_map[Example of missing or unwanted data]. 
+link:{LinkSyndesisIntegrationGuide}#example-missing-unwanted-data_map[Example of missing or unwanted data]. 
 
 .Procedure
 
@@ -40,7 +40,7 @@ the concatenated value to the selected target field.
 [NOTE]
 For information about other transformations that you can apply to 
 multiple source values see 
-link:{LinkFuseOnlineIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values]
+link:{LinkSyndesisIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values]
 +
 Also under *Sources*, there is an entry for each source field that 
 you selected.
@@ -114,6 +114,6 @@ mapping in the table to view preview fields for it.
 
 .Additional resource
 Example of adding padding fields: 
-link:{LinkFuseOnlineIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target field]. 
+link:{LinkSyndesisIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target field]. 
 
 Although that example is for a one-to-many mapping, the principles are the same.

--- a/doc/modules/integrating-applications/proc-create-api-provider-integration.adoc
+++ b/doc/modules/integrating-applications/proc-create-api-provider-integration.adoc
@@ -70,4 +70,4 @@ document defines.
 
 .Next step
 For each operation,
-link:{LinkFuseOnlineIntegrationGuide}#define-integration-operation-flows_api-provider[define a flow that executes that operation].
+link:{LinkSyndesisIntegrationGuide}#define-integration-operation-flows_api-provider[define a flow that executes that operation].

--- a/doc/modules/integrating-applications/proc-create-integration-operation-flows.adoc
+++ b/doc/modules/integrating-applications/proc-create-integration-operation-flows.adoc
@@ -27,7 +27,7 @@ API provider integration's flow definitions to have your updates.
 * You created an API provider integration, gave it a name, and saved it.
 * You created a connection to each application or service that you want
 an operation flow to connect to. For details, see the
-link:{LinkFuseOnlineIntegrationGuide}#about-creating-connections_connections[information about creating connections].
+link:{LinkSyndesisIntegrationGuide}#about-creating-connections_connections[information about creating connections].
 * {prodname} is displaying the list of operations that the API defines.
 
 .Procedure
@@ -56,7 +56,7 @@ plus sign where you want to add a step.
 
 +
 For help, see
-link:{LinkFuseOnlineIntegrationGuide}#about-adding-steps_create[Adding steps between connections].
+link:{LinkSyndesisIntegrationGuide}#about-adding-steps_create[Adding steps between connections].
 
 +
 If you want to add another step that processes
@@ -71,7 +71,7 @@ to add a data mapper step here.
 ... Click the plus sign that is just before that step.
 ... Click *Data Mapper*.
 ... Define the needed mappings. For help, see
-link:{LinkFuseOnlineIntegrationGuide}#mapping-data_ug[Mapping integration data to fields in the next connection].
+link:{LinkSyndesisIntegrationGuide}#mapping-data_ug[Mapping integration data to fields in the next connection].
 ... Click *Done* to add the data mapper step to the flow.
 
 . In the flow visualization, on the
@@ -156,7 +156,7 @@ You can use the `curl` utility to confirm that the integration is working as
 expected. In the `curl` command, specify the external URL that {prodname} displays
 after it publishes the API provider integration.
 For examples of doing this, see
-link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration].
+link:{LinkSyndesisIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration].
 
 * Testing API provider integrations running on OpenShift Container Platform
 when *API discovery is enabled*
@@ -164,7 +164,7 @@ when *API discovery is enabled*
 Red Hat 3scale publishes your API provider integration. To test the integration, open the 3scale dashboard to obtain the integration’s URL.
 +
 You can disable discovery for an API provider integration if, for example, you do not want Red Hat 3scale to control access to the integration’s API or you want to test the API provider integration in {prodname}. If you disable discovery, {prodname} republishes the integration and provides an external URL for invoking and testing integration execution. To do this, in {prodname} go to the integration’s summary page. On this page, click *Disable discovery*. {prodname} republishes the integration and provides the integration’s URL. For examples of how to test an integration, see
-link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration]. After testing, you can re-enable discovery for the API provider integration so that 3scale publishes it.
+link:{LinkSyndesisIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration]. After testing, you can re-enable discovery for the API provider integration so that 3scale publishes it.
 +
 You can enable or disable discovery for each API provider integration.
 endif::rhmi[]
@@ -177,7 +177,7 @@ You can disable discovery for an API provider integration if, for example, you d
 
 To disable discovery for an API provider integration, in Fuse Online go to the integration’s summary page. On this page, click *Disable discovery*. Fuse Online republishes the integration and provides the integration’s URL.
 
-You can use the `curl` utility to confirm that the integration is working as expected. In the `curl` command, specify the external URL that Fuse Online displays after it publishes the API provider integration.  For examples of how to test an integration, see link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration].
+You can use the `curl` utility to confirm that the integration is working as expected. In the `curl` command, specify the external URL that Fuse Online displays after it publishes the API provider integration.  For examples of how to test an integration, see link:{LinkSyndesisIntegrationGuide}#try-api-provider-quickstart_api-provider[Testing the example API provider quickstart integration].
 
 After testing, you can re-enable discovery for the API provider integration so that 3scale publishes it.
 endif::rhmi[]

--- a/doc/modules/integrating-applications/proc-creating-api-connectors.adoc
+++ b/doc/modules/integrating-applications/proc-creating-api-connectors.adoc
@@ -65,7 +65,7 @@ enter a user name and password.
 .. *OAuth 2.0*  — {prodname} prompts you to enter:
 ... *Authorization URL* is the location for registering {prodname} as
 a client of the API. Registration authorizes {prodname} to access the API.
-See link:{LinkFuseOnlineConnectorGuide}#register-with-rest-api_rest[{NameOfFuseOnlineConnectorGuide}, Registering {prodname} as a REST API client]. 
+See link:{LinkSyndesisConnectorGuide}#register-with-rest-api_rest[{NameOfSyndesisConnectorGuide}, Registering {prodname} as a REST API client]. 
 The OpenAPI document or other
 documentation for the API should specify this URL. If it does not then
 you must contact the service provider to obtain this URL.
@@ -116,4 +116,4 @@ You then continue the process for creating a new API client connector.
 
 .Next step
 For details about using your new API connector, see
-link:{LinkFuseOnlineConnectorGuide}#connecting-to-rest-apis_connectors[{NameOfFuseOnlineConnectorGuide}, Connecting to REST APIs]. 
+link:{LinkSyndesisConnectorGuide}#connecting-to-rest-apis_connectors[{NameOfSyndesisConnectorGuide}, Connecting to REST APIs]. 

--- a/doc/modules/integrating-applications/proc-deleting-extensions.adoc
+++ b/doc/modules/integrating-applications/proc-deleting-extensions.adoc
@@ -27,5 +27,5 @@ To run one of these integrations, you will need to edit the
 integration to remove the customization.
 
 .Additional resources
-* link:{LinkFuseOnlineIntegrationGuide}#identifying-extension-use_add-extension[Identifying extension use]
-* link:{LinkFuseOnlineIntegrationGuide}#updating-extensions_add-extension[Updating extensions]
+* link:{LinkSyndesisIntegrationGuide}#identifying-extension-use_add-extension[Identifying extension use]
+* link:{LinkSyndesisIntegrationGuide}#updating-extensions_add-extension[Updating extensions]

--- a/doc/modules/integrating-applications/proc-general-procedure-for-obtaining-authorization.adoc
+++ b/doc/modules/integrating-applications/proc-general-procedure-for-obtaining-authorization.adoc
@@ -54,14 +54,14 @@ client ID and client secret and save the settings.
 
 * Examples of registering applications that have entries in the *Settings* page:
 
-** link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Registering {prodname} as a Salesforce client]
-** link:{LinkFuseOnlineConnectorGuide}#register-with-twitter_twitter[Registering {prodname} as a Twitter client]
+** link:{LinkSyndesisConnectorGuide}#register-with-salesforce_salesforce[Registering {prodname} as a Salesforce client]
+** link:{LinkSyndesisConnectorGuide}#register-with-twitter_twitter[Registering {prodname} as a Twitter client]
 
 * Example of registering with an application that does not have 
 an entry in the {prodname} *Settings* page: 
-link:{LinkFuseOnlineConnectorGuide}#register-with-dropbox_dropbox[Registering {prodname} as a Dropbox client]
+link:{LinkSyndesisConnectorGuide}#register-with-dropbox_dropbox[Registering {prodname} as a Dropbox client]
 
 * Information about using custom connectors that let 
 you access applications that use the
 OAuth protocol: 
-link:{LinkFuseOnlineIntegrationGuide}#creating-connections-from-custom-connectors_connections[About creating a connection from a custom connector]. 
+link:{LinkSyndesisIntegrationGuide}#creating-connections-from-custom-connectors_connections[About creating a connection from a custom connector]. 

--- a/doc/modules/integrating-applications/proc-importing-integrations.adoc
+++ b/doc/modules/integrating-applications/proc-importing-integrations.adoc
@@ -43,13 +43,13 @@ application that uses the OAuth protocol, register your {prodname}
 environment with the application. The steps vary for each application.
 See the appropriate topic:
 
-* link:{LinkFuseOnlineConnectorGuide}#register-with-dropbox_dropbox[Registering with Dropbox]
-* link:{LinkFuseOnlineConnectorGuide}#register-with-google_google[Registering with Google]
-* link:{LinkFuseOnlineConnectorGuide}#registering-with-jira_jira[Registering with Jira]
-* link:{LinkFuseOnlineConnectorGuide}#register-with-rest-api_rest[Registering with a REST API]
-* link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Registering with Salesforce]
-* link:{LinkFuseOnlineConnectorGuide}#connecting-to-concur_connectors[Connecting to SAP Concur]
-* link:{LinkFuseOnlineConnectorGuide}#register-with-twitter_twitter[Registering with Twitter]
+* link:{LinkSyndesisConnectorGuide}#register-with-dropbox_dropbox[Registering with Dropbox]
+* link:{LinkSyndesisConnectorGuide}#register-with-google_google[Registering with Google]
+* link:{LinkSyndesisConnectorGuide}#registering-with-jira_jira[Registering with Jira]
+* link:{LinkSyndesisConnectorGuide}#register-with-rest-api_rest[Registering with a REST API]
+* link:{LinkSyndesisConnectorGuide}#register-with-salesforce_salesforce[Registering with Salesforce]
+* link:{LinkSyndesisConnectorGuide}#connecting-to-concur_connectors[Connecting to SAP Concur]
+* link:{LinkSyndesisConnectorGuide}#register-with-twitter_twitter[Registering with Twitter]
 
 . In the left panel, click *Connections* and confirm that there are no
 longer any connections that require configuration.

--- a/doc/modules/integrating-applications/proc-making-extensions-available.adoc
+++ b/doc/modules/integrating-applications/proc-making-extensions-available.adoc
@@ -58,6 +58,6 @@ custom step(s) available and displays the extension's details page.
 
 .Additional resources
 
-* link:{LinkFuseOnlineIntegrationGuide}#creating-connections-from-custom-connectors_connections[Creating a connection from a custom connectors].
-* link:{LinkFuseOnlineIntegrationGuide}#add-custom-step_create[Adding a custom step]
-* link:{LinkFuseOnlineConnectorGuide}#connecting-to-proprietary-databases_db[Connecting to a proprietary database]
+* link:{LinkSyndesisIntegrationGuide}#creating-connections-from-custom-connectors_connections[Creating a connection from a custom connectors].
+* link:{LinkSyndesisIntegrationGuide}#add-custom-step_create[Adding a custom step]
+* link:{LinkSyndesisConnectorGuide}#connecting-to-proprietary-databases_db[Connecting to a proprietary database]

--- a/doc/modules/integrating-applications/proc-procedure-for-creating-an-integration.adoc
+++ b/doc/modules/integrating-applications/proc-procedure-for-creating-an-integration.adoc
@@ -76,7 +76,7 @@ any required configuration details.
 
 . Optionally, add one or more steps that operate on integration
 data between connections. See
-link:{LinkFuseOnlineIntegrationGuide}#about-adding-steps_create[About adding steps between connections].
+link:{LinkSyndesisIntegrationGuide}#about-adding-steps_create[About adding steps between connections].
 
 . In the integration visualization, look for any
 image:images/tutorials/WarningIcon.png[Warning] icons. These 

--- a/doc/modules/integrating-applications/proc-separate-one-source-field-into-multiple-target-fields.adoc
+++ b/doc/modules/integrating-applications/proc-separate-one-source-field-into-multiple-target-fields.adoc
@@ -12,7 +12,7 @@ target fields. For  example, map the `Name` field to the `FirstName` and
 For the source field, you must know what type of content is in each
 part of this compound field, the order and index of each part of the content, 
 and the separator between parts, such as a space or comma. See
-link:{LinkFuseOnlineIntegrationGuide}#example-missing-unwanted-data_map[Example of missing or unwanted data]. 
+link:{LinkSyndesisIntegrationGuide}#example-missing-unwanted-data_map[Example of missing or unwanted data]. 
 
 .Procedure
 

--- a/doc/modules/integrating-applications/proc-start-with-webhook-connection.adoc
+++ b/doc/modules/integrating-applications/proc-start-with-webhook-connection.adoc
@@ -26,7 +26,7 @@ the {prodname} external URL, which has this token at the end.
 .. Click in the *Select Type* field, and select *JSON schema*.
 .. In the *Definition* field, paste the JSON schema that defines the data 
 types of the parameters in the HTTP request. See 
-link:{LinkFuseOnlineIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
+link:{LinkSyndesisIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
 .. In the *Data Type Name* field, specify a name for this data type. 
 Although this is optional, if you specify a name, it appears in the 
 data mapper *Sources* list, which can make it easier to correctly map fields. 

--- a/doc/modules/integrating-applications/proc-testing-integrations.adoc
+++ b/doc/modules/integrating-applications/proc-testing-integrations.adoc
@@ -16,10 +16,10 @@ development environment.
 
 .Procedure
 
-. Learn about link:{LinkFuseOnlineIntegrationGuide}#about-copying-integrations_copy[copying an integration to another environment].
+. Learn about link:{LinkSyndesisIntegrationGuide}#about-copying-integrations_copy[copying an integration to another environment].
 
 . Export the integration from the development environment. See
-link:{LinkFuseOnlineIntegrationGuide}#exporting-integrations_copy[Exporting an integration].
+link:{LinkSyndesisIntegrationGuide}#exporting-integrations_copy[Exporting an integration].
 
 . Import the integration into the test environment. See
-link:{LinkFuseOnlineIntegrationGuide}#importing-integrations_copy[Importing an integration].
+link:{LinkSyndesisIntegrationGuide}#importing-integrations_copy[Importing an integration].

--- a/doc/modules/integrating-applications/proc-transform-target-data.adoc
+++ b/doc/modules/integrating-applications/proc-transform-target-data.adoc
@@ -27,4 +27,4 @@ trash can again.
 
 .Additional resource
 
-* link:{LinkFuseOnlineIntegrationGuide}#available-transformations_map[Available transformations].
+* link:{LinkSyndesisIntegrationGuide}#available-transformations_map[Available transformations].

--- a/doc/modules/integrating-applications/proc-updating-api-connectors.adoc
+++ b/doc/modules/integrating-applications/proc-updating-api-connectors.adoc
@@ -26,7 +26,7 @@ To easily distinguish between the old connector and the new connector,
 you  might want to specify a version number in the connector name or 
 the connector description. 
 +
-See link:{LinkFuseOnlineIntegrationGuide}#creating-api-connectors_add-client-connector[Creating REST API client connectors].
+See link:{LinkSyndesisIntegrationGuide}#creating-api-connectors_add-client-connector[Creating REST API client connectors].
 
 . Create a new connection from the new connector. Again, you want to be
 able to easily distinguish between connections created from the old

--- a/doc/modules/integrating-applications/proc-using-basic-expression-builder.adoc
+++ b/doc/modules/integrating-applications/proc-using-basic-expression-builder.adoc
@@ -77,4 +77,4 @@ Note that the *matches* condition corresponds to the Simple Language
 *regex* operator. 
 
 * If you cannot define the conditions that you need by using the basic expression builder,
-see link:{LinkFuseOnlineIntegrationGuide}#using-advanced-expression-builder_condition[Using the advanced expression builder to specify conditions].
+see link:{LinkSyndesisIntegrationGuide}#using-advanced-expression-builder_condition[Using the advanced expression builder to specify conditions].

--- a/doc/modules/integrating-applications/proc-viewing-integration-activity.adoc
+++ b/doc/modules/integrating-applications/proc-viewing-integration-activity.adoc
@@ -39,4 +39,4 @@ If you add a log step, then it appears as one of the integration's
 steps when you expand the integration execution that you want to view activity
 information for. You view {prodname} information for a log step in the 
 same way that you view {prodname} information for any other step. See
-link:{LinkFuseOnlineIntegrationGuide}#add-log-step_manage[Logging information about integration execution].
+link:{LinkSyndesisIntegrationGuide}#add-log-step_manage[Logging information about integration execution].

--- a/doc/modules/integrating-applications/ref-about-json-schema-for-http-requests.adoc
+++ b/doc/modules/integrating-applications/ref-about-json-schema-for-http-requests.adoc
@@ -41,4 +41,4 @@ when a Webhook connection's data shape conforms to this JSON schema,
 then query parameters and body content are available for mapping.
 
 For examples, see
-link:{LinkFuseOnlineIntegrationGuide}#how-to-specify-request_webhook[How to specify HTTP requests].
+link:{LinkSyndesisIntegrationGuide}#how-to-specify-request_webhook[How to specify HTTP requests].

--- a/doc/modules/integrating-applications/ref-about-transformations-on-multiple-source-values.adoc
+++ b/doc/modules/integrating-applications/ref-about-transformations-on-multiple-source-values.adoc
@@ -127,5 +127,5 @@ to get `10`, and then subtracts `9` from `10` to get `1`. The mapper inserts
 |===
 
 .Additional resources
-* link:{LinkFuseOnlineIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field]
-* link:{LinkFuseOnlineIntegrationGuide}#example-missing-unwanted-data_map[Separating one source field into multiple target fields]
+* link:{LinkSyndesisIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field]
+* link:{LinkSyndesisIntegrationGuide}#example-missing-unwanted-data_map[Separating one source field into multiple target fields]

--- a/doc/modules/integrating-applications/ref-alternatives-for-triggering-integration-execution.adoc
+++ b/doc/modules/integrating-applications/ref-alternatives-for-triggering-integration-execution.adoc
@@ -8,7 +8,7 @@ When you create an integration, the first step in the integration
 determines how execution of the integration is triggered.
 The first step in an integration can be one of the following:
 
-* *link:{LinkFuseOnlineIntegrationGuide}#connecting-to-applications_ug[Connection to an application or service]*.
+* *link:{LinkSyndesisIntegrationGuide}#connecting-to-applications_ug[Connection to an application or service]*.
 You configure the connection
 for the particular application or service. Examples:
 +
@@ -19,14 +19,14 @@ anyone creates a new lead.
 ** A connection to AWS S3 can periodically poll a particular bucket
 and trigger execution of a simple integration when the bucket contains files.
 
-* *link:{LinkFuseOnlineIntegrationGuide}#add-timer-connection_create[Timer]*. {prodname} triggers execution of a simple integration at the interval that
+* *link:{LinkSyndesisIntegrationGuide}#add-timer-connection_create[Timer]*. {prodname} triggers execution of a simple integration at the interval that
 you specify. This can be a simple timer or a `cron` job.
 
-* *link:{LinkFuseOnlineIntegrationGuide}#triggering-integrations-with-http-requests_ug[Webhook]*. A client can send an HTTP `GET` or `POST`
+* *link:{LinkSyndesisIntegrationGuide}#triggering-integrations-with-http-requests_ug[Webhook]*. A client can send an HTTP `GET` or `POST`
 request to an HTTP endpoint that {prodname} exposes. The request triggers
 execution of the simple integration.
 
-* *link:{LinkFuseOnlineIntegrationGuide}#trigger-integrations-with-api-calls_ug[API Provider]*. An API provider integration starts with a REST API service.
+* *link:{LinkSyndesisIntegrationGuide}#trigger-integrations-with-api-calls_ug[API Provider]*. An API provider integration starts with a REST API service.
 This REST API service is defined by an OpenAPI 3 (or 2)
 document that you provide when you create an API provider integration.
 After you publish an API provider integration,

--- a/doc/modules/integrating-applications/ref-example-missing-unwanted-data.adoc
+++ b/doc/modules/integrating-applications/ref-example-missing-unwanted-data.adoc
@@ -36,7 +36,7 @@ field has 8 ordered parts. Starting at 1, the index of each part is:
 
 In the data mapper, to identify _apartment_, _zip+4_, and _country_ as missing, you 
 add padding fields at indexes 3, 7, and 8. See 
-link:{LinkFuseOnlineIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field].
+link:{LinkSyndesisIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field].
 
 Now suppose that you want to combine source fields for 
 `number`, `street`, `city`, `state`, and `zip` into a `long_address`
@@ -44,4 +44,4 @@ target field. Further suppose that there are no source fields to provide content
 _apartment_, _zip+4_, and _country_. In the data mapper, you need to
 identify these fields as missing. Again, you add padding fields 
 at indexes 3, 7, and 8. See 
-link:{LinkFuseOnlineIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target fields].
+link:{LinkSyndesisIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target fields].

--- a/doc/modules/integrating-applications/ref-guidelines-for-service-sending-requests.adoc
+++ b/doc/modules/integrating-applications/ref-guidelines-for-service-sending-requests.adoc
@@ -11,7 +11,7 @@ your implementation should:
 `GET` or `POST` request.
 * In the URL request, specify HTTP header and query parameter values 
 whose data types adhere to the `io:syndesis:webhook` JSON schema. See
-link:{LinkFuseOnlineIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
+link:{LinkSyndesisIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
 When header and query parameters 
 adhere to this data type specification, then you can map parameter fields to 
 fields that the next connection in the integration can process. 

--- a/doc/modules/integrating-applications/ref-how-requests-are-handled.adoc
+++ b/doc/modules/integrating-applications/ref-how-requests-are-handled.adoc
@@ -10,7 +10,7 @@ a simple integration. Although a `GET` request usually obtains data and a
 to trigger an integration that does either operation. Any parameters 
 in the request are available for mapping to data fields in the
 next connection that is in the integration. For details, see
-link:{LinkFuseOnlineIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
+link:{LinkSyndesisIntegrationGuide}#about-json-schema-for-http-requests_webhook[About the JSON schema for specifying request parameters]. 
 
 A Webhook connection only passes the data it receives to
 the next connection in the integration. 

--- a/doc/modules/integrating-applications/ref-mapping-between-collections-and-non-collections.adoc
+++ b/doc/modules/integrating-applications/ref-mapping-between-collections-and-non-collections.adoc
@@ -80,6 +80,6 @@ second element, the value of the *city* field is `Paris`.
 In the third element, the value of the *city* field is `Tokyo`. 
 
 .Additional resources
-* link:{LinkFuseOnlineIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values before mapping to one target field]
-* link:{LinkFuseOnlineIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field]
-* link:{LinkFuseOnlineIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target fields]
+* link:{LinkSyndesisIntegrationGuide}#about-transformations-on-multiple-source-values_map[About transformations on multiple source values before mapping to one target field]
+* link:{LinkSyndesisIntegrationGuide}#combine-multiple-source-fields-into-one-target-field_map[Combining multiple source fields into one target field]
+* link:{LinkSyndesisIntegrationGuide}#separate-one-source-field-into-multiple-target-fields_map[Separating one source field into multiple target fields]

--- a/doc/modules/integrating-applications/ref-requirements-for-api-provider-integrations.adoc
+++ b/doc/modules/integrating-applications/ref-requirements-for-api-provider-integrations.adoc
@@ -16,7 +16,7 @@ Your OpenAPI document determines which HTTP verbs (such as
 `GET`, `POST`, `DELETE` and so on) you can specify
 in calls to your REST API service URLs. Examples of calls to
 API provider URLs are in the
-link:{LinkFuseOnlineIntegrationGuide}#try-api-provider-quickstart_api-provider[instructions for trying out the API provider quickstart example].
+link:{LinkSyndesisIntegrationGuide}#try-api-provider-quickstart_api-provider[instructions for trying out the API provider quickstart example].
 
 Your OpenAPI document also determines the possible HTTP status codes
 that an operation can return. An operation’s return path can handle

--- a/doc/modules/integrating-applications/ref-troubleshooting-integration-execution.adoc
+++ b/doc/modules/integrating-applications/ref-troubleshooting-integration-execution.adoc
@@ -5,8 +5,8 @@
 = Tips for troubleshooting integration execution
 
 If an integration stops working, check its activity and history details.
-See link:{LinkFuseOnlineIntegrationGuide}#viewing-integration-activity-information_monitor[Viewing integration activity information]
-and link:{LinkFuseOnlineIntegrationGuide}#viewing-integration-history_monitor[Viewing integration history]. 
+See link:{LinkSyndesisIntegrationGuide}#viewing-integration-activity-information_monitor[Viewing integration activity information]
+and link:{LinkSyndesisIntegrationGuide}#viewing-integration-history_monitor[Viewing integration history]. 
 
 For a connection to an application that uses OAuth, 
 you might see an error message that indicates
@@ -41,7 +41,7 @@ for other applications.
 If reconnection is not successful, try this:
 
 . Re-register {prodname} as a client of the application. See 
-link:{LinkFuseOnlineIntegrationGuide}#general-procedure-for-obtaining-authorization_connections[General procedure for obtaining authorization]. 
+link:{LinkSyndesisIntegrationGuide}#general-procedure-for-obtaining-authorization_connections[General procedure for obtaining authorization]. 
 . Create a new connection. 
 . Edit each integration that was using the old connection:
 .. Remove the old connection. 

--- a/doc/modules/integrating-applications/ref-workflow-example.adoc
+++ b/doc/modules/integrating-applications/ref-workflow-example.adoc
@@ -7,7 +7,7 @@
 The best way to understand the workflow for using {prodname} 
 to create a simple integration is to 
 create the sample integrations by following the instructions in the
-link:{LinkFuseOnlineTutorials}[sample integration tutorials].  
+link:{LinkSyndesisTutorials}[sample integration tutorials].  
 
 The following diagram shows the workflow for creating the sample
 Salesforce to Database integration. 
@@ -19,4 +19,4 @@ displays *Running* next to the integration name when the integration
 is ready to be executed.
 
 .Additional resource
-link:{LinkFuseOnlineIntegrationGuide}#configure-publish-api-provider-quickstart_api-provider[Importing and publishing the example API provider quickstart integration].
+link:{LinkSyndesisIntegrationGuide}#configure-publish-api-provider-quickstart_api-provider[Importing and publishing the example API provider quickstart integration].

--- a/doc/modules/tutorials/proc-amq2api-create-custom-step.adoc
+++ b/doc/modules/tutorials/proc-amq2api-create-custom-step.adoc
@@ -38,4 +38,4 @@ the list of extensions that have been imported.
 For information about coding an extension and creating its `.jar` file, see: 
 
 * link:{LinkToolingUserGuide}#FuseOnlineExtension[{NameOfToolingUserGuide} - Use Fuse tooling to develop an extension.]
-* link:{LinkFuseOnlineIntegrationGuide}#developing-extensions_custom[{NameOfFuseOnlineIntegrationGuide} - Manually code an extension.]
+* link:{LinkSyndesisIntegrationGuide}#developing-extensions_custom[{NameOfSyndesisIntegrationGuide} - Manually code an extension.]

--- a/doc/modules/tutorials/proc-create-sf-connection.adoc
+++ b/doc/modules/tutorials/proc-create-sf-connection.adoc
@@ -31,11 +31,11 @@ after registration to the {prodname} *Settings* page.
 +
 ifeval::["{context}" == "t2sf"]
 If you did not already register {prodname}, see 
-link:{LinkFuseOnlineTutorials}#register-with-salesforce_t2sf[Registering {prodname} as a Salesforce client application].
+link:{LinkSyndesisTutorials}#register-with-salesforce_t2sf[Registering {prodname} as a Salesforce client application].
 endif::[]
 ifeval::["{context}" == "sf2db"]
 If you did not already register {prodname}, see 
-link:{LinkFuseOnlineTutorials}#register-with-salesforce_sf2db[Registering {prodname} as a Salesforce client application].
+link:{LinkSyndesisTutorials}#register-with-salesforce_sf2db[Registering {prodname} as a Salesforce client application].
 endif::[]
 
 +
@@ -55,7 +55,7 @@ You might need to log in to Salesforce before you see the authorization page.
 +
 If *Connect Salesforce* does not appear, then your {prodname} environment
 is not registered as a Salesforce client application. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-sf_salesforce[Registering {prodname} as a Salesforce client application].
+link:{LinkSyndesisConnectorGuide}#register-with-sf_salesforce[Registering {prodname} as a Salesforce client application].
 When you try to create a Salesforce connection and your {prodname} environment 
 is not registered as a Salesforce client application, then {prodname} displays
 multiple fields that prompt for authorization information. While you can
@@ -71,7 +71,7 @@ correct {prodname} callback URL:
 
 If you get this error message, then in Salesforce, ensure that the {prodname}
 callback URL is specified according to the instructions in
-link:{LinkFuseOnlineConnectorGuide}#register-with-salesforce_salesforce[Registering {prodname} as a Salesforce client application].
+link:{LinkSyndesisConnectorGuide}#register-with-salesforce_salesforce[Registering {prodname} as a Salesforce client application].
 ====
 . Click *Allow* to return to {prodname}.
 . In the *Name* field, enter your choice of a name that

--- a/doc/modules/tutorials/proc-create-twitter-connection.adoc
+++ b/doc/modules/tutorials/proc-create-twitter-connection.adoc
@@ -41,7 +41,7 @@ You might need to log in to Twitter before you see the authorization page.
 +
 If *Connect Twitter* does not appear, then your {prodname} environment
 is not registered as a Twitter client application. See
-link:{LinkFuseOnlineConnectorGuide}#register-with-twitter_twitter[Registering {prodname} as a Twitter client application].
+link:{LinkSyndesisConnectorGuide}#register-with-twitter_twitter[Registering {prodname} as a Twitter client application].
 When you try to create a Twitter connection and your {prodname} environment 
 is not registered as a Twitter client application, then {prodname} displays
 multiple fields that prompt for authorization information. While you can

--- a/doc/modules/tutorials/proc-register-with-sf.adoc
+++ b/doc/modules/tutorials/proc-register-with-sf.adoc
@@ -26,13 +26,13 @@ credentials.
 ifeval::["{context}" == "t2sf"]
 If you already registered {prodname} as a Salesforce
 client and created a Salesforce connection, skip to 
-link:{LinkFuseOnlineTutorials}#create-twitter-sf-integration_t2sf[Creating and deploying the Twitter to Salesforce integration].
+link:{LinkSyndesisTutorials}#create-twitter-sf-integration_t2sf[Creating and deploying the Twitter to Salesforce integration].
 endif::[]
 
 ifeval::["{context}" == "sf2db"]
 If you already registered {prodname} as a Salesforce
 client and created a Salesforce connection, skip to 
-link:{LinkFuseOnlineTutorials}#create-sf-db-integration_sf2db[Creating and deploying the Salesforce to database integration]. 
+link:{LinkSyndesisTutorials}#create-sf-db-integration_sf2db[Creating and deploying the Salesforce to database integration]. 
 endif::[]
 
  

--- a/doc/modules/tutorials/ref-comparison-of-sample-integrations.adoc
+++ b/doc/modules/tutorials/ref-comparison-of-sample-integrations.adoc
@@ -10,9 +10,9 @@ which one to try first, the following table compares them.
 [cols="4*"]
 |===
 |&nbsp;
-|link:{LinkFuseOnlineTutorials}#twitter-to-salesforce_tutorials[Twitter to Salesforce]
-|link:{LinkFuseOnlineTutorials}#salesforce-to-db_tutorials[Salesforce to Database]
-|link:{LinkFuseOnlineTutorials}#amq-to-rest-api_tutorials[AMQ to REST API]
+|link:{LinkSyndesisTutorials}#twitter-to-salesforce_tutorials[Twitter to Salesforce]
+|link:{LinkSyndesisTutorials}#salesforce-to-db_tutorials[Salesforce to Database]
+|link:{LinkSyndesisTutorials}#amq-to-rest-api_tutorials[AMQ to REST API]
 
 |What it does
 |Captures and filters tweets that mention

--- a/doc/shared/attributes-links.adoc
+++ b/doc/shared/attributes-links.adoc
@@ -1,145 +1,27 @@
-// Red Hat Fuse titles
-:LinkCXFDevGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_cxf_development_guide/index
-:NameOfCXFDevGuide: Apache CXF Development Guide
+//Syndesis titles
 
-:LinkCXFSecurityGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_cxf_security_guide/index
-:NameOfCXFSecurityGuide: Apache CXF Security Guide
+:LinkSyndesisTutorials: https://zregvart.github.io/syndesis.io/manual/tutorials/
+:NameOfSyndesisTutorials: Sample Integration Tutorials
 
-:LinkKarafConsoleRef: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_karaf_console_reference/index
-:NameOfKarafConsoleRef: Apache Karaf Console Reference
+:LinkSyndesisIntegrationGuide: https://zregvart.github.io/syndesis.io/manual/integrating-applications/
+:NameOfSyndesisIntegrationGuide: Integrating Applications
 
-:LinkDeployKaraf: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/deploying_into_apache_karaf/index
-:NameOfDeployKaraf: Deploying into Apache Karaf
+:LinkSyndesisConnectorGuide: https://zregvart.github.io/syndesis.io/manual/connecting/
+:NameOfSyndesisConnectorGuide: Connecting to Applications and Services
 
-:LinkDeployEAP: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/deploying_into_jboss_eap/index
-:NameOfDeployEAP: Deploying into JBoss EAP
+//:LinkSyndesisExtensionsGuide: https://zregvart.github.io/syndesis.io/manual/developing_extensions/
+//:NameOfSyndesisExtensionsGuide: Developing Extensions
 
-:LinkDeploySpringBoot: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/deploying_into_spring_boot/index
-:NameOfDeploySpringBoot: Deploying into Spring Boot
+//:LinkSyndesisManagingGuide: https://zregvart.github.io/syndesis.io/manual/managing_environments/
+//:NameOfSyndesisManagingGuide: Managing Environments
 
-:LinkKarafInstallGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/installing_on_apache_karaf/index
-:NameOfKarafInstallGuide: Installing on Apache Karaf
-
-:LinkEAPInstallGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/installing_on_jboss_eap/index
-:NameOfEAPInstallGuide: Installing on JBoss EAP
-
-:LinkMigrationGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/migration_guide/index
-:NameOfMigrationGuide: Migration Guide
-
-:LinkManagingFuse: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/managing_fuse/index
-:NameOfManagingFuse: Managing Fuse
-
-:LinkReleaseNotes: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/release_notes_for_red_hat_fuse_{version}/index
-:NameOfReleaseNotes: Release Notes
-
-:LinkReleaseNotesBOM: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/release_notes_for_red_hat_fuse_{version}/index#StandaloneDistrib-BOMs
-
-:LinkSecurityGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_karaf_security_guide/index
-:NameOfSecurityGuide: Apache Karaf Security Guide
-
-:LinkTransactionsGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_karaf_transaction_guide/index
-:NameOfTransactionsGuide: Apache Karaf Transaction Guide
-
-:LinkToolingTutorials: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/tooling_tutorials/index
-:NameOfToolingTutorials: Tooling Tutorials
+// Red Hat titles
 
 :LinkToolingUserGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/tooling_user_guide/index
 :NameOfToolingUserGuide: Tooling User Guide
 
-:LinkCamelCompRef: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_camel_component_reference/index
-:NameOfCamelCompRef: Apache Camel Component Reference
-
-:LinkCamelDevGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/apache_camel_development_guide/index
-:NameOfCamelDevGuide: Apache Camel Development Guide
-
-:LinkFISGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/fuse_on_openshift_guide/index
-:NameOfFISGuide: Fuse on OpenShift Guide
-
 :LinkDesigningAPIs: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/designing_apis/index
 :NameDesigningAPIs: Designing APIs
-
-// Fuse Online titles
-
-:LinkFuseOnlineTutorials: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/fuse_online_sample_integration_tutorials/index
-:NameOfFuseOnlineTutorials: Fuse Online Sample Integration Tutorials
-
-:LinkFuseOnlineIntegrationGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/integrating_applications_with_fuse_online/index
-:NameOfFuseOnlineIntegrationGuide: Integrating Applications with Fuse Online
-
-:LinkFuseOnlineConnectorGuide: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/connecting_fuse_online_to_applications_and_services/index
-:NameOfFuseOnlineConnectorGuide: Connecting Fuse Online to Applications and Services
-
-:LinkFuseOnlineOnOCP: https://access.redhat.com/documentation/en-us/{productpkg}/{version}/html-single/installing_and_operating_fuse_online_on_openshift_container_platform/index
-:NameOfFuseOnlineOnOCPGuide: Installing and Operating Fuse Online on OpenShift Container Platform
-
-//REVISIT Don't forget to add the guides from the tooling repo, FIS guide!
-
-// Developer Studio titles
-:DevStudioProdName: Red Hat CodeReady Studio
-:DevStudioProdNameShort: CodeReady Studio
-:DevStudioVersion: 12.13
-
-:LinkDevStudioInstallGuide: https://access.redhat.com/documentation/en-us/red_hat_codeready_studio/{DevStudioVersion}/html-single/installation_guide/index
-:NameOfDevStudioInstallGuide: Installation Guide
-
-:LinkDevStudioRelNotes: https://access.redhat.com/documentation/en-us/red_hat_codeready_studio/{DevStudioVersion}/html-single/release_notes_and_known_issues/index
-:NameOfDevStudioRelNotes: Release Notes and Known Issues
-
-
-// Container Development Kit (CDK) titles
-:CDKProdName: Red Hat Container Development Kit
-:CDKProdNameShort: Container Development Kit
-
-:LinkCDKGettingStarted: https://access.redhat.com/documentation/en-us/red_hat_container_development_kit/{cdk-version}/html-single/getting_started_guide/index
-:NameOfCDKGettingStarted: Getting Started Guide
-
-// Red Hat Single Sign-On titles
-:RHSSOProdName: Red Hat Single Sign-On
-:RHSSOProdNameShort: Single Sign-On
-
-// Red Hat 3scale API Management titles
-:3scaleProdName: Red Hat 3scale API Management
-:3scaleProdNameShort: 3scale
-:3scaleVersion: 2.8
-
-:Link3scaleServiceDiscovery: https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/{3scaleVersion}/html-single/service_discovery/index
-:NameOf3scaleServiceDiscovery: Admin Portal Guide
-
-//Red Hat Integration titles
-:IntegrationVersion: 2020-04
-
-:LinkIntegrationCDCUserGuide: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/change_data_capture_user_guide/index
-:NameIntegrationCDCUserGuide: Change Data Capture User Guide
-
-:LinkDVReference: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/data_virtualization_reference/index
-:NameDVReference: Data Virtualization Reference
-
-:LinkIntegrationDevDeploy: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/developing_and_deploying_api_provider_integrations/index
-:NameIntegrationDevDeploy: Developing and Deploying API Provider Integrations
-
-:LinkDVClientDev: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/developing_clients_for_data_virtualization/index
-:NameDVClientDev: Developing Clients for Data Virtualization
-
-:LinkIntegrationGetStart: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/getting_started_with_apis_in_red_hat_integration/index
-:NameIntegrationGetStart: Getting Started with APIs in Red Hat Integration
-
-:LinkIntegrationGetStartedWithCDC: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/getting_started_with_change_data_capture/index
-:NameIntegrationGetStartedWithCDC: Getting Started with Change Data Capture
-
-:LinkIntegrationGetStartedWithServiceRegistry: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/getting_started_with_service_registry/index
-:NameIntegrationGetStartedWithServiceRegistry: Getting Started with Service Registry
-
-:LinkIntegrationInstallingCDCOnOpenShift: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/installing_change_data_capture_on_openshift/index
-:NameIntegrationInstallingCDCOnOpenShift: Installing Change Data Capture on OpenShift
-
-:LinkIntegrationInstallingCDCOnRHEL: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/installing_change_data_capture_on_rhel/index
-:NameIntegrationInstallingCDCOnRHEL: Installing Change Data Capture on RHEL
-
-:LinkIntegrationMonitor: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/monitoring_red_hat_integration/index
-:NameIntegrationMonitor: Monitoring Red Hat Integration
-
-:LinkIntegrationRelNotes: https://access.redhat.com/documentation/en-us/release_notes_for_red_hat_integration_{IntegrationVersion}/{IntegrationVersion}/html-single/release_notes/index
-:NameIntegrationRelNotes: Release Notes for Red Hat Integration {IntegrationVersion}
 
 :LinkIntegrationData: https://access.redhat.com/documentation/en-us/red_hat_integration/{IntegrationVersion}/html-single/using_data_virtualization/index
 :NameIntegrationData: Using Data Virtualization

--- a/doc/tutorials/master.adoc
+++ b/doc/tutorials/master.adoc
@@ -19,7 +19,7 @@ can help you decide which of these integrations to create first:
 * <<salesforce-to-db_{context}>>
 * <<amq-to-rest-api_{context}>>
 
-See also: link:{LinkFuseOnlineIntegrationGuide}[{NameOfFuseOnlineIntegrationGuide}]
+See also: link:{LinkSyndesisIntegrationGuide}[{NameOfSyndesisIntegrationGuide}]
 
 include::modules/tutorials/ref-comparison-of-sample-integrations.adoc[leveloffset=+1]
 


### PR DESCRIPTION
replace all **LinkFuseOnline** with **LinkSyndesis**
replace all **NameOfFuseOnline** with **NameOfSyndesis**
except all **OnOCP** references - left with FuseOnline

In attributes-links.adoc file:
Changed the values to correspond to the syndesis names and links
Also removed all other Red Hat book links except three that are used in the syndesis doc
