### PR TITLE
fix(ui): Disable/enable array fields in Kafka Connector

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.css
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.css
@@ -2,6 +2,13 @@
   white-space: nowrap ;
 }
 
+/** Prevents the last group of array
+ ** fields from being shorter than the rest
+ */
+.form-array-container.form-array-layout > :last-child {
+  justify-self: inherit;
+}
+
 .form-array-section__title {
   white-space: nowrap;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormArrayComponent.tsx
@@ -7,9 +7,7 @@ import { toValidHtmlId } from './helpers';
 
 import './FormArrayComponent.css';
 
-export const FormArrayComponent: React.FunctionComponent<
-  IFormArrayControlProps
-> = props => {
+export const FormArrayComponent: React.FunctionComponent<IFormArrayControlProps> = props => {
   if (typeof props.property.arrayDefinition === 'undefined') {
     return (
       <div className="alert alert-warning">
@@ -55,7 +53,10 @@ export const FormArrayComponent: React.FunctionComponent<
                 </h5>
               </div>
             )}
-            <div className="form-array-section__fields form-array-layout" {...formGroupAttributes}>
+            <div
+              className="form-array-section__fields form-array-layout"
+              {...formGroupAttributes}
+            >
               {propertiesArray.map(property => {
                 const propertyFieldName = `${fieldName}.${property.name}`;
 
@@ -66,6 +67,8 @@ export const FormArrayComponent: React.FunctionComponent<
                     fieldAttributes,
                     formGroupAttributes,
                     ...property,
+                    disabled:
+                      props.form.isSubmitting || props.property.disabled,
                     key: propertyFieldName,
                     name: propertyFieldName,
                   },
@@ -102,31 +105,36 @@ export const FormArrayComponent: React.FunctionComponent<
                     </Button>
                   </>
                 )}
-                <Button
-                  data-testid={'condition-delete'}
-                  variant={'link'}
-                  onClick={() => props.remove(index)}
-                  isDisabled={!(values.length > minElements)}
-                >
-                  <i className="fa fa-trash" />
-                </Button>
+                {!props.form.isSubmitting && !props.property.disabled && (
+                  <Button
+                    data-testid={'condition-delete'}
+                    variant={'link'}
+                    onClick={() => props.remove(index)}
+                    isDisabled={!(values.length > minElements)}
+                  >
+                    <i className="fa fa-trash" />
+                  </Button>
+                )}
               </div>
             </div>
           </section>
         );
       })}
-      <div className={'form-array-control__array-add'}>
-        <Button
-          variant={'link'}
-          data-testid="form-array-control-add-another-item-button"
-          onClick={() => props.push(getNewArrayRow(definition))}>
-          <>
-            <i className="fa fa-plus-circle" />
-            &nbsp;
-            {options.i18nAddElementText || 'Add Another'}
-          </>
-        </Button>
-      </div>
+      {!props.form.isSubmitting && !props.property.disabled && (
+        <div className={'form-array-control__array-add'}>
+          <Button
+            variant={'link'}
+            data-testid="form-array-control-add-another-item-button"
+            onClick={() => props.push(getNewArrayRow(definition))}
+          >
+            <>
+              <i className="fa fa-plus-circle" />
+              &nbsp;
+              {options.i18nAddElementText || 'Add Another'}
+            </>
+          </Button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Also add some styling and hides buttons for adding/removing array fields when in disabled mode.

cc @Delawen 

<img width="821" alt="Screen Shot 2020-09-11 at 13 28 55" src="https://user-images.githubusercontent.com/3844502/92929452-76ff2500-f438-11ea-8480-11fcdee78a08.png">

<img width="778" alt="Screen Shot 2020-09-11 at 13 44 57" src="https://user-images.githubusercontent.com/3844502/92929442-72d30780-f438-11ea-9b43-30eff7cb0e31.png">
