### PR TITLE
Fix OLM subcommand to use correct property for operator-image parameter (1.10.x)

### DIFF
--- a/install/operator/pkg/cmd/internal/olm/olm.go
+++ b/install/operator/pkg/cmd/internal/olm/olm.go
@@ -44,7 +44,7 @@ func New(parent *internal.Options) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&o.Path, "path", "p", ".", "Path where bundle files should be saved")
-	cmd.PersistentFlags().StringVarP(&o.Path, "operator-image", "o", "syndesis/syndesis-operator:latest", "Syndesis operator docker image")
+	cmd.PersistentFlags().StringVarP(&o.Operator, "operator-image", "o", "syndesis/syndesis-operator:latest", "Syndesis operator docker image")
 	cmd.PersistentFlags().StringVarP(&configuration.TemplateConfig, "operator-config", "", "/conf/config.yaml", "Path to the operator configuration file.")
 	return &cmd
 }


### PR DESCRIPTION
(cherry picked from commit 13f47297412c7ba6a2b87bd3ab88bb80134d2add)