### PR TITLE
fix(ENTESB-13779): Add entity provider write properties

### DIFF
--- a/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEmailTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEmailTest.java
@@ -24,13 +24,16 @@ import org.apache.camel.component.properties.PropertiesParser;
 import org.apache.camel.spring.SpringCamelContext;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.PropertyResolver;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-public class AbstractEmailTest implements EMailConstants {
+@RunWith(SpringJUnit4ClassRunner.class)
+public abstract class AbstractEmailTest implements EMailConstants {
 
     protected static final String NO_HOST = "not.a.running.host";
     protected static final String TEST_USER_NAME = "bob";
@@ -59,10 +62,6 @@ public class AbstractEmailTest implements EMailConstants {
     @Autowired
     private ApplicationContext applicationContext;
     protected CamelContext context;
-
-    public AbstractEmailTest() {
-        super();
-    }
 
     /**
      * Creates a camel context complete with a properties component that handles

--- a/app/connector/flow/pom.xml
+++ b/app/connector/flow/pom.xml
@@ -35,12 +35,6 @@
       <artifactId>camel-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>spi-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>

--- a/app/connector/kudu/pom.xml
+++ b/app/connector/kudu/pom.xml
@@ -124,13 +124,6 @@
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
 
-        <!-- Camel annotations in provided scope to avoid compile errors in IDEs -->
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>spi-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>

--- a/app/connector/odata-v2/src/main/resources/META-INF/syndesis/connector/odata-v2.json
+++ b/app/connector/odata-v2/src/main/resources/META-INF/syndesis/connector/odata-v2.json
@@ -270,7 +270,7 @@
         "propertyDefinitionSteps": [
           {
             "description": "Provide the resource on which to create data",
-            "name": "Resource Path",
+            "name": "Resource",
             "properties": {
               "resourcePath": {
                 "deprecated": false,
@@ -283,6 +283,45 @@
                 "required": true,
                 "secret": false,
                 "type": "string"
+              },
+              "contentOnly": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Content only",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Send content only in resource request. Excludes content metadata and etag from request.",
+                "order": "2",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitEtag": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit ETag",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit ETag.",
+                "order": "3",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitJsonWrapper": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit Json wrapper",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit Json wrapper that is added to the request data as surrounding Json object.",
+                "order": "4",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
               }
             }
           }
@@ -315,7 +354,7 @@
         "propertyDefinitionSteps": [
           {
             "description": "Provide the resource on which to update the data",
-            "name": "Resource Path",
+            "name": "Resource",
             "properties": {
               "resourcePath": {
                 "deprecated": false,
@@ -328,6 +367,45 @@
                 "required": true,
                 "secret": false,
                 "type": "string"
+              },
+              "contentOnly": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Content only",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Send content only in resource request. Excludes content metadata and etag from request.",
+                "order": "2",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitEtag": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit ETag",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit ETag.",
+                "order": "3",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitJsonWrapper": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit Json wrapper",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit Json wrapper that is added to the request data as surrounding Json object.",
+                "order": "4",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
               }
             }
           }

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
@@ -403,7 +403,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         result.assertIsSatisfied();
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
-        String expected = testData(TEST_SERVER_DATA_1);
+        String expected = testData(TEST_SERVER_DATA_1_WITH_COUNT);
         assertThatJson(json).isEqualTo(expected);
     }
 

--- a/app/connector/soap/pom.xml
+++ b/app/connector/soap/pom.xml
@@ -142,6 +142,7 @@
     <dependency>
       <groupId>jakarta.xml.soap</groupId>
       <artifactId>jakarta.xml.soap-api</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
-    <camel.version>3.3.0</camel.version>
+    <camel.version>3.5.0</camel.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/integration/bom-camel-k/pom.xml
+++ b/app/integration/bom-camel-k/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <camel.version>3.3.0</camel.version>
+    <camel.version>3.5.0</camel.version>
     <atlasmap.version>2.0.5</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <validation-api.version>2.0.2</validation-api.version>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.2.6.RELEASE</spring-boot.version>
-    <camel.version>3.3.0</camel.version>
+    <camel.version>3.5.0</camel.version>
     <atlasmap.version>2.1.0-M.2</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -893,10 +893,6 @@
                     <groupId>org.apache.camel</groupId>
                     <artifactId>camel-api</artifactId>
                   </dependency>
-                  <dependency>
-                    <groupId>org.apache.camel</groupId>
-                    <artifactId>spi-annotations</artifactId>
-                  </dependency>
                 </conflictingDependencies>
                 <packages>
                   <package>org.apache.camel.spi</package>
@@ -1352,8 +1348,16 @@
             <artifactId>javax.xml.soap-api</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -1408,6 +1412,10 @@
         <version>${cxf.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>
           </exclusion>
@@ -1460,6 +1468,14 @@
         <version>${cxf.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>*</artifactId>
           </exclusion>
@@ -1471,6 +1487,14 @@
         <artifactId>cxf-rt-rs-client</artifactId>
         <version>${cxf.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>*</artifactId>
@@ -1484,6 +1508,14 @@
         <version>${cxf.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>*</artifactId>
           </exclusion>
@@ -1495,6 +1527,10 @@
         <artifactId>cxf-rt-rs-extension-providers</artifactId>
         <version>${cxf.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>*</artifactId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -100,7 +100,7 @@
     <opentracing.spring.web.starter.version>3.0.0</opentracing.spring.web.starter.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>3.3.0</camel.version>
+    <camel.version>3.5.0</camel.version>
     <camel-k-runtime.version>1.3.0</camel-k-runtime.version>
 
     <undertow.version>2.0.30.Final</undertow.version>


### PR DESCRIPTION
Some OData V2 services do explicitly support content only payloads so we need to skip wrappers and metadata from Json payloads. Let user specify write properties such as contentOnly, omitEtag and omitJsonWrapper. This enables us to control the marshalled Json payloads when updating OData entries.

Update Camel dependency to latest 3.5.0 version as this contains the OData olingo2 component that supports custom entity provider write properties.