### PR TITLE
Fix: console errors and create view loading.

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/PublishStatusWithProgress.tsx
@@ -78,7 +78,7 @@ export const PublishStatusWithProgress: React.FunctionComponent<IPublishStatusWi
             style={getLabelClass()}
             data-testid={'virtualization-publish-status-with-progress'}
           >
-            {props.i18nPublishState}
+            {props.i18nPublishState || ''}
           </Label>
         </Popover>
       </React.Fragment>
@@ -107,7 +107,7 @@ export const PublishStatusWithProgress: React.FunctionComponent<IPublishStatusWi
             data-testid={'virtualization-publish-status-with-progress'}
             style={getLabelClass()}
           >
-            {props.i18nPublishState}
+            {props.i18nPublishState || ''}
           </Label>
         </Popover>
         {props.publishVersion && ` version ${props.publishVersion}`}

--- a/app/ui-react/syndesis/src/app/UI.tsx
+++ b/app/ui-react/syndesis/src/app/UI.tsx
@@ -150,19 +150,6 @@ export const UI: React.FunctionComponent<IAppUIProps> = ({ routes }) => {
     element.setAttribute('href', assetUrl);
   };
 
-  const [productBuild, setProductBuild] = React.useState(false);
-  React.useEffect(() => {
-    updateHref('favicon', !productBuild ? synFavicon : favicon);
-    updateHref(
-      'appleTouchIcon',
-      !productBuild ? synAppleTouchIcon : rhAppleTouchIcon
-    );
-    updateHref(
-      'safariPinnedTab',
-      !productBuild ? synSafariPinnedTabIcon : redHatSafariPinnedTabIcon
-    );
-  }, [productBuild]);
-
   return (
     <UIContext.Provider
       value={{
@@ -177,7 +164,15 @@ export const UI: React.FunctionComponent<IAppUIProps> = ({ routes }) => {
             <AppContext.Consumer>
               {({ user, config }) => {
                 const isProductBuild = config && config.branding.productBuild;
-                setProductBuild(isProductBuild);
+                updateHref('favicon', !isProductBuild ? synFavicon : favicon);
+                updateHref(
+                  'appleTouchIcon',
+                  !isProductBuild ? synAppleTouchIcon : rhAppleTouchIcon
+                );
+                updateHref(
+                  'safariPinnedTab',
+                  !isProductBuild ? synSafariPinnedTabIcon : redHatSafariPinnedTabIcon
+                );
                 const productName = t('shared:project:name');
                 const features =
                   (config && config.features) || ({} as Map<string, any>);

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
@@ -220,7 +220,7 @@ export const ConnectionSchemaContent: React.FunctionComponent<IConnectionSchemaC
     >
       <WithLoader
         error={props.error || error !== false}
-        loading={props.error || !hasSchema}
+        loading={props.loading || !hasSchema}
         loaderChildren={<ConnectionSchemaListSkeleton width={800} />}
         errorChildren={
           <ApiError error={props.errorMessage || (error as Error)} />


### PR DESCRIPTION
- Jira Issue https://issues.redhat.com/browse/TEIIDTOOLS-1023 https://issues.redhat.com/browse/TEIIDTOOLS-1024

- Console errors
Added the empty string as default if props.i18nPublishState is undefined in PublishStatusWithProgress.
used the updateHref function directly in context consumer.

- Create view loading
using the loading prop instead of error for showing loading.

- screenshot 
![image](https://user-images.githubusercontent.com/8264372/82858398-64b4b600-9f31-11ea-9d2c-78dfc4f9ac44.png)
