### PR TITLE
#8950: Enable OLM installation of camel-k

### DIFF
--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -30,7 +30,10 @@ Syndesis:
             Resources:
                 Memory: "1024Mi"
         CamelK:
-            Enabled: false
+            Enabled: true
+            Olm:
+                Package: "camel-k"
+                Channel: "stable"
             Image: "fabric8/s2i-java:3.0-java8"
             CamelVersion: "3.3.0"
             CamelKRuntime: "1.3.0"


### PR DESCRIPTION
* First step towards default installation of camel-k
 ** Set Enabled flag to ALWAYS install camel-k addon
 ** Adds Olm stanza that will create a subscription to the
    community-operator camel-k 1.1.0.
 ** If a later version is required then first need to create a catalog
    source that targets appropriately