### PR TITLE
chore: Skip syndesis-parent tools assembly with flash option

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -38,6 +38,8 @@
     <!-- should archives of S2I and UI modules be deployed to a Maven repository -->
     <deploy.archives>false</deploy.archives>
 
+    <assembly.skip>false</assembly.skip>
+
     <!-- Atlasmap version -->
     <atlasmap.version>2.0.5</atlasmap.version>
 
@@ -354,7 +356,7 @@
       </modules>
     </profile>
 
-    <!-- Like 'no-checks' but even more aggresive (like even no tests)  -->
+    <!-- Like 'no-checks' but even more aggressive (like even no tests)  -->
     <profile>
       <id>flash</id>
       <activation>
@@ -1187,6 +1189,7 @@
             </goals>
             <inherited>false</inherited>
             <configuration>
+              <skipAssembly>${assembly.skip}</skipAssembly>
               <descriptors>
                 <descriptor>tools.xml</descriptor>
               </descriptors>

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -110,7 +110,7 @@ maven_args() {
     local args="--no-transfer-progress"
 
     if [ $(hasflag --flash -f) ]; then
-        args="$args -Pflash"
+        args="$args -Pflash -Dassembly.skip=true"
     fi
 
     if [ $(hasflag --skip-tests) ]; then

--- a/tools/bin/commands/integration-test
+++ b/tools/bin/commands/integration-test
@@ -34,7 +34,7 @@ maven_args() {
         args="$args clean"
     fi
 
-    args="$args verify"
+    args="$args install"
 
     local tests="$(readopt --test -t)"
     if [ -n "${tests}" ]; then


### PR DESCRIPTION
Maven assembly of `syndesis-parent-tools.jar` is run before each build. When using `--flash` option the tools.jar is not used because all checks are disabled. Adding new `assembly.skip` property and skip the assembly plugin when `--flash` option is given.

This saves me about 45 seconds for each flash build on my machine.