### PR TITLE
(backport-1.11.x) Added DataTestIds for ApiConnectorDetalConfig page

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
@@ -36,7 +36,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelName}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
+            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-name'}>
               {properties.name}
             </TextListItem>
           </>
@@ -46,7 +46,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelDescription}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
+            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-description'}>
               {properties.description}
             </TextListItem>
           </>
@@ -56,7 +56,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelHost}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
+            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-host'}>
               {properties.host}
             </TextListItem>
           </>
@@ -66,7 +66,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelBaseUrl}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
+            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-path'}>
               {properties.basePath}
             </TextListItem>
           </>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
@@ -75,10 +75,13 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
           validated={isValid}
         />
       </FormGroup>
-      <FormGroup label={i18nLabelDescription} fieldId="connector-description">
+      <FormGroup 
+        label={i18nLabelDescription} 
+        fieldId="connector-description">
         <TextArea
           value={properties.description}
           onChange={onChange}
+          data-testid={'api-connector-description-field'}
           name="description"
           id="connector-description"
         />
@@ -93,6 +96,7 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
           isRequired={false}
           type="text"
           id="connector-host"
+          data-testid={'api-connector-host-field'}
           aria-describedby="horizontal-form-host-helper"
           name="host"
           onChange={onChange}
@@ -108,6 +112,7 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
           isRequired={false}
           type="text"
           id="connector-baseurl"
+          data-testid={'api-connector-baseurl-field'}
           aria-describedby="horizontal-form-baseurl-helper"
           name="basePath"
           onChange={onChange}


### PR DESCRIPTION
DataTestIds for ApiConnectorDetalConfig page
backport for https://github.com/syndesisio/syndesis/pull/8994 