### PR TITLE
TEIIDTOOLS-1044 Remove duplicate connection from Create View wizard

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
@@ -53,7 +53,9 @@ export const ViewCreateApp: React.FunctionComponent = () => {
       element => element.teiidName === teiidName && element.connectionName === connectionName
     );
 
-    tempArray.splice(index, 1);
+    if (index > -1) {
+      tempArray.splice(index, 1);
+    }
     setSelectedSchemaNodes(tempArray);
   };
 

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -172,11 +172,19 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
    * Get the Connections - and include a connection for the Virtualization
    */
   const getConnectionsForDisplay = (conns: Connection[]) => {
+    // If a virtualization has been published, it will have a connection.  If so, remove it - we will use virtualization metadata.
+    const tempConns = conns.slice();
+    const index = tempConns.findIndex(conn => conn.name === virtualization.name);
+    if (index > -1) {
+      tempConns.splice(index, 1);
+    }
+
+    // Add 'connection' for the virtualization
     const virtConnection: Connection = {
       description: virtualization.description,
       name: virtualization.name,
     };
-    return [...conns, virtConnection];
+    return [...tempConns, virtConnection];
   };
 
   return (


### PR DESCRIPTION
Removes the connection which represents the published Virtualization for the working view.  The working virtualization details are available, so removing the published virtualization connection eliminates some confusion of having two sources with same name.  