### PR TITLE
Fix for Entesb 13816 - The defaultValue should be object not string

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -79,7 +79,7 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getControlHint();
 
-    String getDefaultValue();
+    Object getDefaultValue();
 
     Boolean getDeprecated();
 

--- a/app/connector/webhook/src/main/resources/META-INF/syndesis/connector/webhook.json
+++ b/app/connector/webhook/src/main/resources/META-INF/syndesis/connector/webhook.json
@@ -97,6 +97,7 @@
               "returnBody": {
                 "order": 4,
                 "componentProperty": false,
+                "defaultValue": true,
                 "deprecated": false,
                 "displayName": "Include error message in the return body",
                 "javaType": "Boolean",

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -179,7 +180,7 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
                     final String propertyName = entry.getKey();
                     final ConfigurationProperty configurationProperty = entry.getValue();
 
-                    final String defaultValue = configurationProperty.getDefaultValue();
+                    final String defaultValue = Objects.toString(configurationProperty.getDefaultValue(), null);
                     boolean isSecret = connector.isSecret(propertyName) || action.isSecret(propertyName);
 
                     if (Strings.isEmptyOrBlank(defaultValue) && isSecret) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
@@ -17,6 +17,7 @@ package io.syndesis.integration.runtime.handlers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.syndesis.common.model.action.ConnectorAction;
@@ -89,7 +90,7 @@ public class ConnectorStepHandler implements IntegrationStepHandler, Integration
         // Workaround for https://github.com/syndesisio/syndesis/issues/1713
         for (Map.Entry<String, ConfigurationProperty> entry: configurationProperties.entrySet()) {
             if (ObjectHelper.isNotEmpty(entry.getValue().getDefaultValue())) {
-                properties.putIfAbsent(entry.getKey(), entry.getValue().getDefaultValue());
+                properties.putIfAbsent(entry.getKey(), Objects.toString(entry.getValue().getDefaultValue(), null));
             }
         }
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -194,7 +195,7 @@ public class OpenApiConnectorGenerator extends ConnectorGenerator {
                 builder.putProperty(propertyName, property);
 
                 if (!alreadyConfiguredProperties.containsKey(propertyName)) {
-                    final String defaultValue = property.getDefaultValue();
+                    final String defaultValue = Objects.toString(property.getDefaultValue(), null);
                     if (defaultValue != null) {
                         builder.putConfiguredProperty(propertyName, defaultValue);
                     }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -134,7 +135,7 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
 
                     final String currentValue = current.get(propertyName);
                     if (currentValue == null) {
-                        value = configuration.getDefaultValue();
+                        value = Objects.toString(configuration.getDefaultValue(), null);
                     } else {
                         value = currentValue;
                     }

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
@@ -164,7 +164,7 @@ abstract class AbstractResourceUpdateHandler<T extends WithId<T>> implements Res
         Supplier<LeveledMessage.Builder> supplier, Map<String, ConfigurationProperty> configurationProperties, Map<String, String> configuredProperties) {
 
         for (Map.Entry<String, ConfigurationProperty> entry: configurationProperties.entrySet()) {
-            if (entry.getValue().required() && Strings.isNullOrEmpty(entry.getValue().getDefaultValue()) && !configuredProperties.containsKey(entry.getKey())) {
+            if (entry.getValue().required() && Strings.isNullOrEmpty(Objects.toString(entry.getValue().getDefaultValue(),null)) && !configuredProperties.containsKey(entry.getKey())) {
                 return Collections.singletonList(
                     supplier.get()
                         .level(LeveledMessage.Level.WARN)


### PR DESCRIPTION
This to avoid quotes being put around the values during the maven-support-plugin validation step.