### PR TITLE
TEIIDTOOLS-996 updating to latest teiid / teiid spring boot

### DIFF
--- a/app/dv/pom.xml
+++ b/app/dv/pom.xml
@@ -106,13 +106,13 @@
     <version.springfox>2.9.2</version.springfox>
     <shrinkwrap.version>3.1.4</shrinkwrap.version>
 
-    <version.com.fasterxml.jackson.databind>2.9.10.1</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
+    <version.tomcat>9.0.35</version.tomcat>
+
     <version.io.fabric8.kubernetes-api>3.0.12</version.io.fabric8.kubernetes-api>
 
     <!-- DO NOT CHANGE VERSION PROPETY NAMES, THESE ARE USED IN CODE At s2i -->
     <!-- this is simply a version no dependencies involved right now -->
-    <version.springboot.teiid>1.3.0</version.springboot.teiid>
+    <version.springboot.teiid>${teiid.springboot.version}</version.springboot.teiid>
     <version.mysql>8.0.17</version.mysql>
     <version.postgresql>42.2.9</version.postgresql>
     <version.springboot>${spring-boot.version}</version.springboot>
@@ -250,13 +250,13 @@
         <artifactId>spring-boot-starter-test</artifactId>
         <version>${spring-boot.version}</version>
       </dependency>
-
+      
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <scope>import</scope>
+        <groupId>org.teiid</groupId>
+        <artifactId>teiid-spring-boot-starter</artifactId>
+        <version>${version.springboot.teiid}</version>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>
@@ -292,37 +292,6 @@
       </dependency>
       <dependency>
         <groupId>org.teiid</groupId>
-        <artifactId>teiid-common-core</artifactId>
-        <version>${version.org.teiid}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid</groupId>
-        <artifactId>teiid-api</artifactId>
-        <version>${version.org.teiid}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid</groupId>
-        <artifactId>teiid-engine</artifactId>
-        <version>${version.org.teiid}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.wololo</groupId>
-            <artifactId>jts2geojson</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid</groupId>
         <artifactId>teiid-runtime</artifactId>
         <version>${version.org.teiid}</version>
         <exclusions>
@@ -337,26 +306,6 @@
           <exclusion>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid</groupId>
-        <artifactId>teiid-client</artifactId>
-        <version>${version.org.teiid}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid.connectors</groupId>
-        <artifactId>translator-jdbc</artifactId>
-        <version>${version.org.teiid}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -399,31 +348,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${version.com.fasterxml.jackson.databind}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.teiid</groupId>
-        <artifactId>spring-data-mongodb</artifactId>
-        <version>${version.springboot.teiid}</version>
-      </dependency>
-      <dependency>
         <groupId>org.teiid</groupId>
         <artifactId>spring-data-salesforce</artifactId>
         <version>${version.springboot.teiid}</version>
@@ -435,28 +359,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-core</artifactId>
-        <version>5.4.12.Final</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
-        <version>9.0.33</version>
+        <version>${version.tomcat}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tomcat</groupId>
@@ -478,7 +383,7 @@
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-jpa</artifactId>
-        <version>2.2.6.RELEASE</version>
+        <version>${spring-boot.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.aspectj</groupId>
@@ -561,7 +466,6 @@
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>teiid-spring-boot-common</artifactId>
-      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -604,7 +508,6 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>1.5.20</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -700,10 +603,6 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <!-- for commons logging -->
     <dependency>

--- a/app/dv/src/main/java/io/syndesis/dv/datasources/MongoDBDefinition.java
+++ b/app/dv/src/main/java/io/syndesis/dv/datasources/MongoDBDefinition.java
@@ -18,10 +18,10 @@ package io.syndesis.dv.datasources;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.syndesis.dv.metadata.internal.TeiidDataSourceImpl;
 import org.teiid.spring.data.mongodb.MongoDBConfiguration;
 import org.teiid.spring.data.mongodb.MongoDBConnectionFactory;
-import org.teiid.spring.data.mongodb.MongoDBTemplate;
+
+import io.syndesis.dv.metadata.internal.TeiidDataSourceImpl;
 
 public class MongoDBDefinition extends DataSourceDefinition {
 
@@ -59,7 +59,7 @@ public class MongoDBDefinition extends DataSourceDefinition {
         config.setDatabase(scd.getProperty("database"));
         config.setRemoteServerList(scd.getProperty("host"));
 
-        MongoDBConnectionFactory mcf = new MongoDBConnectionFactory(new MongoDBTemplate(config));
+        MongoDBConnectionFactory mcf = new MongoDBConnectionFactory(config);
 
         Map<String, String> importProperties = new HashMap<String, String>();
         Map<String, String> translatorProperties = new HashMap<String, String>();

--- a/app/dv/src/main/java/io/syndesis/dv/openshift/SyndesisConnectionSynchronizer.java
+++ b/app/dv/src/main/java/io/syndesis/dv/openshift/SyndesisConnectionSynchronizer.java
@@ -25,7 +25,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.teiid.spring.data.BaseConnection;
 import org.teiid.spring.data.BaseConnectionFactory;
 
 import io.syndesis.dv.KException;
@@ -182,7 +181,7 @@ public class SyndesisConnectionSynchronizer {
             if (tds.getSyndesisId().contentEquals(sds.getSyndesisConnectionId())){
                 Object obj = tds.getConnectionFactory();
                 if (obj instanceof BaseConnectionFactory) {
-                    BaseConnection conn = ((BaseConnectionFactory<?>)obj).getConnection();
+                    org.teiid.resource.api.Connection conn = ((BaseConnectionFactory<?>)obj).getConnection();
                     if (conn != null) {
                         conn.close();
                     }

--- a/app/dv/src/main/java/io/syndesis/dv/openshift/TeiidOpenShiftClient.java
+++ b/app/dv/src/main/java/io/syndesis/dv/openshift/TeiidOpenShiftClient.java
@@ -1722,7 +1722,6 @@ public class TeiidOpenShiftClient {
                 vdbDependencies.append(StringConstants.NEW_LINE).append("<dependency>"
                         + "<groupId>org.teiid</groupId>"
                         + "<artifactId>spring-odata</artifactId>"
-                        + "<version>${version.springboot.teiid}</version>"
                         + "</dependency> ");
             }
 
@@ -1730,7 +1729,6 @@ public class TeiidOpenShiftClient {
                 vdbDependencies.append(StringConstants.NEW_LINE).append("<dependency>"
                         + "<groupId>org.teiid</groupId>"
                         + "<artifactId>spring-keycloak</artifactId>"
-                        + "<version>${version.springboot.teiid}</version>"
                         + "</dependency> ");
             }
 

--- a/app/dv/src/main/resources/s2i/template-pom.xml
+++ b/app/dv/src/main/resources/s2i/template-pom.xml
@@ -64,23 +64,33 @@
       </plugin>
     </plugins>
   </build>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.teiid</groupId>
+        <artifactId>teiid-spring-boot-starter</artifactId>
+        <version>\${version.springboot.teiid}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
   <dependencies>
     <!--vdb-dependencies-->
 
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>teiid-spring-boot-starter</artifactId>
-      <version>\${version.springboot.teiid}</version>
     </dependency>
 	<dependency>
 	  <groupId>io.opentracing.contrib</groupId>
 	  <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-	  <version>1.0.1</version>
 	</dependency>
     <dependency>    
       <groupId>org.springframework.boot</groupId>   
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>\${version.springboot}</version>
     </dependency>
   </dependencies>
 </project>

--- a/app/dv/src/test/java/io/syndesis/dv/lsp/completion/TestDdlCompletionItemProvider.java
+++ b/app/dv/src/test/java/io/syndesis/dv/lsp/completion/TestDdlCompletionItemProvider.java
@@ -17,14 +17,12 @@ package io.syndesis.dv.lsp.completion;
 
 import static org.junit.Assert.assertEquals;
 
+import io.syndesis.dv.lsp.completion.providers.DdlCompletionProvider;
 import java.util.List;
-
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.junit.Test;
 import org.teiid.query.parser.SQLParserConstants;
-
-import io.syndesis.dv.lsp.completion.providers.DdlCompletionProvider;
 
 @SuppressWarnings("nls")
 public class TestDdlCompletionItemProvider {
@@ -33,7 +31,7 @@ public class TestDdlCompletionItemProvider {
 
     /**
      * The tokenImage[...] call is returning strings wrapped in double-quotes
-     * 
+     *
      * Need to return a simple string
      * @return string without double quotes
      */
@@ -84,8 +82,8 @@ public class TestDdlCompletionItemProvider {
     @Test
     public void testCreateViewCompletions() {
         //             01234567890123456789
-        String stmt = "CREATE VIEW winelist ( \n" + 
-                      "   wine string(255), price decimal(2, 15), vendor string(255) \n" + 
+        String stmt = "CREATE VIEW winelist ( \n" +
+                      "   wine string(255), price decimal(2, 15), vendor string(255) \n" +
                       ") AS SELECT * FROM PostgresDB.winelist";
 
         List<CompletionItem> items = itemProvider.getCompletionItems(stmt, new Position(0, 0));
@@ -115,10 +113,10 @@ public class TestDdlCompletionItemProvider {
 
     @Test
     public void testTableBody() {
-        String stmt = 
+        String stmt =
 //               01234567890123456789012345678901234567890123456789
                 "CREATE VIEW winelist (\n" +
-                "   wine string(255),\n" + 
+                "   wine string(255),\n" +
 //               01234567890123456789012345678901234567890123456789
                 ")\nAS SELECT * FROM winelist";
 
@@ -135,7 +133,7 @@ public class TestDdlCompletionItemProvider {
 
     @Test
     public void testNoTableBody() {
-        String stmt = 
+        String stmt =
 //               01234567890123456789012345678901234567890123456789
                 "CREATE VIEW winelist AS SELECT * FROM winelist";
 
@@ -147,6 +145,6 @@ public class TestDdlCompletionItemProvider {
 
         // after comma in table element
         items = itemProvider.getCompletionItems(stmt, new Position(1, 31));
-        assertEquals(363, items.size());
+        assertEquals(366, items.size());
     }
 }

--- a/app/dv/src/test/resources/generated-pom-security.xml
+++ b/app/dv/src/test/resources/generated-pom-security.xml
@@ -26,15 +26,15 @@
   <packaging>jar</packaging>
   <properties>
     <version.springboot.teiid>
-      1.3.0
+      @version.springboot.teiid@
     </version.springboot.teiid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.mysql>8.0.17</version.mysql>
+    <version.mysql>@version.mysql@</version.mysql>
     <version.postgresql>@version.postgresql@</version.postgresql>
     <version.springboot>@version.springboot@</version.springboot>
     <version.mssql>@version.mssql@</version.mssql>
     <version.derby>@version.derby@</version.derby>
-    <version.mariadb>@version.mariadb@</version.mariadb>
+    <version.mariadb>@version.mariadb@</version.mariadb>    
   </properties>
 
   <repositories>
@@ -80,31 +80,38 @@
       </plugin>
     </plugins>
   </build>
-  <dependencies>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>\${version.postgresql}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>spring-keycloak</artifactId>
-      <version>\${version.springboot.teiid}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>teiid-spring-boot-starter</artifactId>
-      <version>\${version.springboot.teiid}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-      <version>1.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>\${version.springboot}</version>
-    </dependency>
-  </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.teiid</groupId>
+                <artifactId>teiid-spring-boot-starter</artifactId>
+                <version>\${version.springboot.teiid}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>\${version.postgresql}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>spring-keycloak</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/app/dv/src/test/resources/generated-pom.xml
+++ b/app/dv/src/test/resources/generated-pom.xml
@@ -26,10 +26,10 @@
   <packaging>jar</packaging>
   <properties>
     <version.springboot.teiid>
-      1.3.0
+      @version.springboot.teiid@
     </version.springboot.teiid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.mysql>8.0.17</version.mysql>
+    <version.mysql>@version.mysql@</version.mysql>
     <version.postgresql>@version.postgresql@</version.postgresql>
     <version.springboot>@version.springboot@</version.springboot>
     <version.mssql>@version.mssql@</version.mssql>
@@ -80,26 +80,34 @@
       </plugin>
     </plugins>
   </build>
-  <dependencies>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>\${version.postgresql}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>teiid-spring-boot-starter</artifactId>
-      <version>\${version.springboot.teiid}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-      <version>1.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>\${version.springboot}</version>
-    </dependency>
-  </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.teiid</groupId>
+                <artifactId>teiid-spring-boot-starter</artifactId>
+                <version>\${version.springboot.teiid}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>\${version.postgresql}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -62,7 +62,7 @@
     <json-patch.version>1.9</json-patch.version>
     <kubernetes.client.version>4.6.1</kubernetes.client.version>
 
-    <spring.version>5.2.3.RELEASE</spring.version>
+    <spring.version>5.2.5.RELEASE</spring.version>
     <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
@@ -151,7 +151,8 @@
     <postgresql.version>9.1-901-1.jdbc4</postgresql.version>
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.3.3</micrometer.version>
-    <teiid.version>13.0.1</teiid.version>
+    <teiid.version>14.0.0</teiid.version>
+    <teiid.springboot.version>1.5.0</teiid.springboot.version>
     <aws-java-sdk-core.version>1.11.415</aws-java-sdk-core.version>
     <version.javax.activation>1.2.1</version.javax.activation>
 


### PR DESCRIPTION
making the assumption that we'll want to use the same teiid/tsb version in syndesis as in the generated image.

with this we can further simplify the version management in the template pom and the project pom

this also moves the tomcat dependency back up to 9.0.35 and the spring.version to 5.2.5 to match spring boot 2.2.6