### PR TITLE
(backport) fix: ensure the min property is properly overridden

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
@@ -123,8 +123,8 @@ export const FormDurationComponent: React.FunctionComponent<
     >
       <InputGroup>
         <TextInput
-          min={'0'}
           {...props.property.fieldAttributes}
+          min={'0'}
           data-testid={id}
           id={id}
           type={'number'}


### PR DESCRIPTION
backports https://github.com/syndesisio/syndesis/pull/8653

fixes ENTESB-11829