### PR TITLE
TEIIDTOOLS-1043 Using source specific icon in Create View wizard

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -68,6 +68,7 @@ export interface SchemaNode {
   connectionName: string;
   queryable: boolean;
   children: SchemaNode[];
+  connectionIcon?: JSX.Element;
 }
 
 export interface TableInfo {
@@ -86,6 +87,7 @@ export interface ViewInfo {
 }
 
 export interface SchemaNodeInfo {
+  connectionIcon?: JSX.Element;
   connectionName: string;
   isVirtualizationSchema: boolean;
   name: string;

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SchemaNodeListItem.tsx
@@ -14,6 +14,7 @@ import './SchemaNodeListItem.css';
 
 export interface ISchemaNodeListItemProps {
   name: string;
+  connectionIcon?: JSX.Element;
   connectionName: string;
   isVirtualizationSchema: boolean;
   teiidName: string;
@@ -25,7 +26,8 @@ export interface ISchemaNodeListItemProps {
     name: string,
     teiidName: string,
     nodePath: string[],
-    selected: boolean
+    selected: boolean,
+    connectionIcon?: JSX.Element
   ) => void;
 }
 
@@ -38,7 +40,7 @@ export const SchemaNodeListItem: React.FunctionComponent<
     setItemSelected(props.selected);
   }, [props.selected]);
 
-  const doToggleCheckbox = (connectionName: string, isVirtualizationSchema: boolean, name: string, teiidName: string, nodePath: string[]) => (
+  const doToggleCheckbox = (connectionName: string, isVirtualizationSchema: boolean, name: string, teiidName: string, nodePath: string[], connectionIcon?: JSX.Element) => (
     event: any
   ) => {
     setItemSelected(!itemSelected);
@@ -49,7 +51,8 @@ export const SchemaNodeListItem: React.FunctionComponent<
       name,
       teiidName,
       nodePath,
-      !itemSelected
+      !itemSelected,
+      connectionIcon
     );
   };
 
@@ -77,7 +80,8 @@ export const SchemaNodeListItem: React.FunctionComponent<
             props.isVirtualizationSchema,
             props.name,
             props.teiidName,
-            props.nodePath
+            props.nodePath,
+            props.connectionIcon
           )}
         />
         <DataListItemCells

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
@@ -82,8 +82,8 @@ export const SelectedConnectionListView: React.FunctionComponent<ISelectedConnec
                     >
                       {props.name}
                     </span>
-                    ({props.connectionIcon}
-                    &nbsp;<span>{props.connectionName})</span>
+                    (&nbsp;{props.connectionIcon}
+                    &nbsp;<span>{props.connectionName}&nbsp;)</span>
                   </Text>
                 </TextContent>
               </DataListCell>,

--- a/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
+++ b/app/ui-react/syndesis/src/modules/data/ViewCreateApp.tsx
@@ -27,9 +27,11 @@ export const ViewCreateApp: React.FunctionComponent = () => {
     isVirtualizationSchema: boolean,
     name: string,
     teiidName: string,
-    nodePath: string[]
+    nodePath: string[],
+    connIcon?: JSX.Element
   ) => {
     const srcInfo = {
+      connectionIcon: connIcon,
       connectionName: connName,
       isVirtualizationSchema,
       name,

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -40,7 +40,8 @@ export interface ISelectSourcesPageProps {
     isVirtualizationSchema: boolean,
     name: string,
     teiidName: string,
-    nodePath: string[]
+    nodePath: string[],
+    connectionIcon?: JSX.Element
   ) => void;
   handleNodeDeselected: (connectionName: string, teiidName: string) => void;
   selectedSchemaNodes: SchemaNodeInfo[];

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -102,8 +102,6 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
 
   const handleMetadataLoaded = async (): Promise<void> => {
     if (sourceTableColumns != null && sourceTableColumns.length > 0) {
-      // tslint:disable-next-line:no-console
-      console.log("  VESPage.handleMetadataLoaded() \n\t  virtualization.name = ", virtualization.name);
       monacoContext.setVirtualization(virtualization.name);
       setMetadataLoaded(true);
     }

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
@@ -56,11 +56,13 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
   };
 
   const getConnectionIcon = (schemaNodeInfo: SchemaNodeInfo) => {
-    return schemaNodeInfo.isVirtualizationSchema ? (
-      <CubeIcon />
-    ) : (
-      <DatabaseIcon />
-    );
+    if (schemaNodeInfo.connectionIcon) {
+      return schemaNodeInfo.connectionIcon;
+    } else if (schemaNodeInfo.isVirtualizationSchema) {
+      return <CubeIcon />;
+    } else {
+      return <DatabaseIcon />;
+    }
   };
 
   return (

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -175,6 +175,7 @@ export function generateSchemaNodeInfos(
     if (schemaNode.queryable === true) {
       // Create SchemaNodeInfo
       const view: SchemaNodeInfo = {
+        connectionIcon: schemaNode.connectionIcon,
         connectionName: schemaNode.connectionName,
         isVirtualizationSchema: false,
         name: schemaNode.name,
@@ -190,6 +191,7 @@ export function generateSchemaNodeInfos(
     // Process this nodes children
     if (schemaNode.children && schemaNode.children.length > 0) {
       for (const childNode of schemaNode.children) {
+        childNode.connectionIcon = schemaNode.connectionIcon;
         generateSchemaNodeInfos(schemaNodeInfos, childNode, sourcePath);
       }
     }


### PR DESCRIPTION
Now showing the specific source icon for the selected tables in the CreateView wizard
- added optional connectionIcon attribute on SchemaNode and SchemaNodeInfo models
- wizard adds the optional icon if it is available for display
- also removed console.log in ViewEditorSqlPage