### PR TITLE
[ENTESB-13434] removes ability to review/edit for SOAP connector

### DIFF
--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
@@ -143,10 +143,14 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                           connectorTemplateId: state.connectorTemplateId,
                           specification: apiSummary!,
                         })}
-                        reviewEditHref={resolvers.create.specification({
-                          specification: apiSummary!.configuredProperties!
-                            .specification,
-                        })}
+                        reviewEditHref={
+                          !state.connectorTemplateId
+                            ? resolvers.create.specification({
+                                specification: apiSummary!.configuredProperties!
+                                  .specification,
+                              })
+                            : ''
+                        }
                       />
                     }
                     navigation={


### PR DESCRIPTION
For now, users should _not_ be able to Review/Edit a WSDL file. This PR hides this button from the user if they are creating a SOAP connector. Merging this PR completes [ENTESB-13434](https://issues.redhat.com/browse/ENTESB-13434) as an MVP.

WSDL:

<img width="1009" alt="Screenshot 2020-05-22 10 20 39" src="https://user-images.githubusercontent.com/3844502/82663896-7bed5e00-9c28-11ea-8fa6-69aa2e3a5c7b.png">

JSON:

<img width="924" alt="Screenshot 2020-05-22 10 20 57" src="https://user-images.githubusercontent.com/3844502/82663950-9b848680-9c28-11ea-90f3-17ed3b8eeed8.png">
