### PR TITLE
Fix syndesis script

### DIFF
--- a/tools/bin/commands/completion
+++ b/tools/bin/commands/completion
@@ -14,6 +14,7 @@ EOT
 
 completion::init() {
     # Nothing to do but required
+    echo
 }
 
 completion::run() {

--- a/tools/bin/commands/ui
+++ b/tools/bin/commands/ui
@@ -26,6 +26,7 @@ EOT
 
 ui::init() {
   # nothing required but must be present
+  echo
 }
 
 ui::run() {


### PR DESCRIPTION
calling "syndesis --help" outputs an error

/home/claudio/alphaworks/projects/syndesis/tools/bin/commands/completion: line 18: syntax error near unexpected token `}'
ERROR: Last command exited with 2