### PR TITLE
fix(build): Allows pushing of images to quay.io

### DIFF
--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -965,7 +965,7 @@
       </build>
     </profile>
 
-    <!-- Profile for pushing a compiled image to a regsitry defined by the system property docker.push.registry -->
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
     <profile>
       <id>image-push</id>
       <activation>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -43,13 +43,17 @@
     <!-- Atlasmap version -->
     <atlasmap.version>2.1.0-M.1</atlasmap.version>
 
+    <!-- Image namespace - can be overridden on cli -->
+    <image.namespace>syndesis</image.namespace>
+    <!-- Image tag - can be overridden on cli -->
+    <image.tag>%l</image.tag>
     <!-- Image names -->
-    <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>
-    <image.s2i.camelk>syndesis/syndesis-s2i-camelk:%l</image.s2i.camelk>
-    <image.server>syndesis/syndesis-server:%l</image.server>
-    <image.meta>syndesis/syndesis-meta:%l</image.meta>
-    <image.ui>syndesis/syndesis-ui:%l</image.ui>
-    <image.dv>syndesis/syndesis-dv:%l</image.dv>
+    <image.s2i>${image.namespace}/syndesis-s2i:${image.tag}</image.s2i>
+    <image.s2i.camelk>${image.namespace}/syndesis-s2i-camelk:${image.tag}</image.s2i.camelk>
+    <image.server>${image.namespace}/syndesis-server:${image.tag}</image.server>
+    <image.meta>${image.namespace}/syndesis-meta:${image.tag}</image.meta>
+    <image.ui>${image.namespace}/syndesis-ui:${image.tag}</image.ui>
+    <image.dv>${image.namespace}/syndesis-dv:${image.tag}</image.dv>
 
     <fabric8.maven.plugin.version>4.2.0</fabric8.maven.plugin.version>
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
@@ -203,7 +207,7 @@
       </build>
     </profile>
 
-    <!-- Profile for pushing a compiled image to a regsitry defined by the system property docker.push.registry -->
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
     <profile>
       <id>image-push</id>
       <activation>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -471,6 +471,9 @@
           <name>::image</name>
         </property>
       </activation>
+      <properties>
+        <fabric8.generator.name>${image.s2i}</fabric8.generator.name>
+      </properties>
       <build>
         <plugins>
 
@@ -511,7 +514,7 @@
 
     </profile>
 
-    <!-- Profile for pushing a compiled image to a regsitry defined by the system property docker.push.registry -->
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
     <profile>
       <id>image-push</id>
       <activation>
@@ -519,6 +522,9 @@
           <name>::image.push</name>
         </property>
       </activation>
+      <properties>
+        <fabric8.generator.name>${image.s2i}</fabric8.generator.name>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -527,10 +533,26 @@
             <executions>
               <execution>
                 <id>push</id>
+                <phase>install</phase>
                 <goals>
                   <goal>push</goal>
                 </goals>
-                <phase>install</phase>
+                <configuration>
+                  <images>
+                    <image>
+                      <name>${image.s2i}</name>
+                      <build>
+                        <!--
+                          Doesn't actually build here but must be present, otherwise
+                          push starts to do a default java-exec type build. So this is
+                          a copy of the build image plugin above
+                        -->
+                        <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                        <contextDir>${image.build.directory}</contextDir>
+                      </build>
+                    </image>
+                  </images>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -983,7 +983,7 @@
       </build>
     </profile>
 
-    <!-- Profile for pushing a compiled image to a regsitry defined by the system property docker.push.registry -->
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
     <profile>
       <id>image-push</id>
       <activation>

--- a/app/test/s2i-camelk/pom.xml
+++ b/app/test/s2i-camelk/pom.xml
@@ -356,7 +356,52 @@
               </execution>
             </executions>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
 
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
+    <profile>
+      <id>image-push</id>
+      <activation>
+        <property>
+          <name>::image.push</name>
+        </property>
+      </activation>
+      <properties>
+        <fabric8.generator.name>${image.s2i.camelk}</fabric8.generator.name>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>fabric8-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>push</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <images>
+                    <image>
+                      <name>${image.s2i.camelk}</name>
+                      <build>
+                        <!--
+                          Doesn't actually build here but must be present, otherwise
+                          push starts to do a default java-exec type build. So this is
+                          a copy of the build image plugin above
+                        -->
+                        <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                        <contextDir>${image.build.directory}</contextDir>
+                      </build>
+                    </image>
+                  </images>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -430,7 +430,7 @@
       </build>
     </profile>
 
-    <!-- Profile for pushing a compiled image to a regsitry defined by the system property docker.push.registry -->
+    <!-- Profile for pushing a compiled image to a registry defined by the system property docker.push.registry -->
     <profile>
       <id>image-push</id>
       <activation>

--- a/tools/bin/commands/build
+++ b/tools/bin/commands/build
@@ -22,9 +22,9 @@ build::usage() {
 -i  --image                    Build container via s2i images (openshift only), too (for those modules creating images)
     --docker                   Create images using docker. Used by CI for pushing to registry (assumed if not using openshift)
     --podman                   Create operator image using podman. (not yet available for other images)
-    --operator-tag             The tag to use for the operator image
-    --operator-image           The image name of the operator (normally, syndesis/syndesis-operator but sometimes need to drop the 'syndesis' prefix)
     --registry                 Registry to push the built images (used in conjunction with --docker / --podman)
+    --image-namespace          The namespace where the images of the images in the registry (syndesis by default)
+    --image-tag                The tag to use for the built images (latest by default)
 -p  --project <project>        Specifies the project / namespace to create images
 -g  --goals <g1>,<g2>, ..      Use custom Maven goals to execute for the build. Default goal is `install`
 -s  --settings <path>          Path to Maven settings.xml
@@ -96,9 +96,7 @@ build::run() {
 
     # Build operator if requested
     if $(should_build "operator" "$modules") && [ "$canbuildop" = "OK" ]; then
-        local optag=$(readopt --operator-tag)
-        local opimage=$(readopt --operator-image)
-        do_operator $top_dir "${optag}" "${opimage}"
+        do_operator $top_dir
     fi
 
     # Build image for upgrade pod if requested
@@ -169,12 +167,22 @@ maven_args() {
         local regarg=""
         if [ "${mode}" == "kubernetes" ] && [ $(hasflag --registry) ]; then
           local registry=$(readopt --registry)
+          local nm=$(readopt --image-namespace)
+
+          # Profile to switch on pushing to registry
           profiles="${profiles},image-push"
           regarg="-Ddocker.push.registry=${registry}"
+          if [ -n "${nm}" ]; then
+              regarg="${regarg} -Dimage.namespace=${nm}"
+          fi
         fi
 
         args="${args} -P ${profiles} -Dfabric8.mode=${mode} ${regarg}"
 
+        local tag=$(readopt --image-tag)
+        if [ -n "${tag}" ]; then
+            args="${args} -Dimage.tag=${tag} "
+        fi
     fi
 
     if [ $(hasflag --camel-snapshot) ]; then
@@ -230,9 +238,7 @@ maven_args() {
 }
 
 do_operator() {
-    local top_dir=$1
-    local tag=${2:-}
-    local image=${3:-}
+    local top_dir="${1}"
 
     echo "=============================================================================="
     echo "Building syndesis-operator"
@@ -246,10 +252,12 @@ do_operator() {
         args="$args --source-gen ${source_gen}"
     fi
 
-    if [ -n "${image}" ]; then
-        args="${args} --image-name=${image}"
+    local image_namespace=$(readopt --image-namespace)
+    if [ -n "${image_namespace}" ]; then
+        args="${args} --image-namespace=${image_namespace}"
     fi
 
+    local tag=$(readopt --image-tag)
     if [ -n "${tag}" ]; then
         args="${args} --image-tag=${tag}"
     fi


### PR DESCRIPTION
* commands/build
* build.sh
* .lib.sh
 * Removes operator-image-name parameter as not necessary
 * Adds image-namespace parameter so can be modified, eg. set namespace as
   user-id -> quay.io/phantomjinx/syndesis-operator
 * Splits image-namespace from image-name so former can be modified
 * Full operator image name: registry/namespace/image-name
 * Passes the image.tag into maven builds so correct tag is built and pushed

* app/pom.xml
 * Modifies image-name properties to expose both namespace & tag

* s2i/pom.xml
 * Extra config needed to ensure fabric8 pushes the correct named image