### PR TITLE
Upgrade iltorb to 2.4.5, skip PUPPETEER CHROMIUM DOWNLOAD

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -119,7 +119,7 @@
     <dep.plugin.git-commit-id.version>4.0.0</dep.plugin.git-commit-id.version>
 
     <!-- UI dependencies -->
-    <iltorb-version>2.4.1</iltorb-version>
+    <iltorb-version>2.4.5</iltorb-version>
     <node-sass-version>4.12.0</node-sass-version>
 
     <!-- Common dependencies -->

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -81,6 +81,7 @@
             <configuration>
               <environmentVariables>
                 <CYPRESS_INSTALL_BINARY>0</CYPRESS_INSTALL_BINARY>
+                <PUPPETEER_SKIP_CHROMIUM_DOWNLOAD>true</PUPPETEER_SKIP_CHROMIUM_DOWNLOAD>
               </environmentVariables>
               <arguments>install --force --no-progress --frozen-lockfile ${yarn-install-args} ${yarn-verbose}</arguments>
             </configuration>
@@ -316,7 +317,7 @@
                 </goals>
                 <configuration>
                   <url>${iltorb-binary-site}/v${iltorb-version}/iltorb-v${iltorb-version}-node-v64-${os.type}-x64.tar.gz</url>
-                  <outputFileName>45aa7d-iltorb-v${iltorb-version}-node-v64-${os.type}-x64.tar.gz</outputFileName>
+                  <outputFileName>2a34dd-iltorb-v${iltorb-version}-node-v64-linux-x64.tar.gz</outputFileName>
                   <outputDirectory>${user.home}/.npm/_prebuilds/</outputDirectory>
                 </configuration>
               </execution>


### PR DESCRIPTION
Upgrade iltorb to 2.4.5, skip PUPPETEER CHROMIUM DOWNLOAD