### PR TITLE
doc update for feature - select library extension at integration save

### DIFF
--- a/doc/modules/customizing/proc-creating-jdbc-driver-library-extensions.adoc
+++ b/doc/modules/customizing/proc-creating-jdbc-driver-library-extensions.adoc
@@ -50,18 +50,6 @@ any relevant metadata as needed.
 .. Execute `./mvnw -pl :syndesis-library-jdbc-driver clean package` to build the extension.
 
 The generated `.jar` file is in the `syndesis-library-jdbc-driver/target`
-folder. Provide this `.jar` file for uploading to {prodname}.
+folder. Import this `.jar` file as an extension in {prodname}.
 
-[NOTE]
-====
-{prodname} does not yet offer a way to select which library extension(s) an
-integration should include. When you add a database connection to an
-integration, {prodname} adds all extensions that have
-the `jdbc-driver` tag to integration runtime. This is expected to
-improve in a future release.
-
-ifeval::["{location}" == "upstream"]
-For more information, see
-https://github.com/syndesisio/syndesis/issues/2809[this GitHub issue].
-endif::[]
-====
+After you import a library extension, when you save an integration in {prodname} you can optionally select the imported library extension and associate it with the integration.    

--- a/doc/modules/customizing/ref-develop-library-extensions.adoc
+++ b/doc/modules/customizing/ref-develop-library-extensions.adoc
@@ -8,28 +8,7 @@ A library extension provides a resource that an
 integration requires at runtime. A library extension does not contribute steps or 
 connectors to {prodname}. 
 
-Support for library extensions is evolving. In this release, in the 
-{prodname} web interface:
-
-*  When you create an integration, 
-you cannot select which library extension(s) an 
-integration should include. 
-+
-ifeval::["{location}" == "upstream"]
-For more information, see 
-https://github.com/syndesisio/syndesis/issues/2808[this GitHub issue]. 
-endif::[]
-
-* When you add a database connection to an integration, 
-{prodname} adds all extensions that 
-have the `jdbc-driver` tag to the integration runtime. 
-+
-ifeval::["{location}" == "upstream"]
-For more information, see 
-https://github.com/syndesisio/syndesis/issues/2809[this GitHub issue]. 
-
-endif::[]
-
+When you save an integration, you can optionally select one or more imported library extensions that you want to include with the integration.    
 
 A library extension does not define any actions. 
 Here is a sample definition for a library extension:

--- a/doc/modules/integrating-applications/proc-making-extensions-available.adoc
+++ b/doc/modules/integrating-applications/proc-making-extensions-available.adoc
@@ -43,15 +43,7 @@ an icon in the extension, then {prodname} generates an icon.
 For a step extension, {prodname} displays
 the name of each custom step that the extension defines.
 +
-For a library
-extension, if this extension contains a newer version of a JDBC driver that you 
-previously uploaded, then you must remove the older version from your classpath.
-Ensure that your classpath has only one version of this driver and that the
-reference is to the newer driver you are uploading. Integrations that are running
-and that use connections based on the older driver are not affected. 
-New connections that you create will use the new driver.
-If you start an integration that has a connection that was created with the
-older driver, {prodname} automatically uses the new driver instead. 
+For a library extension, {prodname} includes the imported Maven dependencies into the integration runtime classpath. You must ensure that the imported Maven dependencies do not conflict with other dependencies that are already used in the integration (including any other library extension, such as a JDBC driver).
 
 . Click *Import Extension*. {prodname} makes the custom connector or 
 custom step(s) available and displays the extension's details page. 

--- a/doc/modules/integrating-applications/proc-procedure-for-creating-an-integration.adoc
+++ b/doc/modules/integrating-applications/proc-procedure-for-creating-an-integration.adoc
@@ -93,6 +93,8 @@ integration from any other integrations.
 . Optionally, in the *Description* field, enter a description, for example, you can
 indicate what this integration does.
 
+.  Optionally, from the list of library extensions that you have imported, you can select one or more library extensions to associate with the integration. Note that you must have already imported a library `.jar` file as a {prodname} extension if you want it to appear in this list so that you can select it.
+
 . If you are ready to start running the integration, click *Save and publish*.
 +
 {prodname} displays the integration summary. You


### PR DESCRIPTION
Ready for review: update to the doc to address the new feature for selecting runtime libraries when the user saves an integration