### PR TITLE
fix: use productized db image for initPod

### DIFF
--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -61,7 +61,7 @@ Syndesis:
             Name: "syndesis"
             User: "syndesis"
             URL: "postgresql://syndesis-db:5432/syndesis?sslmode=disable"
-            Image: "centos/postgresql-96-centos7"
+            Image: "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"
             Exporter:
                 Image: "docker.io/wrouesnel/postgres_exporter:v0.4.7"
             Resources:

--- a/install/operator/pkg/cmd/internal/install/install_defaults.go
+++ b/install/operator/pkg/cmd/internal/install/install_defaults.go
@@ -1,3 +1,3 @@
 package install
 
-const defaultDatabaseImage = "centos/postgresql-96-centos7"
+const defaultDatabaseImage = "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"


### PR DESCRIPTION
When we build in fuseonline we dont generate the assets, therefore this file needs to contains the final db productized image. Source: https://github.com/jboss-fuse/fuse-online-operator/blob/private-devel-fuse-7.7-openshift-rhel-7/Dockerfile#L14

Signed-off-by: Luis Garcia Acosta <lgarciaac@gmail.com>