### PR TITLE
Operator changes

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -229,6 +229,14 @@ build_image()
             check_error "$hasoc"
         fi
 
+        #
+        # Check that oc is logged in and communicating with a cluster
+        #
+        set +e
+        version="$(oc version 2>&1)"
+        set -e
+        check_error "${version}"
+
         echo ======================================================
         echo Building image with S2I
         echo ======================================================
@@ -239,6 +247,8 @@ build_image()
         # Otherwise remove the build-config to repoint to the new image:tag.
         #
         local bcOutName="$(oc get bc "${S2I_STREAM_NAME}" -o=jsonpath='{.spec.output.to.name}' 2>&1)"
+        check_error "${bcOutName}"
+
         local imgTag="${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
         # Remove any registry prefix from OPERATOR_IMAGE_NAME
         imgTag="${imgTag##*/}"

--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -232,6 +232,26 @@ build_image()
         echo ======================================================
         echo Building image with S2I
         echo ======================================================
+
+        #
+        # If a build config already exists, check whether its pointing at the same
+        # image name and tag as this one. If it does then can use it to rebuild.
+        # Otherwise remove the build-config to repoint to the new image:tag.
+        #
+        local bcOutName="$(oc get bc "${S2I_STREAM_NAME}" -o=jsonpath='{.spec.output.to.name}' 2>&1)"
+        local imgTag="${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
+        # Remove any registry prefix from OPERATOR_IMAGE_NAME
+        imgTag="${imgTag##*/}"
+
+        if [ "${bcOutName}" != "${imgTag}" ]; then
+            echo "Removing old BuildConfig ${S2I_STREAM_NAME} due to different image:tag"
+            #
+            # build config exists but not generated the same image & tag as is requested
+            # so remove it to allow a new bc to be generated.
+            #
+            oc delete bc "${S2I_STREAM_NAME}" >/dev/null 2>&1
+        fi
+
         if [ -z "$(oc get bc -o name | grep ${S2I_STREAM_NAME})" ]; then
             echo "Creating BuildConfig ${S2I_STREAM_NAME} with tag ${OPERATOR_IMAGE_TAG}"
             oc new-build --strategy=docker --binary=true --to=${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG} --name ${S2I_STREAM_NAME}

--- a/install/operator/build.sh
+++ b/install/operator/build.sh
@@ -13,6 +13,19 @@ source "$(pwd)/../../tools/bin/commands/util/openshift_funcs"
 source "$(pwd)/../../tools/bin/commands/util/kube_funcs"
 source "./.lib.sh"
 
+#
+# Ensure any errors from check_error are printed to the terminal
+# Uses same trap as syndesis command
+#
+#
+ERROR_FILE="$(mktemp /tmp/syndesis-build-output.XXXXXX)"
+add_to_trap "print_error ${ERROR_FILE}"
+#
+# This should be the only trap
+# Other instances should use add_to_trap
+#
+trap "process_trap" EXIT
+
 DOCKER_REGISTRY="$(readopt 		 --registry           '')"
 OPERATOR_IMAGE_NAME="$(readopt --image-name         docker.io/syndesis/syndesis-operator)"
 OPERATOR_IMAGE_TAG="$(readopt  --image-tag          latest)"

--- a/install/operator/build.sh
+++ b/install/operator/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Builds the operator, using operator-sdk for developers that have it
-# installed locally, or using docker if they don't have it installed.
+# installed locally, or using docker|podman if they don't have it installed.
 #
 
 set -e
@@ -26,7 +26,7 @@ add_to_trap "print_error ${ERROR_FILE}"
 #
 trap "process_trap" EXIT
 
-DOCKER_REGISTRY="$(readopt 		 --registry           '')"
+CONTAINER_REGISTRY="$(readopt  --registry           '')"
 OPERATOR_IMAGE_NAME="$(readopt --image-name         docker.io/syndesis/syndesis-operator)"
 OPERATOR_IMAGE_TAG="$(readopt  --image-tag          latest)"
 S2I_STREAM_NAME="$(readopt     --s2i-stream-name    syndesis-operator)"
@@ -44,11 +44,11 @@ usage: ./build.sh [options]
 where options are:
   --help                                  display this help messages
   --source-gen <on|skip|verify-none>      should the source generators be run (default: on)
-  --operator-build <auto|docker|go|skip>  how to build the operator executable (default: auto)
-  --image-build <auto|docker|s2i|skip>    how to build the image (default: auto)
-	--registry <registry host[:port]>       custom docker registry to locate the image
-  --image-name <name>                     docker image name (default: syndesis/syndesis-operator)
-  --image-tag  <tag>                      docker image tag (default: latest)
+  --operator-build <auto|docker|podman|go|skip>  how to build the operator executable (default: auto)
+  --image-build <auto|docker|podman|s2i|skip>    how to build the image (default: auto)
+  --registry <registry host[:port]>       custom container registry to locate the image
+  --image-name <name>                     container image name (default: syndesis/syndesis-operator)
+  --image-tag  <tag>                      container image tag (default: latest)
   --s2i-stream-name <name>                s2i image stream name (default: syndesis-operator)
   --go-options <name>                     additional build options to pass to the go build
   --go-proxy <url>                        proxy url for finding go dependencies (default: https://proxy.golang.org)
@@ -67,8 +67,9 @@ BUILD_TIME=$(date +%Y-%m-%dT%H:%M:%S%z)
 # pointing to the registry
 #
 FULL_OPERATOR_IMAGE_NAME=$OPERATOR_IMAGE_NAME
-if [ -n "$DOCKER_REGISTRY" ]; then
-	FULL_OPERATOR_IMAGE_NAME="$DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME"
+if [ -n "$CONTAINER_REGISTRY" ]; then
+	OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME##*/} # Drop prefix as not necessarily applicable to registry
+	FULL_OPERATOR_IMAGE_NAME="${CONTAINER_REGISTRY}/${OPERATOR_IMAGE_NAME}"
 fi
 
 if [ $OPERATOR_BUILD_MODE != "skip" ] ; then
@@ -80,5 +81,5 @@ if [ $OPERATOR_BUILD_MODE != "skip" ] ; then
 fi
 
 if [ $IMAGE_BUILD_MODE != "skip" ] ; then
-  build_image $IMAGE_BUILD_MODE $OPERATOR_IMAGE_NAME $OPERATOR_IMAGE_TAG $S2I_STREAM_NAME $DOCKER_REGISTRY
+  build_image $IMAGE_BUILD_MODE $OPERATOR_IMAGE_NAME $OPERATOR_IMAGE_TAG $S2I_STREAM_NAME $CONTAINER_REGISTRY
 fi

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -245,54 +245,51 @@ do_operator() {
         args="$args --source-gen ${source_gen}"
     fi
 
-    if [ $(hasflag -i --image --docker) ]; then
-        local BUILD_ARGS=""
-        if [ -n "${image}" ]; then
-          BUILD_ARGS="${BUILD_ARGS} --image-name=${image}"
-        fi
-
-        if [ -n "${tag}" ]; then
-          BUILD_ARGS="${BUILD_ARGS} --image-tag=${tag}"
-        fi
-
-        local image_build=""
-
-        if [[ $(hasflag --docker) ]]; then
-            image_build="docker"
-        else
-            #
-            # Try and detect the type of platform if any
-            #
-            determine_platform
-
-            if [[ ${IS_OPENSHIFT} == "YES" ]]; then
-                image_build="s2i"
-            else
-                image_build="docker"
-            fi
-        fi
-
-        #
-        # If building to kubernetes we might need a registry to push
-        # the images to (unless using the default of docker.io)
-        # Don't need it for s2i
-        #
-        if [ "$image_build" == "docker" ] && [ $(hasflag --registry) ]; then
-            local registry=$(readopt --registry)
-            BUILD_ARGS="${BUILD_ARGS} --registry ${registry}"
-        fi
-
-        ./build.sh ${args} --image-build="${image_build}" ${BUILD_ARGS}
-
-        check_error $(install_built_operator "${top_dir}/install/operator")
-
-        echo "=============================================================================="
-        echo "Built operator copied to ${OPERATOR_BINARY}."
-        echo "Built ${PLATFORM_DETECT} binary copied to ${PLATFORM_DETECT_BINARY}."
-        echo "=============================================================================="
-    else
-        check_error "ERROR: One of '-i / --image' and/or '--docker' should be specified"
+    if [ -n "${image}" ]; then
+        args="${args} --image-name=${image}"
     fi
+
+    if [ -n "${tag}" ]; then
+        args="${args} --image-tag=${tag}"
+    fi
+
+    local image_build=""
+    if [[ $(hasflag -i --image --docker) ]]; then
+        image_build="docker"
+    else
+        #
+        # Try and detect the type of platform if any
+        #
+        determine_platform
+
+        if [[ ${IS_OPENSHIFT} == "YES" ]]; then
+            image_build="s2i"
+        else
+            image_build="docker"
+        fi
+    fi
+
+    echo "Building mode determined to be ${image_build}"
+    args="--image-build=${image_build} ${args}"
+
+    #
+    # If building to kubernetes we might need a registry to push
+    # the images to (unless using the default of docker.io)
+    # Don't need it for s2i
+    #
+    if [ "${image_build}" == "docker" ] && [ $(hasflag --registry) ]; then
+        local registry=$(readopt --registry)
+        args="${args} --registry ${registry}"
+    fi
+
+    ./build.sh ${args}
+
+    check_error $(install_built_operator "${top_dir}/install/operator")
+
+    echo "=============================================================================="
+    echo "Built operator copied to ${OPERATOR_BINARY}."
+    echo "Built ${PLATFORM_DETECT} binary copied to ${PLATFORM_DETECT_BINARY}."
+    echo "=============================================================================="
 
     popd >/dev/null
 }

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -18,11 +18,12 @@ build::usage() {
     --skip-tests               Skip unit, integration and system test execution
     --skip-checks              Disable all checks
 -f  --flash                    Skip checks and tests execution (fastest mode)
--i  --image                    Build Docker via s2i images (openshift only), too (for those modules creating images)
-    --docker                   Use a plain Docker build for creating images. Used by CI for pushing to Docker Hub (assumed if not using openshift)
+-i  --image                    Build container via s2i images (openshift only), too (for those modules creating images)
+    --docker                   Create images using docker. Used by CI for pushing to registry (assumed if not using openshift)
+    --podman                   Create operator image using podman. (not yet available for other images)
     --operator-tag             The tag to use for the operator image
     --operator-image           The image name of the operator (normally, syndesis/syndesis-operator but sometimes need to drop the 'syndesis' prefix)
-    --registry                 Registry to push the built images (used in conjunction with --docker)
+    --registry                 Registry to push the built images (used in conjunction with --docker / --podman)
 -p  --project <project>        Specifies the project / namespace to create images
 -g  --goals <g1>,<g2>, ..      Use custom Maven goals to execute for the build. Default goal is `install`
 -s  --settings <path>          Path to Maven settings.xml
@@ -169,7 +170,6 @@ maven_args() {
           local registry=$(readopt --registry)
           profiles="${profiles},image-push"
           regarg="-Ddocker.push.registry=${registry}"
-          #args="$args -Dimage.push=true -Ddocker.push.registry=${registry}"
         fi
 
         args="${args} -P ${profiles} -Dfabric8.mode=${mode} ${regarg}"
@@ -254,7 +254,9 @@ do_operator() {
     fi
 
     local image_build=""
-    if [[ $(hasflag -i --image --docker) ]]; then
+    if [[ $(hasflag --podman) ]]; then
+        image_build="podman"
+    elif [[ $(hasflag -i --image --docker) ]]; then
         image_build="docker"
     else
         #
@@ -277,9 +279,13 @@ do_operator() {
     # the images to (unless using the default of docker.io)
     # Don't need it for s2i
     #
-    if [ "${image_build}" == "docker" ] && [ $(hasflag --registry) ]; then
-        local registry=$(readopt --registry)
-        args="${args} --registry ${registry}"
+    if [ $(hasflag --registry) ]; then
+        if [ "${image_build}" == "s2i" ]; then
+            echo "WARNING: The --registry flag is not applicable for s2i (openshift source-2-image) builds"
+        else
+            local registry=$(readopt --registry)
+            args="${args} --registry ${registry}"
+        fi
     fi
 
     ./build.sh ${args}

--- a/tools/bin/commands/util/common_funcs
+++ b/tools/bin/commands/util/common_funcs
@@ -362,6 +362,24 @@ determine_platform() {
     fi
 }
 
+podman_is_available() {
+    set +e
+
+    if [ $(check_for_command "podman") != "OK" ]; then
+        set -e
+        echo "ERROR: 'podman' command not installed"
+        return
+    fi
+
+    if podman info >/dev/null 2>&1; then
+        echo "OK"
+    else
+        echo "ERROR: the 'podman' command is not connected to a server"
+    fi
+
+    set -e
+}
+
 docker_is_available() {
     set +e
 

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -16,14 +16,15 @@ check_oc_version() {
     # Extracts any version number of the format dd.dd.dd, eg. 3.10.0 or 4.1.0
     #
 
-    local test=$(${OC} version | ${GREP} -Eiv 'ubernetes|erver' | ${GREP} -o '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\?')
+    local version=$(${OC} version 2>&1)
+    local test=$(echo "${version}" | ${GREP} -Eiv 'ubernetes|erver' | ${GREP} -o '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\?')
     if [ -z "${test}" ]; then
-        test=$(${OC} version | ${GREP} 'lient' | ${GREP} -o '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\?')
+        test=$(echo "${version}" | ${GREP} 'lient' | ${GREP} -o '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\?')
     fi
 
     if [ -z "$test" ]; then
-      echo "ERROR: 'Version of oc could not be found'"
-      return
+        echo "ERROR: 'Version of oc could not be found'"
+        return
     fi
 
     echo $(compare_version $test $minimum)
@@ -210,13 +211,10 @@ setup_minishift_oc() {
 #
 is_oc_available() {
 
-    # Check path first if it already exists
-    set +e
-    which ${OC} &>/dev/null
-    if [ $? -eq 0 ]; then
-      set -e
-      echo $(check_oc_version)
-      return
+    local result=$(check_for_command ${OC})
+    if [ "$(contains_error "${result}")" != "YES" ]; then
+        echo $(check_oc_version)
+        return
     fi
 
     #
@@ -228,6 +226,7 @@ is_oc_available() {
     # shell and so the changes to the PATH variable will not be propogated
     # to the parent shell.
     #
+    set +e
     hasminishift=$(is_minishift_available)
     if [ "$hasminishift" == "OK" ]; then
       set -e

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -100,12 +100,18 @@ download_operator_binary() {
             release_tag=$(echo $url| awk -F '/' '{print $8}')
         fi
 
-        if [ -z "$url" ]
-        then
-          echo "ERROR - the operator download URL could not be constructed"
-          exit 1
+        #
+        # Check curl returns a valid url
+        #
+        if [ -z "${url}" ]; then
+            if [[ -n "$release_tag" ]]; then
+                echo "unable to find a valid release url for release tag ${release_tag}"
+            else
+                echo "unable to find any valid release urls"
+            fi
+            return 1
         else
-          echo "Downloading from $url ..."
+            echo "Downloading from $url ..."
         fi
 
         if $(curl -sL ${url} | tar xz -C $(dirname ${OPERATOR_BINARY})); then


### PR DESCRIPTION
* feature(operator): Add podman support to operator build scripts
  * .lib.sh
    * Breaks out operator image build function
    * Adds podman support to both building the operator binary and image
    * Makes references to registry neutral, removing "docker"
    * When building operator binary, first check for oc then podman then docker
  * build.sh
    * Adds podman as an option to expected switches
  * common_funcs
    * Function for checking is podman is available
  * build
    * Support for podman when building the operator (cannot yet use it for building other images)
* fix(operator): build script should report all errors if oc version fails
  * If oc available but not logged in, avoid the error being swallowed and ensure its displayed to the user and the build script stop
* Fix(scripts): Remove BuildConfig in build command if using different tag
* Fix(scripts): makes operator build script consistent with previous versions
  * `syndesis build -m operator`
    * -> Client logged into openshift: builds image using s2i
    * -> Client logged into minikube: builds image using docker
    * -> Client not logged in: builds image using docker
  * `syndesis build -m operator -i / --image / --docker
    * -> builds image using docker
* Fix: Corrects failure of database upgrade not scaling correctly
  * awaitScale does not wait correctly for db-upgrade deployment since the status.Replicas starts out as 0 as well as the status.ReadyReplicas.
  * Modifies to test against Spec.Replicas instead which is the expected replica number (1)
  * Updates tests to allow for more complex Deployment check by wrapping & updating the created deployment.
* Fix: Check for a valid url returned when querying github releases