### PR TITLE
fix(server): skip connection properties comparison when dynamic

### DIFF
--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
@@ -402,7 +402,7 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
                             dataManager.update(dbConnection);
                         }
 
-                        if (connection.getId().isPresent()) {
+                        if (connection.getId().isPresent() && (!connection.getConnector().isPresent() || !connection.getConnector().get().getTags().contains("dynamic"))) {
                             //
                             // Compare the connection in the draft integration's
                             // step


### PR DESCRIPTION
* Added a condition to skip the connection properties comparison if we are marking the connector as dynamic. A dynamic connector will retrieve connection properties and fail the comparison as they meant to be read at runtime.
* Added a unit test to validate the fix.

Fixes #8519