### PR TITLE
fix(ENTESB-13779): Fix connector-odata-v2 unit test

### DIFF
--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataRouteTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataRouteTest.java
@@ -49,6 +49,7 @@ public abstract class AbstractODataRouteTest extends AbstractODataTest {
     protected static final String REF_SERVER_PRODUCT_DATA_2 = "ref-server-product-data-2.json";
     protected static final String REF_SERVER_PRODUCT_DATA_2_WITH_COUNT = "ref-server-product-data-2-with-count.json";
     protected static final String REF_SERVER_SUPPLIER_DATA_1 = "ref-server-supplier-data-1.json";
+    protected static final String REF_SERVER_SUPPLIER_DATA_2 = "ref-server-supplier-data-2.json";
     protected static final String REF_SERVER_SUPPLIER_DATA_1_EXPANDED = "ref-server-supplier-data-1-expanded.json";
     protected static final String REF_SERVER_SUPPLIER_DATA_1_ADDRESS = "ref-server-supplier-data-1-address.json";
     protected static final String REF_SERVER_SUPPLIER_DATA_1_ADDRESS_STREET = "ref-server-supplier-data-1-address-street.json";

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
@@ -586,7 +586,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         RouteBuilder routes = newIntegrationRouteBuilder(odataIntegration);
         context.addRoutes(routes);
 
-        int expectedMsgCount = 1;
+        int expectedMsgCount = 2;
         MockEndpoint result = initMockEndpoint();
         result.setExpectedMessageCount(expectedMsgCount);
 
@@ -597,6 +597,11 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
         String expected = testData(REF_SERVER_SUPPLIER_DATA_1);
+        assertThatJson(json).isEqualTo(expected);
+
+        json = extractJsonFromExchgMsg(result, 1, String.class);
+        assertNotNull(json);
+        expected = testData(REF_SERVER_SUPPLIER_DATA_2);
         assertThatJson(json).isEqualTo(expected);
 
         //

--- a/app/connector/odata-v2/src/test/resources/io/syndesis/connector/odata2/consumer/ref-server-supplier-data-2.json
+++ b/app/connector/odata-v2/src/test/resources/io/syndesis/connector/odata2/consumer/ref-server-supplier-data-2.json
@@ -1,0 +1,12 @@
+{
+  "Address": {
+    "State": "WA",
+    "ZipCode": "98052",
+    "Street": "NE 40th",
+    "Country": "USA",
+    "City": "Redmond"
+  },
+  "Concurrency": 0,
+  "ID": 1,
+  "Name": "Tokyo Traders"
+}


### PR DESCRIPTION
Make sure to check for all split data returned from results. Was causing daily-release-build to fail.