### PR TITLE
(fix) TEIIDTOOLS-765 Allows layering of views in CreateView wizard

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -87,6 +87,7 @@ export interface ViewInfo {
 
 export interface SchemaNodeInfo {
   connectionName: string;
+  isVirtualizationSchema: boolean;
   name: string;
   nodePath: string[];
   teiidName: string;
@@ -100,6 +101,7 @@ export interface VirtualizationSourceStatus {
   sourceName: string;
   teiidName: string;
   lastLoad: number;
+  isVirtualizationSource?: boolean;
 }
 
 export interface DVStatusObj {

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ConnectionSchemaListItem.tsx
@@ -33,6 +33,7 @@ export interface IConnectionSchemaListItemProps {
   i18nStatusErrorPopoverTitle: string;
   i18nStatusErrorPopoverLink: string;
   icon: React.ReactNode;
+  isVirtualizationSource: boolean;
   loading: boolean;
   refreshConnectionSchema: (connectionName: string) => void;
 }
@@ -87,36 +88,40 @@ export const ConnectionSchemaListItem: React.FunctionComponent<IConnectionSchema
             </DataListCell>,
           ]}
         />
-        <DataListAction
-          aria-labelledby={'connection schema list actions'}
-          id={'connection-schema-list-actions'}
-          aria-label={'Actions'}
-        >
-          <Grid>
-            <GridItem span={6}>{props.i18nLastUpdatedMessage}</GridItem>
-            <GridItem span={4}>
-              <DvConnectionStatus
-                dvStatus={props.dvStatus}
-                dvStatusMessage={props.dvStatusMessage}
-                i18nRefreshInProgress={props.i18nRefreshInProgress}
-                i18nStatusErrorPopoverTitle={props.i18nStatusErrorPopoverTitle}
-                i18nStatusErrorPopoverLink={props.i18nStatusErrorPopoverLink}
-                loading={props.loading}
-              />
-            </GridItem>
-            <GridItem span={2}>
-              <Button
-                data-testid={'connection-schema-list-item__refresh-button'}
-                variant={ButtonVariant.secondary}
-                onClick={handleRefreshClick}
-                isDisabled={props.loading}
-              >
-                {props.i18nRefresh}&nbsp;
-                {<SyncIcon />}
-              </Button>
-            </GridItem>
-          </Grid>
-        </DataListAction>
+        {!props.isVirtualizationSource && (
+          <DataListAction
+            aria-labelledby={'connection schema list actions'}
+            id={'connection-schema-list-actions'}
+            aria-label={'Actions'}
+          >
+            <Grid>
+              <GridItem span={6}>{props.i18nLastUpdatedMessage}</GridItem>
+              <GridItem span={4}>
+                <DvConnectionStatus
+                  dvStatus={props.dvStatus}
+                  dvStatusMessage={props.dvStatusMessage}
+                  i18nRefreshInProgress={props.i18nRefreshInProgress}
+                  i18nStatusErrorPopoverTitle={
+                    props.i18nStatusErrorPopoverTitle
+                  }
+                  i18nStatusErrorPopoverLink={props.i18nStatusErrorPopoverLink}
+                  loading={props.loading}
+                />
+              </GridItem>
+              <GridItem span={2}>
+                <Button
+                  data-testid={'connection-schema-list-item__refresh-button'}
+                  variant={ButtonVariant.secondary}
+                  onClick={handleRefreshClick}
+                  isDisabled={props.loading}
+                >
+                  {props.i18nRefresh}&nbsp;
+                  {<SyncIcon />}
+                </Button>
+              </GridItem>
+            </Grid>
+          </DataListAction>
+        )}
       </DataListItemRow>
       {props.children && props.dvStatus === ConnectionStatus.ACTIVE ? (
         <DataListContent

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
@@ -15,11 +15,13 @@ import './SchemaNodeListItem.css';
 export interface ISchemaNodeListItemProps {
   name: string;
   connectionName: string;
+  isVirtualizationSchema: boolean;
   teiidName: string;
   nodePath: string[];
   selected: boolean;
   onSelectionChanged: (
     connectionName: string,
+    isVirtualizationSchema: boolean,
     name: string,
     teiidName: string,
     nodePath: string[],
@@ -36,13 +38,14 @@ export const SchemaNodeListItem: React.FunctionComponent<
     setItemSelected(props.selected);
   }, [props.selected]);
 
-  const doToggleCheckbox = (connectionName: string, name: string, teiidName: string, nodePath: string[]) => (
+  const doToggleCheckbox = (connectionName: string, isVirtualizationSchema: boolean, name: string, teiidName: string, nodePath: string[]) => (
     event: any
   ) => {
     setItemSelected(!itemSelected);
 
     props.onSelectionChanged(
       connectionName,
+      isVirtualizationSchema,
       name,
       teiidName,
       nodePath,
@@ -71,6 +74,7 @@ export const SchemaNodeListItem: React.FunctionComponent<
           checked={props.selected}
           onChange={doToggleCheckbox(
             props.connectionName,
+            props.isVirtualizationSchema,
             props.name,
             props.teiidName,
             props.nodePath

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
@@ -15,7 +15,6 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import { DatabaseIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableVariant } from '@patternfly/react-table';
 import * as React from 'react';
 import './SelectedConnectionListView.css';
@@ -23,6 +22,7 @@ import './SelectedConnectionListView.css';
 export interface ISelectedConnectionListViewProps {
   expanded: string[];
   name: string;
+  connectionIcon: JSX.Element;
   connectionName: string;
   index: number;
   rows: string[][];
@@ -82,7 +82,7 @@ export const SelectedConnectionListView: React.FunctionComponent<ISelectedConnec
                     >
                       {props.name}
                     </span>
-                    (<DatabaseIcon />
+                    ({props.connectionIcon}
                     &nbsp;<span>{props.connectionName})</span>
                   </Text>
                 </TextContent>

--- a/app/ui-react/packages/ui/stories/Data/CreateViewWizard/ConnectionSchemaList.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/CreateViewWizard/ConnectionSchemaList.stories.tsx
@@ -19,6 +19,8 @@ const connectionName2 = 'Connection_2';
 const connectionDescription2 = 'Connection 2 description';
 const connectionName3 = 'Connection_3';
 const connectionDescription3 = 'Connection 3 description';
+const connectionName4 = 'VirtSchema';
+const connectionDescription4 = 'VirtSchema description';
 const selectionChangedActionText = 'Selection Changed';
 
 const conn2NodeItems = [
@@ -27,6 +29,7 @@ const conn2NodeItems = [
     name={'Customer'}
     teiidName={'Customer'}
     connectionName={connectionName2}
+    isVirtualizationSchema={false}
     nodePath={['public', 'Customer']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
@@ -36,6 +39,7 @@ const conn2NodeItems = [
     name={'Account'}
     teiidName={'Account'}
     connectionName={connectionName2}
+    isVirtualizationSchema={false}
     nodePath={['public', 'Account']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
@@ -47,6 +51,7 @@ const conn3NodeItems = [
     name={'Holdings'}
     teiidName={'Holdings'}
     connectionName={connectionName3}
+    isVirtualizationSchema={false}
     nodePath={['public', 'Holdings']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
@@ -56,7 +61,30 @@ const conn3NodeItems = [
     name={'Product'}
     teiidName={'Product'}
     connectionName={connectionName3}
+    isVirtualizationSchema={false}
     nodePath={['public', 'Product']}
+    selected={false}
+    onSelectionChanged={action(selectionChangedActionText)}
+  />,
+];
+const conn4NodeItems = [
+  <SchemaNodeListItem
+    key="conn4Item1"
+    name={'View1'}
+    teiidName={'View1'}
+    connectionName={connectionName4}
+    isVirtualizationSchema={true}
+    nodePath={['View1']}
+    selected={false}
+    onSelectionChanged={action(selectionChangedActionText)}
+  />,
+  <SchemaNodeListItem
+    key="conn4Item2"
+    name={'View2'}
+    teiidName={'View2'}
+    connectionName={connectionName4}
+    nodePath={['View2']}
+    isVirtualizationSchema={true}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}
   />,
@@ -79,6 +107,7 @@ const connectionItems = [
     i18nStatusErrorPopoverTitle={'Connection Problem'}
     i18nStatusErrorPopoverLink={'Show connection problem'}
     icon={<div />}
+    isVirtualizationSource={false}
     loading={false}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />,
@@ -99,6 +128,7 @@ const connectionItems = [
     i18nStatusErrorPopoverTitle={'Connection Problem'}
     i18nStatusErrorPopoverLink={'Show connection problem'}
     icon={<div />}
+    isVirtualizationSource={false}
     loading={false}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />,
@@ -119,6 +149,28 @@ const connectionItems = [
     i18nStatusErrorPopoverTitle={'Connection Problem'}
     i18nStatusErrorPopoverLink={'Show connection problem'}
     icon={<div />}
+    isVirtualizationSource={false}
+    loading={false}
+    refreshConnectionSchema={action('refreshConnectionSchema')}
+  />,
+  <ConnectionSchemaListItem
+    key="virtualizationSchema"
+    connectionName={connectionName4}
+    connectionDescription={connectionDescription4}
+    children={conn4NodeItems}
+    haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    dvStatusMessage={'The connection is active'}
+    i18nLastUpdatedMessage={text('i18nLastUpdatedMessage', 'Last updated: xx.yy.zz')}
+    i18nRefresh={text('i18nRefresh', 'Refresh')}
+    i18nRefreshInProgress={text(
+      'i18nRefreshInProgress',
+      'Refresh in progress...'
+    )}
+    i18nStatusErrorPopoverTitle={'Connection Problem'}
+    i18nStatusErrorPopoverLink={'Show connection problem'}
+    icon={<div />}
+    isVirtualizationSource={true}
     loading={false}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />,
@@ -147,7 +199,7 @@ stories
     </Router>
   ))
 
-  .add('3 connections', () => (
+  .add('4 connections', () => (
     <Router>
       <ConnectionSchemaList
         i18nEmptyStateInfo={text('i18nEmptyStateInfo', emptyStateMsg)}

--- a/app/ui-react/packages/ui/stories/Data/CreateViewWizard/ConnectionSchemaListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/CreateViewWizard/ConnectionSchemaListItem.stories.tsx
@@ -26,6 +26,7 @@ stories.add('ACTIVE, not loading', () => (
     i18nStatusErrorPopoverTitle={'Connection Error'}
     i18nStatusErrorPopoverLink={'Connection error'}
     icon={<div />}
+    isVirtualizationSource={false}
     loading={false}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />
@@ -47,6 +48,7 @@ stories.add('ACTIVE, loading', () => (
     i18nStatusErrorPopoverTitle={'Connection Error'}
     i18nStatusErrorPopoverLink={'Connection error'}
     icon={<div />}
+    isVirtualizationSource={false}
     loading={true}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />
@@ -68,6 +70,7 @@ stories.add('INACTIVE, loading', () => (
     i18nStatusErrorPopoverTitle={'Connection Error'}
     i18nStatusErrorPopoverLink={'Connection error'}
     icon={<div />}
+    isVirtualizationSource={false}
     loading={true}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />
@@ -89,6 +92,29 @@ stories.add('FAILED, not loading', () => (
     i18nStatusErrorPopoverTitle={'Connection Error'}
     i18nStatusErrorPopoverLink={'Connection error'}
     icon={<div />}
+    isVirtualizationSource={false}
+    loading={false}
+    refreshConnectionSchema={action('refreshConnectionSchema')}
+  />
+));
+
+stories.add('Virtualization Schema, ACTIVE, not loading', () => (
+  <ConnectionSchemaListItem
+    connectionName={connectionName}
+    connectionDescription={connectionDescription}
+    haveSelectedSource={false}
+    dvStatus={ConnectionStatus.ACTIVE}
+    dvStatusMessage={'The connection is active'}
+    i18nLastUpdatedMessage={text('i18nLastUpdatedMessage', 'Last updated: xx.yy.zz')}
+    i18nRefresh={text('i18nRefresh', 'Refresh')}
+    i18nRefreshInProgress={text(
+      'i18nRefreshInProgress',
+      'Refresh in progress...'
+    )}
+    i18nStatusErrorPopoverTitle={'Connection Error'}
+    i18nStatusErrorPopoverLink={'Connection error'}
+    icon={<div />}
+    isVirtualizationSource={true}
     loading={false}
     refreshConnectionSchema={action('refreshConnectionSchema')}
   />

--- a/app/ui-react/packages/ui/stories/Data/CreateViewWizard/SelectedConnectionListView.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/CreateViewWizard/SelectedConnectionListView.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { DatabaseIcon } from '@patternfly/react-icons';
 import { SelectedConnectionListView } from '../../../src';
 
 const stories = storiesOf(
@@ -26,6 +27,7 @@ stories.add('expanded list', () => (
     <SelectedConnectionListView
       key={selectedConnectionIndex1}
       name={selectedConnectionTable1}
+      connectionIcon={<DatabaseIcon />}
       connectionName={selectedConnectionName1}
       index={0}
       toggle={action('On toggle')}

--- a/app/ui-react/packages/ui/stories/Data/CreateViewWizard/SelectedConnectionTables.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/CreateViewWizard/SelectedConnectionTables.stories.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { DatabaseIcon } from '@patternfly/react-icons';
 import {
   SelectedConnectionListView,
   SelectedConnectionTables,
@@ -25,6 +26,7 @@ const selectedConnectionListItems = [
   <SelectedConnectionListView
     key={selectedConnectionIndex1}
     name={selectedConnectionTable1}
+    connectionIcon={<DatabaseIcon />}
     connectionName={selectedConnectionName1}
     index={0}
     toggle={action('On toggle')}
@@ -38,6 +40,7 @@ const selectedConnectionListItems = [
   <SelectedConnectionListView
     key={selectedConnectionIndex2}
     name={selectedConnectionTable2}
+    connectionIcon={<DatabaseIcon />}
     connectionName={selectedConnectionName2}
     index={1}
     toggle={action('On toggle')}

--- a/app/ui-react/packages/ui/stories/Data/Views/SchemaNodeListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Views/SchemaNodeListItem.stories.tsx
@@ -20,6 +20,7 @@ stories.add('sample schema node item', () => (
     name={text('name', nodeName)}
     teiidName={text('teiidName', teiidName)}
     connectionName={'connection1'}
+    isVirtualizationSchema={false}
     nodePath={['public','customers']}
     selected={false}
     onSelectionChanged={action(selectionChangedActionText)}

--- a/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
@@ -24,12 +24,14 @@ export const ViewCreateApp: React.FunctionComponent = () => {
 
   const handleNodeSelected = async (
     connName: string,
+    isVirtualizationSchema: boolean,
     name: string,
     teiidName: string,
     nodePath: string[]
   ) => {
     const srcInfo = {
       connectionName: connName,
+      isVirtualizationSchema,
       name,
       nodePath,
       teiidName,

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -4,8 +4,8 @@ import {
   useVirtualizationHelpers,
   useVirtualizationRuntimeMetadata,
 } from '@syndesis/api';
-import { SchemaNodeInfo, TableInfo, Virtualization } from '@syndesis/models';
-import { QueryResults } from '@syndesis/models/src';
+import { Connection, SchemaNodeInfo, TableInfo, ViewSourceInfo, Virtualization } from '@syndesis/models';
+import { QueryResults, VirtualizationSourceStatus } from '@syndesis/models/src';
 import { PreviewData, ViewCreateLayout, ViewWizardHeader } from '@syndesis/ui';
 import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -37,6 +37,7 @@ export interface ISelectSourcesRouteState {
 export interface ISelectSourcesPageProps {
   handleNodeSelected: (
     connectionName: string,
+    isVirtualizationSchema: boolean,
     name: string,
     teiidName: string,
     nodePath: string[]
@@ -143,6 +144,41 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
     return undefined;
   };
 
+  /**
+   * Get schema for the virtualization
+   */
+  const getVirtualizationSchema = (sourceInfo: ViewSourceInfo) => {
+    return sourceInfo.schemas.find(schema => schema.name === virtualization.name);
+  };
+
+  /**
+   * Get the Connection Statuses - and add a connection status for the Virtualization
+   */
+  const getConnectionStatusesAddVirtualization = (statuses: VirtualizationSourceStatus[]) => {
+    const virtSourceStatus: VirtualizationSourceStatus = {
+      errors: [],
+      id: virtualization.name,
+      isVirtualizationSource: true,
+      lastLoad: 0,
+      loading: false,
+      schemaState: 'ACTIVE',
+      sourceName: virtualization.name,
+      teiidName: virtualization.name,
+    }
+    return [...statuses, virtSourceStatus];
+  };
+
+  /**
+   * Get the Connections - and include a connection for the Virtualization
+   */
+  const getConnectionsForDisplay = (conns: Connection[]) => {
+    const virtConnection: Connection = {
+      description: virtualization.description,
+      name: virtualization.name,
+    };
+    return [...conns, virtConnection];
+  };
+
   return (
     <>
     <PageTitle title={t('createViewPageTitle')} />
@@ -179,8 +215,9 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
           loading={
             !hasConnectionsData || !hasConnectionStatuses || !hasViewSourceInfo
           }
-          dvSourceStatuses={connectionStatuses}
-          connections={connectionsData.connectionsForDisplay}
+          dvSourceStatuses={getConnectionStatusesAddVirtualization(connectionStatuses)}
+          connections={getConnectionsForDisplay(connectionsData.connectionsForDisplay)}
+          virtualizationSchema={getVirtualizationSchema(viewSourceInfo)}
           onNodeSelected={props.handleNodeSelected}
           onNodeDeselected={onTableDeselect}
           selectedSchemaNodes={props.selectedSchemaNodes}

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
@@ -1,3 +1,4 @@
+import { CubeIcon, DatabaseIcon } from '@patternfly/react-icons';
 import {
   ConnectionTable,
   SchemaNodeInfo,
@@ -54,6 +55,14 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
     ]);
   };
 
+  const getConnectionIcon = (schemaNodeInfo: SchemaNodeInfo) => {
+    return schemaNodeInfo.isVirtualizationSchema ? (
+      <CubeIcon />
+    ) : (
+      <DatabaseIcon />
+    );
+  };
+
   return (
     <SelectedConnectionTables
       selectedSchemaNodesLength={props.selectedSchemaNodes.length}
@@ -65,6 +74,7 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
         <SelectedConnectionListView
           key={index}
           name={info.teiidName}
+          connectionIcon={getConnectionIcon(info)}
           connectionName={info.connectionName}
           index={index}
           toggle={toggle}

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -32,6 +32,8 @@ export enum DvConnectionStatus {
   INACTIVE = 'INACTIVE',
 }
 
+const VIRTUALIZATION_PLACEHOLDER = '$dv';
+
 /**
  * Get the date and time display
  * @param numericTimestamp the numeric timestamp
@@ -174,6 +176,7 @@ export function generateSchemaNodeInfos(
       // Create SchemaNodeInfo
       const view: SchemaNodeInfo = {
         connectionName: schemaNode.connectionName,
+        isVirtualizationSchema: false,
         name: schemaNode.name,
         nodePath: sourcePath,
         teiidName: schemaNode.teiidName,
@@ -221,9 +224,10 @@ function loadPaths(schemaNodeInfo: SchemaNodeInfo[]): string[] {
 
   let index = 0;
   schemaNodeInfo.map(
-    item =>
-      (srcPaths[index++] =
-        'schema=' + item.connectionName + '/table=' + item.teiidName)
+    item => {
+      const connName = item.isVirtualizationSchema ? VIRTUALIZATION_PLACEHOLDER : item.connectionName;
+      return srcPaths[index++] = 'schema=' + connName + '/table=' + item.teiidName;
+    }
   );
 
   return srcPaths;
@@ -313,6 +317,7 @@ export function generateDvConnections(
         dvSelected: selectionState,
         dvSourceError: virtSrcStatus.errors[0],
         dvStatus: connStatus,
+        dvVirtualizationSource: virtSrcStatus.isVirtualizationSource ? 'true' : 'false',
       };
       dvConns.push(conn);
     }
@@ -376,6 +381,18 @@ export function isDvConnectionLoading(conn: Connection) {
   return conn.options &&
     conn.options.dvLoading &&
     conn.options.dvLoading === String(true)
+    ? true
+    : false;
+}
+
+/**
+ * Determine if the Connection is a virtualization source.  DV uses the options on a connection to set virtualization source
+ * @param connection the connection
+ */
+export function isDvConnectionVirtualizationSource(conn: Connection) {
+  return conn.options &&
+    conn.options.dvVirtualizationSource &&
+    conn.options.dvVirtualizationSource === String(true)
     ? true
     : false;
 }


### PR DESCRIPTION
Adds the ability for new views created in the 'Create View' wizard to be based upon other views in the virtualization.  The existing virtualization views are displayed as a source for use in the new virtualization.
- adds 'isVirtualizationSource' attribute to the sourceStatuses.  The connection options are then utilized to tag a 'Virtualization Connection' for different handling.
- SelectSourcesPage adds a connection/sourceStatus for the virtualization, in addition to the other backend connections.
- The ConnectionSchemaListItem rows for the 'virtualization source' omit the refresh controls, since there is no need to refresh the virtualization like other backend sources.
- ViewDefinition 'sourcePaths' for the virtualization views utilize '$dv' for the schema.  A corresponding backend change recognizes this placeholder and is able to generate the view
- Modification to allow display of 'cube' icon for the virtualization sources
- updated the corresponding stories

![CreateAView](https://user-images.githubusercontent.com/1820403/83562499-49bce580-a4df-11ea-8ed8-48151f456825.png)
