### PR TITLE
fix(ui): ENTESB-14048 validate api client connector security fields

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/securityValidation.ts
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/securityValidation.ts
@@ -1,0 +1,27 @@
+import { ICreateConnectorPropsUi } from './ApiConnectorCreatorSecurityForm';
+
+export interface IErrorValidation {
+  password?: string;
+  username?: string;
+}
+
+export default function validateSecurity(values: ICreateConnectorPropsUi) {
+  const errors: IErrorValidation = {};
+
+  if (
+    values.authenticationType === 'basic' ||
+    values.authenticationType === 'ws-security-ut'
+  ) {
+    if (values.passwordType !== 'PasswordNone') {
+      if (!values.username) {
+        errors.username = 'Username is required';
+      }
+
+      if (!values.password) {
+        errors.password = 'Password is required';
+      }
+    }
+  }
+
+  return errors;
+}

--- a/app/ui-react/packages/ui/stories/Customization/create/3-Security.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/create/3-Security.stories.tsx
@@ -2,13 +2,19 @@ import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { ApiConnectorCreatorLayout } from '../../../src/Customization/apiClientConnectors';
+import {
+  ApiConnectorCreatorLayout,
+  ICreateConnectorPropsUi,
+} from '../../../src/Customization/apiClientConnectors';
 import {
   ApiConnectorCreatorBreadSteps,
   ApiConnectorCreatorFooter,
   ApiConnectorCreatorSecurity,
   ApiConnectorCreatorToggleList,
 } from '../../../src/Customization/apiClientConnectors/create';
+import validateSecurity, {
+  IErrorValidation,
+} from '../../../src/Customization/apiClientConnectors/create/securityValidation';
 import soapSpec from './soap';
 
 const stories = storiesOf(
@@ -16,7 +22,7 @@ const stories = storiesOf(
   module
 );
 
-const preConfiguredValues = {
+const preConfiguredValues: ICreateConnectorPropsUi = {
   authenticationType: soapSpec.properties!.authenticationType.defaultValue,
   authorizationEndpoint: soapSpec.properties!.authorizationEndpoint
     .defaultValue,
@@ -36,25 +42,39 @@ const dropdownOptions = {
 const component = (authenticationType: string) => {
   preConfiguredValues.authenticationType = authenticationType;
 
+  const [errors, setErrors] = React.useState<IErrorValidation>({
+    password: undefined,
+    username: undefined,
+  });
   const [values, setValues] = React.useState(preConfiguredValues);
 
   const handleChange = (param: any, event: any) => {
     const { checked, name, type } = event.target;
-
-    // Checkboxes require special treatment
     const isCheckbox = type === 'checkbox';
     const value = isCheckbox ? checked : event.target.value;
-
-    // If this is a change in the authentication type,
-    // clear any previous values.
     const isAuthType = name === 'authenticationType';
 
+    let localValues: ICreateConnectorPropsUi;
+
     if (isAuthType) {
-      setValues({ ...preConfiguredValues, [name]: value });
+      localValues = { ...preConfiguredValues, [name]: value };
     } else {
-      setValues({ ...values, [name]: value });
+      localValues = { ...values, [name]: value };
+
+      if (name === 'passwordType') {
+        localValues.addTimestamp = undefined;
+        localValues.addUsernameTokenCreated = undefined;
+        localValues.addUsernameTokenNonce = undefined;
+        localValues.username = undefined;
+        localValues.password = undefined;
+      }
     }
+
+    setValues(() => localValues);
+    setErrors(() => validateSecurity(localValues));
   };
+
+  const isValid = !errors.username && !errors.password;
 
   return (
     <ApiConnectorCreatorLayout
@@ -86,7 +106,7 @@ const component = (authenticationType: string) => {
           i18nBack={'Back'}
           i18nNext={'Next'}
           isNextLoading={boolean('isNextLoading', false)}
-          isNextDisabled={boolean('isNextDisabled', false)}
+          isNextDisabled={!isValid}
         />
       }
       navigation={

--- a/app/ui-react/packages/ui/stories/Customization/create/soap.js
+++ b/app/ui-react/packages/ui/stories/Customization/create/soap.js
@@ -7,6 +7,22 @@ export default {
         'SOAP Endpoint address from WSDL SOAP Binding or user specified address.',
       displayName: 'Address',
     },
+    addTimestamp: {
+      defaultValue: false,
+      description: 'Add a Timestamp to WS-Security header.',
+      displayName: 'Timestamp',
+    },
+    addUsernameTokenCreated: {
+      defaultValue: false,
+      description:
+        'Add Created timestamp element to WS-Security Username Token header.',
+      displayName: 'Username Token Created',
+    },
+    addUsernameTokenNonce: {
+      defaultValue: false,
+      description: 'Add Nonce element to WS-Security Username Token header.',
+      displayName: 'Username Token Nonce',
+    },
     authenticationType: {
       defaultValue: 'none',
       description:
@@ -31,7 +47,7 @@ export default {
       defaultValue: 'auth-endpoint',
     },
     passwordType: {
-      defaultValue: 'PasswordText',
+      defaultValue: 'PasswordNone',
       displayName: 'Password Type',
       enum: [
         {
@@ -47,6 +63,10 @@ export default {
           value: 'PasswordDigest',
         },
       ],
+    },
+    tokenEndpoint: {
+      defaultValue: '',
+      displayName: 'Token Endpoint',
     },
   },
   configuredProperties: {

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
@@ -100,7 +100,9 @@ export const SecurityPage: React.FunctionComponent = () => {
                 )}
               />
               <ApiConnectorCreatorSecurityForm defaultValues={defaultValues}>
-                {({ handleChange, values }) => {
+                {({ errors, handleChange, values }) => {
+                  const isValid = !errors?.username && !errors.password;
+
                   return (
                     <ApiConnectorCreatorLayout
                       content={
@@ -153,7 +155,7 @@ export const SecurityPage: React.FunctionComponent = () => {
                           i18nBack={t('shared:Back')}
                           i18nNext={t('shared:Next')}
                           isNextLoading={false}
-                          isNextDisabled={false}
+                          isNextDisabled={!isValid}
                         />
                       }
                       navigation={


### PR DESCRIPTION
Validates connector security form for HTTP basic auth, no auth, and WS security. It's still unclear, but I don't think we need additional validation for OpenAPI specs that use API Key or OAuth, because, IIRC, the API is setting these using the spec, which is validated beforehand.

[ENTESB-14048](https://issues.redhat.com/browse/ENTESB-14048)

Screenshots:

<img width="862" alt="Screenshot 2020-06-15 16 39 25" src="https://user-images.githubusercontent.com/3844502/84688060-95877a00-af36-11ea-94a3-5ed2e61b538d.png">

<img width="862" alt="Screenshot 2020-06-15 16 39 36" src="https://user-images.githubusercontent.com/3844502/84688065-991b0100-af36-11ea-974d-ecfaca091c01.png">

<img width="859" alt="Screenshot 2020-06-15 16 40 39" src="https://user-images.githubusercontent.com/3844502/84688070-9d471e80-af36-11ea-828e-ac57f5fc23d6.png">

<img width="893" alt="Screenshot 2020-06-15 16 40 48" src="https://user-images.githubusercontent.com/3844502/84688091-a46e2c80-af36-11ea-8b95-b3a0cbc4643c.png">
