### PR TITLE
fix(ui) - [ENTESB-14056] update inline editing to better reflect pf4

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/InlineTextEdit.css
+++ b/app/ui-react/packages/ui/src/Shared/InlineTextEdit.css
@@ -4,3 +4,7 @@
   font-size: 0.75em;
   margin-left: 8px;
 }
+
+.pf-c-button.pf-m-control::after {
+  border: 0;
+}

--- a/app/ui-react/packages/ui/src/Shared/InlineTextEdit.tsx
+++ b/app/ui-react/packages/ui/src/Shared/InlineTextEdit.tsx
@@ -8,11 +8,8 @@ import {
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
-import { OkIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
-import {
-  global_danger_color_100,
-  global_success_color_100,
-} from '@patternfly/react-tokens';
+import { CheckIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
+import { global_palette_black_600 } from '@patternfly/react-tokens';
 import classnames from 'classnames';
 import * as React from 'react';
 import { Omit } from 'react-router';
@@ -92,7 +89,7 @@ const EditWidget: React.FunctionComponent<IEditWidget> = ({
                   <Loader inline={true} size={'sm'} />
                 </span>
               ) : (
-                <OkIcon size={'sm'} color={global_success_color_100.value} />
+                <CheckIcon size={'sm'} color={global_palette_black_600.value} />
               )}
             </Button>
             <Button
@@ -100,7 +97,7 @@ const EditWidget: React.FunctionComponent<IEditWidget> = ({
               isDisabled={saving}
               onClick={onCancel}
             >
-              <TimesIcon size={'sm'} color={global_danger_color_100.value} />
+              <TimesIcon size={'sm'} color={global_palette_black_600.value} />
             </Button>
           </InputGroup>
         </FormGroup>
@@ -130,7 +127,7 @@ const EditWidget: React.FunctionComponent<IEditWidget> = ({
                   <Loader inline={true} size={'sm'} />
                 </span>
               ) : (
-                <OkIcon size={'sm'} color={global_success_color_100.value} />
+                <CheckIcon size={'sm'} color={global_palette_black_600.value} />
               )}
             </Button>
             <Button
@@ -138,7 +135,7 @@ const EditWidget: React.FunctionComponent<IEditWidget> = ({
               isDisabled={saving}
               onClick={onCancel}
             >
-              <TimesIcon size={'sm'} color={global_danger_color_100.value} />
+              <TimesIcon size={'sm'} color={global_palette_black_600.value} />
             </Button>
           </InputGroup>
         </FormGroup>


### PR DESCRIPTION
Fix for [ENTESB-14056](https://issues.redhat.com/browse/ENTESB-14056) - inline editing to better reflect [pf4](https://www.patternfly.org/v4/documentation/react/components/table/#editable-rows).

This was the best I could do without updating the actual component and only sticking to styling changes.

Integration Details:

<img width="561" alt="Screen Shot 2020-09-09 at 15 31 15" src="https://user-images.githubusercontent.com/3844502/92614574-1cd55700-f2b4-11ea-84ef-daa0496ccc77.png">

<img width="740" alt="Screen Shot 2020-09-09 at 15 31 40" src="https://user-images.githubusercontent.com/3844502/92614629-29f24600-f2b4-11ea-99df-2377973c2216.png">

Connection Details:

<img width="637" alt="Screen Shot 2020-09-09 at 15 38 42" src="https://user-images.githubusercontent.com/3844502/92614646-2f4f9080-f2b4-11ea-9547-6045a738ac43.png">
