### PR TITLE
feature(e2e): Run integration tests as github actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,19 @@
+name: Integration Tests for PR
+
+on: pull_request
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build Syndesis
+        run: tools/bin/syndesis build --backend --flash 
+      - name: Run integration tests
+        run: tools/bin/syndesis integration-test
+

--- a/.github/workflows/e2e_mainbranch.yml
+++ b/.github/workflows/e2e_mainbranch.yml
@@ -1,0 +1,24 @@
+name: Integration Tests
+
+# Trigger the workflow on push 
+# but only for the master branch
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build Syndesis
+        run: tools/bin/syndesis build --backend --flash 
+      - name: Run integration tests
+        run: tools/bin/syndesis integration-test
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/syndesisio/syndesis)](https://github.com/syndesisio/syndesis/releases/latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.syndesis/syndesis-parent/badge.svg?style=flat-square)](https://search.maven.org/search?q=g:io.syndesis)
 [![CircleCI](https://circleci.com/gh/syndesisio/syndesis/tree/master.svg?style=svg)](https://circleci.com/gh/syndesisio/syndesis/tree/master)
+[![Integration Tests](https://github.com/syndesisio/syndesis/workflows/Integration%20Tests/badge.svg)](https://github.com/syndesisio/syndesis/runs/)
 [![Gitter](https://badges.gitter.im/syndesisio/community.svg)](https://gitter.im/syndesisio/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Google Groups](https://img.shields.io/badge/Google%20Groups-Syndesis-blue)](https://groups.google.com/forum/#!forum/syndesis)
 


### PR DESCRIPTION
Adds two github actions that runs integration tests: one on each PR and one on master after each push to check master stability (and adds the badge on README.md).

I would need someone with privileges to add the PR action as mandatory on all merges like the circleci task :) We will not ignore e2e anymore!