### PR TITLE
Bankport 1.11.x: ENTESB-12840 Enable including error messages in API Provider …

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiFlowGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiFlowGenerator.java
@@ -278,7 +278,7 @@ public abstract class OpenApiFlowGenerator<T extends OasDocument, O extends OasO
             .connection(connection)
             .stepKind(StepKind.endpoint)
             .putConfiguredProperty(HTTP_RESPONSE_CODE_PROPERTY, getResponseCode(operation))
-            .putConfiguredProperty(ERROR_RESPONSE_BODY, "false")
+            .putConfiguredProperty(ERROR_RESPONSE_BODY, "true")
             .putConfiguredProperty(ERROR_RESPONSE_CODES_PROPERTY, "{}")
             .putMetadata("configured", "true")
             .build();


### PR DESCRIPTION
…by default

Backport to 1.11.x