### PR TITLE
upgrade jackson to 2.11 and disable default data typing

### DIFF
--- a/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -58,7 +59,8 @@ public final class JsonUtils {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
                 .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
-                .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+                .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE)
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES);
         OBJECT_READER = OBJECT_MAPPER.reader();
         OBJECT_WRITER = OBJECT_MAPPER.writer();
     }

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -30,7 +30,7 @@
     <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
     <camel.version>3.3.0</camel.version>
     <atlasmap.version>2.1.0-M.1</atlasmap.version>
-    <jackson.databind.version>2.10.0.pr1</jackson.databind.version>
+    <jackson.databind.version>2.11.2</jackson.databind.version>
   </properties>
 
   <!-- Metadata need to publish to central -->

--- a/app/meta/src/main/java/io/syndesis/connector/meta/JacksonContextResolver.java
+++ b/app/meta/src/main/java/io/syndesis/connector/meta/JacksonContextResolver.java
@@ -15,15 +15,17 @@
  */
 package io.syndesis.connector.meta;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import org.springframework.stereotype.Component;
-
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.springframework.stereotype.Component;
 
 @Provider
 @Component
@@ -31,7 +33,9 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
     private final ObjectMapper objectMapper;
 
     public JacksonContextResolver() {
-        this.objectMapper = new ObjectMapper()
+        this.objectMapper = JsonMapper.builder()
+            .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+            .build()
             .registerModule(new Jdk8Module())
             .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
             .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/HttpClient.java
@@ -20,7 +20,9 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -52,7 +54,10 @@ public class HttpClient {
     // ************
 
     private static Client createClient() {
-        final ObjectMapper mapper = new ObjectMapper().registerModules(new Jdk8Module());
+        final ObjectMapper mapper = JsonMapper.builder()
+            .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+            .build()
+            .registerModules(new Jdk8Module());
         final ResteasyJackson2Provider resteasyJacksonProvider = new ResteasyJackson2Provider();
 
         resteasyJacksonProvider.setMapper(mapper);

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/Utils.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/Utils.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -44,6 +45,7 @@ public final class Utils {
 
     static {
         ObjectMapper objectMapper = new ObjectMapper()
+            .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
             .registerModules(new Jdk8Module(), new EpochMillisTimeModule(), new JavaTimeModule())
             .setPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY))
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -31,7 +31,6 @@
 
   <properties>
     <basepom.test.timeout>300</basepom.test.timeout>
-    <basepom.test.timeout>150</basepom.test.timeout>
     <basepom.failsafe.timeout>0</basepom.failsafe.timeout>
     <failOnMissingWebXml>false</failOnMissingWebXml>
 
@@ -218,6 +217,13 @@
           <prettyPrint>true</prettyPrint>
           <outputFormat>JSONANDYAML</outputFormat>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>internal-openapi</id>

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/ExternalVerifierService.java
@@ -26,6 +26,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
@@ -60,7 +61,9 @@ public class ExternalVerifierService implements Verifier {
     @PostConstruct
     public void init() {
         if (this.client == null) {
-            final ObjectMapper mapper = new ObjectMapper().registerModules(new Jdk8Module());
+            final ObjectMapper mapper = new ObjectMapper()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .registerModules(new Jdk8Module());
             final ResteasyJackson2Provider resteasyJacksonProvider = new ResteasyJackson2Provider();
 
             resteasyJacksonProvider.setMapper(mapper);

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -28,6 +28,10 @@
   <artifactId>test-support</artifactId>
   <name>Test :: Support</name>
 
+  <properties>
+    <basepom.test.timeout>300</basepom.test.timeout>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/install/operator/deploy/crds/syndesis.io_syndesis_crd.yaml
+++ b/install/operator/deploy/crds/syndesis.io_syndesis_crd.yaml
@@ -522,8 +522,6 @@ spec:
                           volumeCapacity:
                             type: string
                         type: object
-                      rules:
-                        type: string
                     type: object
                   server:
                     properties:


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-14584

There was an upgrade to resteasy 4.5 that requires jackson 2.11

https://github.com/syndesisio/syndesis/pull/8921

If there is any need to allow classes to be deserialized using Default Typing, it should be activated with Default Typing and setting a custom PolymorphicTypeValidator.