### PR TITLE
chore: Fix build CLI on MacOS

### DIFF
--- a/tools/bin/commands/util/common_funcs
+++ b/tools/bin/commands/util/common_funcs
@@ -412,10 +412,12 @@ gnugrep() {
 
     if $(isMacOs); then
 
-      if $(check_for_command "ggrep") -ne "OK" ]; then
-        check_error "ERROR: Please install ggrep on OSX usimg 'brew install grep'"
-      else
+      ggrepCheck=$(check_for_command "ggrep")
+
+      if [[ "$ggrepCheck" == "OK" ]]; then
         GREP=$(which ggrep)
+      else
+        check_error "ERROR: Please install ggrep on OSX using 'brew install grep'"
       fi
 
     else


### PR DESCRIPTION
Check for existing ggrep binary was not working properly on MacOS. 

The command hit the another error before actually doing the check:

`common_funcs: line 415: OK: command not found`

Fixed check to work on MacOS