### PR TITLE
Fix: role permission dropdown issue and metadata tree spacing

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.css
@@ -4,6 +4,14 @@
   flex-direction: column;
 }
 
+.ddl-editor_tree_comp{
+  --pf-c-page__main-section--PaddingRight: 5px;
+}
+
+.ddl-editor_comp{
+  --pf-c-page__main-section--PaddingLeft: 5px;
+}
+
 .ddl-editor_metatree_table{
   overflow-y: auto;
 }

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/ViewEditor/DdlEditor.tsx
@@ -168,7 +168,7 @@ export const DdlEditor: React.FunctionComponent<IDdlEditorProps> = React.memo(
           <PageSection
             isFilled={true}
             variant={'light'}
-            className={'ddl-editor'}
+            className={'ddl-editor ddl-editor_tree_comp'}
           >
             <div
               className={
@@ -191,7 +191,7 @@ export const DdlEditor: React.FunctionComponent<IDdlEditorProps> = React.memo(
           <PageSection
             isFilled={true}
             variant={'light'}
-            className={'ddl-editor'}
+            className={'ddl-editor ddl-editor_comp'}
           >
             <Title headingLevel="h5" size="lg">
               {props.i18nTitle}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionList.tsx
@@ -24,7 +24,7 @@ export interface IRolePermissionListProps {
   i18nRemoveRoleRow: string;
   i18nRoleExists: string;
   viewRolePermissionList: ITablePrivilege[];
-  selectedRoles: string[];
+  selectedRoles: Map<string, string[]>;
   updateRolePermissionModel: (
     roleName: string | undefined,
     permissions: string[],
@@ -42,11 +42,15 @@ export const RolePermissionList: React.FunctionComponent<IRolePermissionListProp
   const [roleRowList, setRoleRowList] = React.useState<string[]>(['role0']);
   const [currentRoles, setCurrentRoles] = React.useState<string[]>(props.roles);
 
-  const removeRolePermission = (index: string) => {
-    const rolelistCopy = roleRowList.slice();
-    rolelistCopy.splice(rolelistCopy.indexOf(index), 1);
-    setRoleRowList(rolelistCopy);
-  };
+  const removeRolePermission = React.useCallback(
+    (index) => {
+      const rolelistCopy = roleRowList.slice();
+      rolelistCopy.splice(rolelistCopy.indexOf(index), 1);
+      setRoleRowList(rolelistCopy);
+    },
+    [roleRowList, setRoleRowList],
+  );
+
 
   const addRolePermission = () => {
     if (roleRowList.length === 0) {
@@ -63,7 +67,7 @@ export const RolePermissionList: React.FunctionComponent<IRolePermissionListProp
 
   React.useEffect(() => {
     const updatedRoles = props.roles.filter(role => {
-      return !props.selectedRoles.includes(role);
+      return !props.selectedRoles.has(role);
     });
     setCurrentRoles(updatedRoles);
   }, [props.selectedRoles]);

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionList.tsx
@@ -35,7 +35,10 @@ export interface IRolePermissionListProps {
   roles: string[];
 }
 
+const selectedPermissions: string[] = [];
+
 export const RolePermissionList: React.FunctionComponent<IRolePermissionListProps> = props => {
+
   const [roleRowList, setRoleRowList] = React.useState<string[]>(['role0']);
   const [currentRoles, setCurrentRoles] = React.useState<string[]>(props.roles);
 
@@ -54,6 +57,9 @@ export const RolePermissionList: React.FunctionComponent<IRolePermissionListProp
       setRoleRowList([...roleRowList, 'role' + roleRowNo]);
     }
   };
+  React.useEffect(()=>{
+    setCurrentRoles(props.roles);
+  },[props.roles]);
 
   React.useEffect(() => {
     const updatedRoles = props.roles.filter(role => {
@@ -106,7 +112,7 @@ export const RolePermissionList: React.FunctionComponent<IRolePermissionListProp
             roles={props.roles}
             removeRolePermission={removeRolePermission}
             selectedRole=""
-            selectedPermissions={[]}
+            selectedPermissions={selectedPermissions}
             updateRolePermissionModel={props.updateRolePermissionModel}
             deleteRoleFromPermissionModel={props.deleteRoleFromPermissionModel}
             i18nSelectRole={props.i18nSelectRole}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.css
@@ -8,6 +8,6 @@
 }
 
 .role-permission-list-item_select .pf-c-select__menu {
-    max-height: 250px;
+    max-height: 200px;
     overflow-y: auto;
 }

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.tsx
@@ -106,15 +106,7 @@ const getRoles = (roles: string[]) =>{
     return roleList;
 }
 
-const areEqual = (prevProps: any, nextProps: any) =>{
-  return (prevProps.roles === nextProps.roles &&
-    prevProps.availableRoles === nextProps.availableRoles &&
-    prevProps.index === nextProps.index &&
-    prevProps.selectedRole === nextProps.selectedRole);
-}
-
 export const RolePermissionListItem: React.FunctionComponent<IRolePermissionListItemProps> = React.memo( props => {
-  
   const [checkState, setCheckState] = React.useState(
     getCheckInitial(props.selectedPermissions)
   );
@@ -348,4 +340,4 @@ export const RolePermissionListItem: React.FunctionComponent<IRolePermissionList
       </DataListItem>
     </>
   );
-},areEqual);
+});

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/RolePermissionListItem.tsx
@@ -106,7 +106,15 @@ const getRoles = (roles: string[]) =>{
     return roleList;
 }
 
-export const RolePermissionListItem: React.FunctionComponent<IRolePermissionListItemProps> = props => {
+const areEqual = (prevProps: any, nextProps: any) =>{
+  return (prevProps.roles === nextProps.roles &&
+    prevProps.availableRoles === nextProps.availableRoles &&
+    prevProps.index === nextProps.index &&
+    prevProps.selectedRole === nextProps.selectedRole);
+}
+
+export const RolePermissionListItem: React.FunctionComponent<IRolePermissionListItemProps> = React.memo( props => {
+  
   const [checkState, setCheckState] = React.useState(
     getCheckInitial(props.selectedPermissions)
   );
@@ -340,4 +348,4 @@ export const RolePermissionListItem: React.FunctionComponent<IRolePermissionList
       </DataListItem>
     </>
   );
-};
+},areEqual);

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/ViewPermissionList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/ViewPermissionList.tsx
@@ -111,8 +111,6 @@ const getUpdatePermissionsPayload = (
 
 const viewRolePermissionList: ITablePrivilege[] = [];
 
-  let selectedRoles: string[] = [];
-
 export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = props => {
   /**
    * React useState Hook to handle state in component.
@@ -139,31 +137,37 @@ export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = 
 
   let selectedViewText = Array.from(props.itemSelected.values()).join(', ');
 
-  const updateRolePermissionModel = (
-    roleName: string | undefined,
-    permissions: string[],
-    deleteRole: boolean,
-    prevSelected: string | undefined
-  ) => {
-    const rolePermissionModelCopy = new Map<string, string[]>(
-      rolePermissionModel
-    );
-    // tslint:disable-next-line: no-unused-expression
-    roleName && rolePermissionModelCopy.set(roleName, permissions);
-    if (deleteRole && prevSelected) {
-      rolePermissionModelCopy.delete(prevSelected);
-    }
-    setRolePermissionModel(rolePermissionModelCopy);
-  };
-
-  const deleteRoleFromPermissionModel = (roleName: string) => {
-    const rolePermissionModelCopy = new Map<string, string[]>(
-      rolePermissionModel
-    );
-    // tslint:disable-next-line: no-unused-expression
-    rolePermissionModelCopy.delete(roleName) &&
+  const updateRolePermissionModel = React.useCallback(
+    (
+      roleName: string | undefined,
+      permissions: string[],
+      deleteRole: boolean,
+      prevSelected: string | undefined
+    ) => {
+      const rolePermissionModelCopy = new Map<string, string[]>(
+        rolePermissionModel
+      );
+      // tslint:disable-next-line: no-unused-expression
+      roleName && rolePermissionModelCopy.set(roleName, permissions);
+      if (deleteRole && prevSelected) {
+        rolePermissionModelCopy.delete(prevSelected);
+      }
       setRolePermissionModel(rolePermissionModelCopy);
-  };
+    },
+    [rolePermissionModel, setRolePermissionModel]
+  );
+
+  const deleteRoleFromPermissionModel = React.useCallback(
+    (roleName: string) => {
+      const rolePermissionModelCopy = new Map<string, string[]>(
+        rolePermissionModel
+      );
+      // tslint:disable-next-line: no-unused-expression
+      rolePermissionModelCopy.delete(roleName) &&
+        setRolePermissionModel(rolePermissionModelCopy);
+    },
+    [rolePermissionModel, setRolePermissionModel],
+  );
 
   const clearRolePermissionModel = () => {
     setRolePermissionModel(new Map<string, string[]>());
@@ -225,7 +229,6 @@ export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = 
   }, [props.itemSelected]);
 
   React.useEffect(() => {
-    selectedRoles = [...Array.from(rolePermissionModel.keys())];
     if (rolePermissionModel.size < 1 || showLoading) {
       setSaveEnabled(false);
       // Save button enables if one or more roles exist, and all have a permission checked
@@ -370,7 +373,7 @@ export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = 
               i18nRoleExists={props.i18nRoleExists}
               viewRolePermissionList={viewRolePermissionList}
               roles={props.dvRoles}
-              selectedRoles= {selectedRoles}
+              selectedRoles= {rolePermissionModel}
               updateRolePermissionModel={updateRolePermissionModel}
               deleteRoleFromPermissionModel={deleteRoleFromPermissionModel}
             />

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/ViewPermissionList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/DataPermission/ViewPermissionList.tsx
@@ -109,6 +109,10 @@ const getUpdatePermissionsPayload = (
   return returnVal;
 };
 
+const viewRolePermissionList: ITablePrivilege[] = [];
+
+  let selectedRoles: string[] = [];
+
 export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = props => {
   /**
    * React useState Hook to handle state in component.
@@ -221,6 +225,7 @@ export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = 
   }, [props.itemSelected]);
 
   React.useEffect(() => {
+    selectedRoles = [...Array.from(rolePermissionModel.keys())];
     if (rolePermissionModel.size < 1 || showLoading) {
       setSaveEnabled(false);
       // Save button enables if one or more roles exist, and all have a permission checked
@@ -363,9 +368,9 @@ export const ViewPermissionList: React.FunctionComponent<IViewPermissionList> = 
               i18nSelectRole={props.i18nSelectRole}
               i18nRemoveRoleRow={props.i18nRemoveRoleRow}
               i18nRoleExists={props.i18nRoleExists}
-              viewRolePermissionList={[]}
+              viewRolePermissionList={viewRolePermissionList}
               roles={props.dvRoles}
-              selectedRoles= {Array.from(rolePermissionModel.keys())}
+              selectedRoles= {selectedRoles}
               updateRolePermissionModel={updateRolePermissionModel}
               deleteRoleFromPermissionModel={deleteRoleFromPermissionModel}
             />


### PR DESCRIPTION
- Jira Issue https://issues.redhat.com/browse/TEIIDTOOLS-1026 https://issues.redhat.com/browse/TEIIDTOOLS-1021

- Used React.memo to stop the re-rendering of RolePermissionListItem component. 

- In place of passing the new reference of the array in props updating the value to existing array.(selectedPermissions in RolePermissionList  && viewRolePermissionList, selectedRoles in ViewPermissionList)

- Reduced the spacing between the metadata tree and DDL editor.
![image](https://user-images.githubusercontent.com/8264372/83439921-a4aff780-a461-11ea-9c85-0b650492a3cc.png)
