### PR TITLE
TEIIDTOOLS-1043 Use source specific icon in CreateView wizard selections

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/SelectedConnectionListView.tsx
@@ -22,7 +22,7 @@ import './SelectedConnectionListView.css';
 export interface ISelectedConnectionListViewProps {
   expanded: string[];
   name: string;
-  connectionIcon: JSX.Element;
+  connectionIcon: React.ReactNode;
   connectionName: string;
   index: number;
   rows: string[][];
@@ -82,8 +82,8 @@ export const SelectedConnectionListView: React.FunctionComponent<ISelectedConnec
                     >
                       {props.name}
                     </span>
-                    ({props.connectionIcon}
-                    &nbsp;<span>{props.connectionName})</span>
+                    (&nbsp;{props.connectionIcon}
+                    &nbsp;<span>{props.connectionName}&nbsp;)</span>
                   </Text>
                 </TextContent>
               </DataListCell>,

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -1,3 +1,4 @@
+import { CubeIcon } from '@patternfly/react-icons';
 import {
   useConnections,
   useVirtualizationConnectionStatuses,
@@ -11,7 +12,7 @@ import { useRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { UIContext } from '../../../../app';
-import { PageTitle } from '../../../../shared';
+import { EntityIcon, PageTitle } from '../../../../shared';
 import resolvers from '../../../resolvers';
 import { getQueryColumns, getQueryRows } from '../../shared';
 import {
@@ -186,6 +187,23 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
     };
     return [...tempConns, virtConnection];
   };
+  
+  const getConnectionIcons = (conns: Connection[], small: boolean) => {
+    const iconMap: Map<string, JSX.Element> = new Map();
+    // Set icons for the connections
+    for(const theConn of conns) {
+      const icon = small ? (
+        <EntityIcon entity={theConn} alt={theConn.name} width={12} />
+      ) : (
+        <EntityIcon entity={theConn} alt={theConn.name} width={23} />
+      );
+      iconMap.set(theConn.name, icon);
+    }
+    // Add the virtualization icon
+    const virtIcon = small ? <CubeIcon /> : <CubeIcon size={'lg'} />;
+    iconMap.set(virtualization.name, virtIcon);
+    return iconMap;
+  };
 
   return (
     <>
@@ -225,6 +243,7 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
           }
           dvSourceStatuses={getConnectionStatusesAddVirtualization(connectionStatuses)}
           connections={getConnectionsForDisplay(connectionsData.connectionsForDisplay)}
+          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, false)}
           virtualizationSchema={getVirtualizationSchema(viewSourceInfo)}
           onNodeSelected={props.handleNodeSelected}
           onNodeDeselected={onTableDeselect}
@@ -234,6 +253,7 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
       selectedTables={
         <ConnectionTables
           selectedSchemaNodes={props.selectedSchemaNodes}
+          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, true)}
           onNodeDeselected={onTableDeselect}
           columnDetails={viewSourceInfo.schemas}
           setShowPreviewData={toggleShowPreviewData}

--- a/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewEditor/ViewEditorSqlPage.tsx
@@ -102,8 +102,6 @@ export const ViewEditorSqlPage: React.FunctionComponent = () => {
 
   const handleMetadataLoaded = async (): Promise<void> => {
     if (sourceTableColumns != null && sourceTableColumns.length > 0) {
-      // tslint:disable-next-line:no-console
-      console.log("  VESPage.handleMetadataLoaded() \n\t  virtualization.name = ", virtualization.name);
       monacoContext.setVirtualization(virtualization.name);
       setMetadataLoaded(true);
     }

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionSchemaContent.tsx
@@ -1,4 +1,3 @@
-import { CubeIcon } from '@patternfly/react-icons';
 import { useVirtualizationConnectionSchema, useVirtualizationHelpers } from '@syndesis/api';
 import {
   Connection,
@@ -17,7 +16,7 @@ import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { UIContext } from '../../../app';
-import { ApiError, EntityIcon } from '../../../shared';
+import { ApiError } from '../../../shared';
 import resolvers from '../../resolvers';
 import {
   generateDvConnections,
@@ -53,6 +52,7 @@ export interface ILastRefreshMessage {
 
 export interface IConnectionSchemaContentProps {
   connections: Connection[];
+  connectionIcons: Map<string, React.ReactNode>;
   dvSourceStatuses: VirtualizationSourceStatus[];
   error: boolean;
   errorMessage?: string;
@@ -206,14 +206,6 @@ export const ConnectionSchemaContent: React.FunctionComponent<IConnectionSchemaC
     return status ? status.teiidName : '';
   };
 
-  const getConnectionIcon = (conn: Connection) => {
-    return isDvConnectionVirtualizationSource(conn) ? (
-      <CubeIcon size={'lg'} />
-    ) : (
-      <EntityIcon entity={conn} alt={conn.name} width={23} />
-    );
-  }
-
   const getSchemaNodeInfos = (schemaNodes: SchemaNode[], connName: string, isVirtSource: boolean) => {
     const schemaNodeInfos: SchemaNodeInfo[] = [];
     // Connection source - generate from schemaNodes
@@ -279,7 +271,7 @@ export const ConnectionSchemaContent: React.FunctionComponent<IConnectionSchemaC
                 i18nRefreshInProgress={t('refreshInProgress')}
                 i18nStatusErrorPopoverLink={t('connectionStatusPopoverLink')}
                 i18nStatusErrorPopoverTitle={t('connectionStatusPopoverTitle')}
-                icon={getConnectionIcon(c)}
+                icon={props.connectionIcons.get(c.name)}
                 isVirtualizationSource={isVirtSource}
                 loading={isDvConnectionLoading(c)}
                 refreshConnectionSchema={handleRefreshSchema}

--- a/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ConnectionTables.tsx
@@ -1,4 +1,3 @@
-import { CubeIcon, DatabaseIcon } from '@patternfly/react-icons';
 import {
   ConnectionTable,
   SchemaNodeInfo,
@@ -14,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 export interface IConnectionTablesProps {
   selectedSchemaNodes: SchemaNodeInfo[];
   columnDetails: ConnectionTable[];
+  connectionIcons: Map<string, React.ReactNode>;
   onNodeDeselected: (connectionName: string, teiidName: string) => void;
   setShowPreviewData: (connectionName: string, tableName: string) => void;
 }
@@ -55,14 +55,6 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
     ]);
   };
 
-  const getConnectionIcon = (schemaNodeInfo: SchemaNodeInfo) => {
-    return schemaNodeInfo.isVirtualizationSchema ? (
-      <CubeIcon />
-    ) : (
-      <DatabaseIcon />
-    );
-  };
-
   return (
     <SelectedConnectionTables
       selectedSchemaNodesLength={props.selectedSchemaNodes.length}
@@ -74,7 +66,7 @@ export const ConnectionTables: React.FunctionComponent<IConnectionTablesProps> =
         <SelectedConnectionListView
           key={index}
           name={info.teiidName}
-          connectionIcon={getConnectionIcon(info)}
+          connectionIcon={props.connectionIcons.get(info.connectionName)}
           connectionName={info.connectionName}
           index={index}
           toggle={toggle}


### PR DESCRIPTION
Now using the source specific icons for the selected tables in CreateView wizard.
- supplies map of the ConnectionIcons to ConnectionSchemaContent and ConnectionTables components.
- SelectSourcesPage generates the icons - optionally small or large size
- also removed console.log from ViewEditorSqlPage