### PR TITLE
[backport 1.10.x] removes ability to review/edit for SOAP connector

### DIFF
--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
@@ -143,10 +143,14 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                           connectorTemplateId: state.connectorTemplateId,
                           specification: apiSummary!,
                         })}
-                        reviewEditHref={resolvers.create.specification({
-                          specification: apiSummary!.configuredProperties!
-                            .specification,
-                        })}
+                        reviewEditHref={
+                          !state.connectorTemplateId
+                            ? resolvers.create.specification({
+                                specification: apiSummary!.configuredProperties!
+                                  .specification,
+                              })
+                            : ''
+                        }
                       />
                     }
                     navigation={


### PR DESCRIPTION
backporting https://github.com/syndesisio/syndesis/pull/8536, which fixes the bug where users are able to edit WSDL files on upload in the API Client Connector wizard.