### PR TITLE
[backport 1.11.x] chore(dependencies): resteasy and persistence-api latest dependency upgrade

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/openapi/CapturingCodec.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/openapi/CapturingCodec.java
@@ -79,7 +79,7 @@ final class CapturingCodec extends ObjectCodec {
 
     @Override
     @SuppressWarnings("TypeParameterUnusedInFormals")
-    public <T> T readValue(final JsonParser p, final TypeReference<?> valueTypeRef) throws IOException {
+    public <T> T readValue(final JsonParser p, final TypeReference<T> valueTypeRef) throws IOException {
         final T ret = delegate.readValue(p, valueTypeRef);
         captured = ret;
 
@@ -103,8 +103,8 @@ final class CapturingCodec extends ObjectCodec {
     }
 
     @Override
-    public <T> Iterator<T> readValues(final JsonParser p, final TypeReference<?> valueTypeRef) throws IOException {
-        final Iterator<T> ret = delegate.readValue(p, valueTypeRef);
+    public <T> Iterator<T> readValues(final JsonParser p, final TypeReference<T> valueTypeRef) throws IOException {
+        final Iterator<T> ret = delegate.readValues(p, valueTypeRef);
         captured = ret;
 
         return ret;

--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -131,7 +131,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -157,7 +157,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
     </dependency>
 
     <dependency>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -488,6 +488,18 @@
         </executions>
       </plugin>
 
+      <!-- Resteasy dependency has a duplication in org.jboss.resteasy:resteasy-client:4.5.6.Final and org.jboss.resteasy:resteasy-client-api:4.5.6.Final -->
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredResourcePatterns>
+            <ignoredResourcePattern>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_en.properties</ignoredResourcePattern>
+            <ignoredResourcePattern>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_xx.properties</ignoredResourcePattern>
+          </ignoredResourcePatterns>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/VerifierExceptionMapper.java
@@ -59,7 +59,7 @@ public class VerifierExceptionMapper implements ExceptionMapper<Throwable> {
     public Response toResponse(final Throwable exception) {
         // the proxy @Context would provide would not let us access the wrapped
         // request
-        final HttpServletRequest request = ResteasyProviderFactory.getContextData(HttpServletRequest.class);
+        final HttpServletRequest request = ResteasyProviderFactory.getInstance().getContextData(HttpServletRequest.class);
 
         LOG.error("Exception while handling request: {} {}", request.getMethod(), request.getRequestURI(), exception);
         if (LOG.isDebugEnabled()) {

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -147,8 +147,8 @@
     <mongodb.version>3.9.0</mongodb.version>
 
     <spring-security.version>5.2.1.RELEASE</spring-security.version>
-    <resteasy.version>3.6.1.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>2.0.1.Final</resteasy-spring-boot-starter.version>
+    <resteasy.version>4.5.6.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>4.6.1.Final</resteasy-spring-boot-starter.version>
 
     <immutables.version>2.8.1</immutables.version>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -58,7 +58,7 @@
 
     <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
 
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.11.1</jackson.version>
     <json-patch.version>1.9</json-patch.version>
     <kubernetes.client.version>4.6.1</kubernetes.client.version>
 
@@ -1758,6 +1758,10 @@
         <version>${resteasy.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1769,21 +1773,13 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
           </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs</artifactId>
-        <version>${resteasy.version}</version>
-        <exclusions>
           <exclusion>
-            <groupId>org.jboss.spec.javax.xml.bind</groupId>
-            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1805,6 +1801,18 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1816,6 +1824,62 @@
           <exclusion>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-core-spi</artifactId>
+        <version>${resteasy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-client</artifactId>
+        <version>${resteasy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jackson2-provider</artifactId>
+        <version>${resteasy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -304,7 +304,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkedProcessTimeoutInSeconds>180</forkedProcessTimeoutInSeconds>
+          <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
         </configuration>
       </plugin>
       <!-- CXF has a couple of duplicate resources across both it's own and wss4j dependencies -->

--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -222,7 +222,13 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/dao/pom.xml
+++ b/app/server/dao/pom.xml
@@ -75,6 +75,7 @@
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <version>1.0.0.Final</version>
     </dependency>
 
     <dependency>
@@ -113,6 +114,7 @@
       <!-- We need the net.jcip.annotations.GuardedBy for Infinispan (at compile time only) -->
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/app/server/dao/pom.xml
+++ b/app/server/dao/pom.xml
@@ -73,9 +73,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -209,9 +209,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -165,7 +165,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
     </dependency>
 
     <dependency>
@@ -211,6 +211,7 @@
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <version>1.0.0.Final</version>
     </dependency>
 
     <dependency>

--- a/app/server/metrics/prometheus/pom.xml
+++ b/app/server/metrics/prometheus/pom.xml
@@ -63,11 +63,6 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
 

--- a/app/server/metrics/prometheus/pom.xml
+++ b/app/server/metrics/prometheus/pom.xml
@@ -113,7 +113,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
@@ -60,7 +60,7 @@ public class HttpClient {
 
         resteasyJacksonProvider.setMapper(mapper);
 
-        final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
+        final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
         providerFactory.register(resteasyJacksonProvider);
 
         final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
@@ -17,16 +17,14 @@ package io.syndesis.server.metrics.prometheus;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MediaType;
+
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-
-import java.util.concurrent.TimeUnit;
 
 public class HttpClient {
 
@@ -63,10 +61,8 @@ public class HttpClient {
         final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
         providerFactory.register(resteasyJacksonProvider);
 
-        final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);
-
         return ClientBuilder.newBuilder()
-            .withConfig(configuration)
+            .withConfig(providerFactory.getConfiguration())
             .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
             .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
             .build();

--- a/app/server/pom.xml
+++ b/app/server/pom.xml
@@ -60,6 +60,22 @@
     <module>metrics/prometheus</module>
   </modules>
 
+  <build>
+    <plugins>
+      <!-- Resteasy dependency has a duplication in org.jboss.resteasy:resteasy-client:4.5.6.Final and org.jboss.resteasy:resteasy-client-api:4.5.6.Final -->
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredResourcePatterns>
+            <ignoredResourcePattern>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_en.properties</ignoredResourcePattern>
+            <ignoredResourcePattern>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_xx.properties</ignoredResourcePattern>
+          </ignoredResourcePatterns>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
 
     <profile>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -876,9 +876,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <version>1.0.0.Final</version>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -669,7 +669,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-validator-provider-11</artifactId>
+      <artifactId>resteasy-validator-provider</artifactId>
     </dependency>
 
     <dependency>
@@ -684,7 +684,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
     </dependency>
 
     <dependency>
@@ -878,6 +878,7 @@
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <version>1.0.0.Final</version>
     </dependency>
 
     <dependency>

--- a/app/server/update-controller/pom.xml
+++ b/app/server/update-controller/pom.xml
@@ -102,6 +102,7 @@
       <!-- We need the net.jcip.annotations.GuardedBy for Infinispan (at compile time only) -->
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -82,12 +82,7 @@
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
+      <artifactId>resteasy-core-spi</artifactId>
     </dependency>
 
     <dependency>
@@ -99,7 +94,14 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-core</artifactId>
+      <version>${resteasy.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -95,6 +95,13 @@
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
 
+    <!-- required by resteasy-jackson2-provider -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
@@ -15,21 +15,19 @@
  */
 package io.syndesis.server.verifier;
 
-import java.util.List;
-import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import org.jboss.resteasy.client.jaxrs.internal.LocalResteasyProviderFactory;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -67,12 +65,10 @@ public class ExternalVerifierService implements Verifier {
 
             resteasyJacksonProvider.setMapper(mapper);
 
-            final ResteasyProviderFactory providerFactory = new ResteasyProviderFactory();
+            final ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
             providerFactory.register(resteasyJacksonProvider);
 
-            final Configuration configuration = new LocalResteasyProviderFactory(providerFactory);
-
-            this.client = ClientBuilder.newClient(configuration);
+            this.client = ClientBuilder.newClient(providerFactory);
         }
 
     }

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -310,6 +310,8 @@
             <ignore>com/consol/citrus/schema/citrus-config-${citrus.version}.xsd</ignore>
             <ignore>com/consol/citrus/schema/citrus-testcase.xsd</ignore>
             <ignore>com/consol/citrus/schema/citrus-testcase-${citrus.version}.xsd</ignore>
+            <ignore>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_en.properties</ignore>
+            <ignore>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_xx.properties</ignore>
           </ignoredResourcePatterns>
         </configuration>
       </plugin>

--- a/app/test/pom.xml
+++ b/app/test/pom.xml
@@ -41,6 +41,17 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <!-- Resteasy dependency has a duplication in org.jboss.resteasy:resteasy-client:4.5.6.Final and org.jboss.resteasy:resteasy-client-api:4.5.6.Final -->
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration>
+          <ignoredResourcePatterns>
+            <ignore>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_en.properties</ignore>
+            <ignore>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_xx.properties</ignore>
+          </ignoredResourcePatterns>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
* Bumped jackson libraries to 2.11.1 as resteasy depends on this one
* Adding exclusions with libraries clashing due to duplication
* Fixed a few classes for compilation failures due to jackson and resteasy new dependencies

Closes ENTESB-14310

* use javax.persistence-api instead of hibernate-jpa-2.1-api

Closes ENTESB-10680