### PR TITLE
refactor: implement multi-stage build

### DIFF
--- a/install/operator/build.sh
+++ b/install/operator/build.sh
@@ -26,16 +26,16 @@ add_to_trap "print_error ${ERROR_FILE}"
 #
 trap "process_trap" EXIT
 
-IMAGE_NAME="syndesis-operator"
+export IMAGE_NAME="syndesis-operator"
 
-CONTAINER_REGISTRY="$(readopt  --registry           docker.io)"
-IMAGE_NAMESPACE="$(readopt     --image-namespace    syndesis)"
-IMAGE_TAG="$(readopt           --image-tag          latest)"
+export CONTAINER_REGISTRY="$(readopt  --registry           docker.io)"
+export IMAGE_NAMESPACE="$(readopt     --image-namespace    syndesis)"
+export IMAGE_TAG="$(readopt           --image-tag          latest)"
 S2I_STREAM_NAME="$(readopt     --s2i-stream-name    syndesis-operator)"
 OPERATOR_BUILD_MODE="$(readopt --operator-build     auto)"
 IMAGE_BUILD_MODE="$(readopt    --image-build        auto)"
 SOURCE_GEN="$(readopt          --source-gen         on)"
-GO_BUILD_OPTIONS="$(readopt    --go-options         '')"
+export GO_BUILD_OPTIONS="$(readopt    --go-options         '')"
 GO_PROXY_URL="$(readopt        --go-proxy           https://proxy.golang.org)"
 
 if [[ -n "$(readopt --help)" ]] ; then
@@ -62,22 +62,12 @@ fi
 #
 # Timestamp for the building of the operator
 #
-BUILD_TIME=$(date +%Y-%m-%dT%H:%M:%S%z)
-
-# Custom registry needs to be injected into the operator so that
-# the image coordinate in the operator resource can be rendered
-# pointing to the registry
-#
-FULL_OPERATOR_IMAGE_NAME="${CONTAINER_REGISTRY}/${IMAGE_NAMESPACE}/${IMAGE_NAME}"
+export BUILD_TIME=$(date +%Y-%m-%dT%H:%M:%S%z)
 
 if [ $OPERATOR_BUILD_MODE != "skip" ] ; then
-	LD_FLAGS=$(echo "-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorImage=${FULL_OPERATOR_IMAGE_NAME}" \
-		"-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorTag=${IMAGE_TAG}" \
-		"-X github.com/syndesisio/syndesis/install/operator/pkg.BuildDateTime=${BUILD_TIME}")
-	echo "LD_FLAGS: ${LD_FLAGS}"
-  build_operator $OPERATOR_BUILD_MODE "$SOURCE_GEN" "$GO_PROXY_URL" -ldflags "${LD_FLAGS}" $GO_BUILD_OPTIONS
+  build_operator $OPERATOR_BUILD_MODE "$SOURCE_GEN" "$GO_PROXY_URL"
 fi
 
 if [ $IMAGE_BUILD_MODE != "skip" ] ; then
-  build_image $IMAGE_BUILD_MODE $CONTAINER_REGISTRY $IMAGE_NAMESPACE $IMAGE_NAME $IMAGE_TAG $S2I_STREAM_NAME
+  build_image $IMAGE_BUILD_MODE $S2I_STREAM_NAME
 fi

--- a/install/operator/build/Dockerfile
+++ b/install/operator/build/Dockerfile
@@ -1,11 +1,48 @@
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+# ------------
+# Builder
+# ------------
+FROM golang:1.13.7 as builder
+
+ARG GO_BUILD_OPTIONS=
+ARG CONTAINER_REGISTRY=docker.io
+ARG IMAGE_NAMESPACE=syndesis
+ARG IMAGE_NAME=syndesis-operator
+ARG IMAGE_TAG=latest
+ARG BUILD_TIME=
+
+ENV OPERATOR="github.com/syndesisio/syndesis/install/operator"
+ENV GO111MODULE=on
+ENV LDFLAGS="-X ${OPERATOR}/pkg.DefaultOperatorImage=${CONTAINER_REGISTRY}/${IMAGE_NAMESPACE}/${IMAGE_NAME} -X ${OPERATOR}/pkg.DefaultOperatorTag=${IMAGE_TAG} ${LDFLAGS} -X ${OPERATOR}/pkg.BuildDateTime=${BUILD_TIME}"
+
+WORKDIR /go/src/${OPERATOR}
+
+COPY . .
+RUN go generate ./pkg/...
+RUN go test -test.short -mod=vendor ./cmd/... ./pkg/...
+
+# Build syndesis-operator binary
+RUN go build -ldflags "${LDFLAGS}" ${GO_BUILD_OPTIONS} \
+    -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} \
+    -o out/syndesis-operator \
+    -mod=vendor ${OPERATOR}/cmd/manager
+
+# Build platform-detect binary
+RUN go build -ldflags "${LDFLAGS}" ${GO_BUILD_OPTIONS} \
+    -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} \
+    -o out/platform-detect \
+    -mod=vendor ${OPERATOR}/cmd/detect
+
+# ------------
+# Runner
+# ------------
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest as runner
 
 ENV OPERATOR=/usr/local/bin/syndesis-operator \
     USER_UID=1001 \
     USER_NAME=operator
 
 # install operator binary
-COPY build/_output/bin/syndesis-operator ${OPERATOR}
+COPY --from=builder /go/src/github.com/syndesisio/syndesis/install/operator/out/syndesis-operator ${OPERATOR}
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 USER ${USER_UID}


### PR DESCRIPTION
- enables skaffold based workflows
- the multi-arch control flow needed to be extracted out of the container, which blowed up the changeset

Unblocks https://github.com/xoe-labs/syndesis/pull/1

/cc @phantomjinx 

For speed go generate and got test should be taken out of the container, however we need to guarantee existence of a go in path, which we can do with shell.nix - Once that PR is accepted a whole lot of current complexities evaporate into joyful in-existence.