### PR TITLE
fix(test): exclude citrus-validation-xml

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3325,6 +3325,10 @@
         <version>${citrus.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-validation-xml</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>


### PR DESCRIPTION
The presence of the library is making many test expecting a json message to fail as they are parsed as xml messages

Fixes #8776