### PR TITLE
feat: don't show successful validation for unknown connectors

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
@@ -15,7 +15,7 @@ import './ConnectionDetailsForm.css';
 
 export interface IConnectionDetailsValidationResult {
   message: string;
-  type: 'error' | 'success';
+  type: 'error' | 'success' | 'info';
 }
 
 export interface IConnectionDetailsFormProps {

--- a/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectorConfigurationForm.tsx
@@ -5,7 +5,7 @@ import { ERROR, WARNING } from '../Shared';
 
 export interface IConnectorConfigurationFormValidationResult {
   message: string;
-  type: 'error' | 'success';
+  type: 'error' | 'success' | 'info';
 }
 
 export interface IConnectorConfigurationFormProps {
@@ -56,14 +56,14 @@ export const ConnectorConfigurationForm: React.FunctionComponent<IConnectorConfi
     </StackItem>
     <StackItem>
       {validationResults &&
-      validationResults.map((e, idx) => (
-        <Alert
-          title={e.message}
-          key={idx}
-          isInline={true}
-          variant={e.type === ERROR ? WARNING : e.type}
-        />
-      ))}
+        validationResults.map((e, idx) => (
+          <Alert
+            title={e.message}
+            key={idx}
+            isInline={true}
+            variant={e.type === ERROR ? WARNING : e.type}
+          />
+        ))}
     </StackItem>
     <StackItem>
       <Form

--- a/app/ui-react/syndesis/src/modules/connections/locales/connections-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/connections/locales/connections-translations.en.json
@@ -18,6 +18,8 @@
   "namePlaceholder": "Must enter a connection name...",
   "usedByOne": "Used by 1 integration",
   "usedByMulti": "Used by integrations {{count}} times",
+  "validationSuccessful": "{{name}} has been successfully validated",
+  "validationUnsupported": "{{name}} does not support validation",
   "create": {
     "unsavedChangesTitle": "Do you really want to cancel?",
     "unsavedChangesMessage": "You have not finished creating the connection. If you cancel now you will lose data you already entered. Do you still want to cancel?",


### PR DESCRIPTION
fixes #8608

With this the UI will show:

![image](https://user-images.githubusercontent.com/351660/84172227-c4d74c00-aa49-11ea-870b-cc0612256cd6.png)

instead of a successful validation, specifically when the validation response indicates the connector ID is unknown, in other cases as a stopgap the error response will be displayed to the user as an info alert.