### PR TITLE
[Backport-1.11.x] fix(ENTESB-13779): Add entity provider write properties

### DIFF
--- a/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/component/ODataComponent.java
+++ b/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/component/ODataComponent.java
@@ -18,6 +18,13 @@ package io.syndesis.connector.odata2.component;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import io.syndesis.connector.odata2.ODataConstants;
+import io.syndesis.connector.odata2.ODataUtil;
+import io.syndesis.connector.support.util.ConnectorOptions;
+import io.syndesis.connector.support.util.PropertyBuilder;
+import io.syndesis.integration.component.proxy.ComponentDefinition;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import org.apache.camel.Component;
 import org.apache.camel.Endpoint;
 import org.apache.camel.component.olingo2.Olingo2AppEndpointConfiguration;
@@ -25,14 +32,9 @@ import org.apache.camel.component.olingo2.Olingo2Component;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import io.syndesis.connector.odata2.ODataConstants;
-import io.syndesis.connector.odata2.ODataUtil;
-import io.syndesis.connector.support.util.ConnectorOptions;
-import io.syndesis.connector.support.util.PropertyBuilder;
-import io.syndesis.integration.component.proxy.ComponentDefinition;
-import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import org.apache.olingo.odata2.api.ep.EntityProviderWriteProperties;
 
-@SuppressWarnings("PMD.GodClass") // TODO refactor
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyFields"}) // TODO refactor
 public final class ODataComponent extends ComponentProxyComponent implements ODataConstants {
 
     /**
@@ -64,6 +66,11 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
     private int backoffIdleThreshold = -1;
     private int backoffMultiplier = -1;
     private boolean splitResult;
+
+    // Producer properties
+    private boolean contentOnly;
+    private boolean omitJsonWrapper;
+    private boolean omitEtag;
 
     ODataComponent(String componentId, String componentScheme) {
         super(componentId, componentScheme);
@@ -165,6 +172,30 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
         this.splitResult = splitResult;
     }
 
+    public boolean isContentOnly() {
+        return contentOnly;
+    }
+
+    public void setContentOnly(boolean contentOnly) {
+        this.contentOnly = contentOnly;
+    }
+
+    public boolean isOmitJsonWrapper() {
+        return omitJsonWrapper;
+    }
+
+    public void setOmitJsonWrapper(boolean omitJsonWrapper) {
+        this.omitJsonWrapper = omitJsonWrapper;
+    }
+
+    public boolean isOmitEtag() {
+        return omitEtag;
+    }
+
+    public void setOmitEtag(boolean omitEtag) {
+        this.omitEtag = omitEtag;
+    }
+
     public String getConnectorDirection() {
         return connectorDirection;
     }
@@ -174,7 +205,7 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
     }
 
     private Map<String, Object> bundleOptions(Map<String, Object> options) {
-        PropertyBuilder<Object> builder = new PropertyBuilder<Object>();
+        PropertyBuilder<Object> builder = new PropertyBuilder<>();
 
         for (Map.Entry<String, Object> option : options.entrySet()) {
             builder.propertyIfNotNull(option.getKey(), option.getValue());
@@ -248,9 +279,28 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
             configuration.setFilterAlreadySeen(isFilterAlreadySeen());
         }
 
+        if (shouldSetEntityProviderWriteProperties(method)) {
+            EntityProviderWriteProperties entityProviderWriteProperties = EntityProviderWriteProperties.serviceRoot(null)
+                .contentOnly(contentOnly)
+                .omitETag(omitEtag)
+                .omitJsonWrapper(omitJsonWrapper).build();
+            configuration.setEntityProviderWriteProperties(entityProviderWriteProperties);
+        }
+
         Olingo2Component component = new Olingo2Component(getCamelContext());
         component.setConfiguration(configuration);
         return Optional.of(component);
+    }
+
+    /**
+     * Set custom entity provider write properties for create/merge operation
+     * and when values differing from defaults.
+     * @param method current connector action method.
+     * @return true if entity provider write properties should be set for given method.
+     */
+    private boolean shouldSetEntityProviderWriteProperties(Methods method) {
+        return (Methods.CREATE.equals(method) || Methods.MERGE.equals(method))
+            && (contentOnly || omitJsonWrapper || omitEtag);
     }
 
     private void configureResourcePath(Olingo2AppEndpointConfiguration configuration, Map<String, Object> options) {

--- a/app/connector/odata-v2/src/main/resources/META-INF/syndesis/connector/odata-v2.json
+++ b/app/connector/odata-v2/src/main/resources/META-INF/syndesis/connector/odata-v2.json
@@ -270,7 +270,7 @@
         "propertyDefinitionSteps": [
           {
             "description": "Provide the resource on which to create data",
-            "name": "Resource Path",
+            "name": "Resource",
             "properties": {
               "resourcePath": {
                 "deprecated": false,
@@ -283,6 +283,45 @@
                 "required": true,
                 "secret": false,
                 "type": "string"
+              },
+              "contentOnly": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Content only",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Send content only in resource request. Excludes content metadata and etag from request.",
+                "order": "2",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitEtag": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit ETag",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit ETag.",
+                "order": "3",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitJsonWrapper": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit Json wrapper",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit Json wrapper that is added to the request data as surrounding Json object.",
+                "order": "4",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
               }
             }
           }
@@ -315,7 +354,7 @@
         "propertyDefinitionSteps": [
           {
             "description": "Provide the resource on which to update the data",
-            "name": "Resource Path",
+            "name": "Resource",
             "properties": {
               "resourcePath": {
                 "deprecated": false,
@@ -328,6 +367,45 @@
                 "required": true,
                 "secret": false,
                 "type": "string"
+              },
+              "contentOnly": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Content only",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Send content only in resource request. Excludes content metadata and etag from request.",
+                "order": "2",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitEtag": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit ETag",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit ETag.",
+                "order": "3",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
+              },
+              "omitJsonWrapper": {
+                "deprecated": false,
+                "defaultValue": false,
+                "displayName": "Omit Json wrapper",
+                "group": "common",
+                "javaType": "java.lang.Boolean",
+                "kind": "parameter",
+                "labelHint": "Omit Json wrapper that is added to the request data as surrounding Json object.",
+                "order": "4",
+                "required": true,
+                "secret": false,
+                "type": "boolean"
               }
             }
           }

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/consumer/ODataReadRouteSplitResultsTest.java
@@ -404,7 +404,7 @@ public class ODataReadRouteSplitResultsTest extends AbstractODataReadRouteTest {
         result.assertIsSatisfied();
         String json = extractJsonFromExchgMsg(result, 0, String.class);
         assertNotNull(json);
-        String expected = testData(TEST_SERVER_DATA_1);
+        String expected = testData(TEST_SERVER_DATA_1_WITH_COUNT);
         JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
     }
 


### PR DESCRIPTION
Some OData V2 services do explicitly support content only payloads so we need to skip wrappers and metadata from Json payloads. Let user specify write properties such as contentOnly, omitEtag and omitJsonWrapper. This enables us to control the marshalled Json payloads when updating OData entries.

Update Camel dependency to latest 3.5.0 version as this contains the OData olingo2 component that supports custom entity provider write properties.

(cherry picked from commit eaa465364329bb8f5a3a895f4e20c56898467d5b)