### PR TITLE
fix(dv) ENTESB-13939 related to the refactor backport

### DIFF
--- a/app/dv/pom.xml
+++ b/app/dv/pom.xml
@@ -107,6 +107,8 @@
     <version.springfox>2.9.2</version.springfox>
     <shrinkwrap.version>3.1.4</shrinkwrap.version>
 
+    <version.tomcat>9.0.35</version.tomcat>
+
     <version.com.fasterxml.jackson.databind>2.9.10.1</version.com.fasterxml.jackson.databind>
     <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
     <version.io.fabric8.kubernetes-api>3.0.12</version.io.fabric8.kubernetes-api>
@@ -456,13 +458,7 @@
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
-        <version>9.0.33</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-annotations-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>${version.tomcat}</version>
       </dependency>
       <dependency>
           <groupId>org.eclipse.lsp4j</groupId>
@@ -521,6 +517,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
     </dependency>
     <dependency>
       <groupId>javax.persistence</groupId>


### PR DESCRIPTION
with the tomcat annotations excluded we need an explicit annotations
dependency