### PR TITLE
Added classname to OpenApiSelectMethod

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiSelectMethod.tsx
@@ -144,7 +144,7 @@ export const OpenApiSelectMethod: React.FunctionComponent<IOpenApiSelectMethodPr
     }
   };
   return (
-    <Stack>
+    <Stack className={'open-api-select-method'} data-testid={'openapi-select-method'}>
       <StackItem>
         <Split onClick={() => onSelectMethod(FILE)}>
           <SplitItem>


### PR DESCRIPTION
The classname was left out on accident and added test-id for test stability.