### PR TITLE
Fix: specific source icon in Create View wizard Preview table

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/PreviewData.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/PreviewData.tsx
@@ -18,6 +18,8 @@ export interface IPreviewDataProps {
   i18nShowPreview: string;
   isLoadingPreview: boolean;
   isExpanded: boolean;
+  connectionIcon: React.ReactNode;
+  connectionName: string;
   onToggle: () => void;
 }
 
@@ -26,7 +28,8 @@ export const PreviewData: React.FunctionComponent<IPreviewDataProps> = props => 
     <>
       <TextContent>
         <Text component={TextVariants.h2}>
-          <span>{props.i18nPreviewHeading}</span>
+          <span>{props.i18nPreviewHeading} (&nbsp;{props.connectionIcon}
+                    &nbsp;{props.connectionName}&nbsp;)</span>
         </Text>
       </TextContent>
       <Expandable

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -125,7 +125,7 @@
     "resultsTableValidEmptyInfo": "Save the view editor and click Refresh to display the preview results.",
     "resultsTableValidEmptyTitle": "No data available",
     "showPreview": "Show preview",
-    "previewHeading": "Preview of {{name}} ({{connection}})"
+    "previewHeading": "Preview of {{name}}"
   },
   "previewData": "Preview data",
   "publishedDataVirtualization": "Running",

--- a/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/viewCreate/SelectSourcesPage.tsx
@@ -188,19 +188,16 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
     return [...tempConns, virtConnection];
   };
   
-  const getConnectionIcons = (conns: Connection[], small: boolean) => {
+  const getConnectionIcons = (conns: Connection[], size: number) => {
     const iconMap: Map<string, JSX.Element> = new Map();
     // Set icons for the connections
     for(const theConn of conns) {
-      const icon = small ? (
-        <EntityIcon entity={theConn} alt={theConn.name} width={12} />
-      ) : (
-        <EntityIcon entity={theConn} alt={theConn.name} width={23} />
-      );
+      const icon = <EntityIcon entity={theConn} alt={theConn.name} width={size} />;
       iconMap.set(theConn.name, icon);
     }
     // Add the virtualization icon
-    const virtIcon = small ? <CubeIcon /> : <CubeIcon size={'lg'} />;
+    const iconsize = size>15 ? size>20 ? 'lg': 'md' : 'sm';
+    const virtIcon = <CubeIcon size={iconsize} />;
     iconMap.set(virtualization.name, virtIcon);
     return iconMap;
   };
@@ -243,7 +240,7 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
           }
           dvSourceStatuses={getConnectionStatusesAddVirtualization(connectionStatuses)}
           connections={getConnectionsForDisplay(connectionsData.connectionsForDisplay)}
-          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, false)}
+          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, 23)}
           virtualizationSchema={getVirtualizationSchema(viewSourceInfo)}
           onNodeSelected={props.handleNodeSelected}
           onNodeDeselected={onTableDeselect}
@@ -253,7 +250,7 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
       selectedTables={
         <ConnectionTables
           selectedSchemaNodes={props.selectedSchemaNodes}
-          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, true)}
+          connectionIcons={getConnectionIcons(connectionsData.connectionsForDisplay, 12)}
           onNodeDeselected={onTableDeselect}
           columnDetails={viewSourceInfo.schemas}
           setShowPreviewData={toggleShowPreviewData}
@@ -270,9 +267,10 @@ export const SelectSourcesPage: React.FunctionComponent<ISelectSourcesPageProps>
           i18nHidePreview={t('preview.hidePreview')}
           i18nShowPreview={t('preview.showPreview')}
           i18nPreviewHeading={t('preview.previewHeading', {
-            connection: previewTable.connectionName,
             name: previewTable.tableName
           })}
+          connectionName={previewTable.connectionName}
+          connectionIcon={getConnectionIcons(connectionsData.connectionsForDisplay, 17).get(previewTable.connectionName)}
           isLoadingPreview={isLoadingPreview}
           isExpanded={isExpanded}
           onToggle={onToggle}


### PR DESCRIPTION
- Jira issue https://issues.redhat.com/browse/TEIIDTOOLS-1050

- used getConnectionIcons method in SelectSourcePage to pass the icon of the preview table connection.

- screenshot 
![image](https://user-images.githubusercontent.com/8264372/84882039-49f6dc80-b0ac-11ea-9f10-bd814fe421fe.png)
