### PR TITLE
chore: Update to AtlasMap 2.0.5

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-760024</camel.version>
-    <atlasmap.version>2.0.4</atlasmap.version>
+    <atlasmap.version>2.0.5</atlasmap.version>
     <jackson.databind.version>2.9.9</jackson.databind.version>
     <mongodb.version>3.9.0</mongodb.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,7 +39,7 @@
     <deploy.archives>false</deploy.archives>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>2.0.4</atlasmap.version>
+    <atlasmap.version>2.0.5</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -84,7 +84,7 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.0.4",
+    "@atlasmap/atlasmap": "^2.0.5",
     "react-fast-compare": "^2.0.2"
   },
   "jest": {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -226,19 +226,19 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.0.4.tgz#ac0c27763b3b7366e0126cf31a1a2bccdeb76ba8"
-  integrity sha512-QtRBFJp9gH8ZqR57+DjGssMb1dMk0XFNj/IaF3zM93dYC0IVuC6b38Z6ii8uTGIorPA3Kqn5WdkUQsWaFG3nMg==
+"@atlasmap/atlasmap@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.0.5.tgz#66b134b6c801dd68e2a340df5bac224c65b49d42"
+  integrity sha512-Of91lhDO8I44l99LJlV5Mlms7Q27fVQsvkHfuXnI9n5c1h6YmDLUzRv3xx+Agzs4VeDkzS7BWgRmk2TzpcyFDg==
   dependencies:
-    "@atlasmap/core" "^2.0.4"
+    "@atlasmap/core" "^2.0.5"
     react-sage "^0.0.42"
     use-debounce "^3.4.2"
 
-"@atlasmap/core@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.0.4.tgz#1b83a429fb7b48d93c4bffb19cdb3441b667921e"
-  integrity sha512-IKBYTp/5UaOJcMi7tziAybiFdL4qmbnjdmdfLJzXebbZm4IqLaiubYimtt60AWthBl6pTMtSN3Je8+uNFqX2LQ==
+"@atlasmap/core@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.0.5.tgz#398cc365455116a5fe565a24c1431832a07dac32"
+  integrity sha512-HbHBHk7QGDzNYAsL9ZnNwzulLpwoc0b49eW3L/NBY8yZYl0KCxRKgE9YLeMyxO1jDDbehTx3CqRb4nqI9Vongg==
   dependencies:
     file-saver "2.0.2"
     loglevel "^1.6.7"


### PR DESCRIPTION
Backporting: #8718
Fixes: https://issues.redhat.com/browse/ENTESB-12362
Release note: https://github.com/atlasmap/atlasmap/releases/tag/atlasmap-2.0.5

Hi @claudio4j, can we get this backported before next build?