### PR TITLE
apicurio: 1.1.2 -> 1.1.4

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2839,7 +2839,7 @@
       <dependency>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-data-models</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.4</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
I'm suffering from this: https://github.com/Apicurio/apicurio-data-models/pull/158
See also: https://github.com/Apicurio/apicurio-data-models/releases/tag/1.1.4