### PR TITLE
Fix: Interactive read fails with -s switch for password

### DIFF
--- a/tools/bin/commands/util/client_funcs
+++ b/tools/bin/commands/util/client_funcs
@@ -44,7 +44,7 @@ get_current_user() {
 get_admin_user() {
     local admin="${1:-}"
     local client_dir=$(create_client_cache)
-    local cache_file="${client_dir}/admin-${KUBE}--user"
+    local cache_file="${client_dir}/admin-${KUBE}-user"
 
     if [ -f "${cache_file}" ]; then
         local admin=$(head -n 1 "${cache_file}")

--- a/tools/bin/commands/util/kube_funcs
+++ b/tools/bin/commands/util/kube_funcs
@@ -262,10 +262,10 @@ create_kube_user() {
 
 get_kube_namespace() {
     local nm="${1:-}"
-    local kuser=$(get_admin_user)
-    check_error "${kuser}"
 
     if [ -n "${nm}" ]; then
+        local kuser=$(get_admin_user)
+        check_error "${kuser}"
         echo $(${KUBECTL} get namespace "${nm}" -o=jsonpath="{.metadata.name}" --user="${kuser}" 2>&1)
     else
         local cur_ctx

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -46,14 +46,16 @@ login_oc_as_admin() {
 
     local admin_user=$(get_admin_user "${1:-}")
 
-    read -p -s "Please enter the password for the cluster-admin ${admin_user}?: " password
+    read -p "Please enter the password for the cluster-admin '${admin_user}' or just press 'Enter' for no password?: " password
     echo
-    if [ -z "$password" ]; then
-        check_error "Error: No password for ${admin_user} was entered. Aborting."
+
+    local options=" -u ${admin_user}"
+    if [ -n "${password}" ]; then
+        options="${options} -p ${password}"
     fi
 
     # Login in as admin
-    local result=$(oc login -u "$admin_user" -p "${password}" 2>&1)
+    local result=$(oc login ${options} 2>&1)
     check_error "$result"
 
     # Return the command to use to revert to the initial user


### PR DESCRIPTION
* openshift_funcs
 * Cannot call read -s as this seems to fail when called within a subshell
 * Remove check for no password as in minishift context, no password is
   legitimate
 * Only add -p to `oc login` if a password is specified

* kube_funcs
 * Only request admin password if specifically need it

* client_funcs
 * Remove mistaken double-hyphen in caching filename