### PR TITLE
(backport) fix: use the right type for the 'min' property

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
@@ -123,7 +123,7 @@ export const FormDurationComponent: React.FunctionComponent<
     >
       <InputGroup>
         <TextInput
-          min={0}
+          min={'0'}
           {...props.property.fieldAttributes}
           data-testid={id}
           id={id}


### PR DESCRIPTION
fixes ENTESB-11829

Backports https://github.com/syndesisio/syndesis/pull/8614