### PR TITLE
Upgrade fabric8 k8s client

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -60,7 +60,7 @@
 
     <jackson.version>2.11.2</jackson.version>
     <json-patch.version>1.9</json-patch.version>
-    <kubernetes.client.version>4.6.1</kubernetes.client.version>
+    <kubernetes.client.version>4.9.0</kubernetes.client.version>
 
     <spring.version>5.1.8.RELEASE</spring.version>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>

--- a/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
+++ b/app/server/openshift/src/test/java/io/syndesis/server/openshift/OpenShiftServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
@@ -38,7 +39,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
-
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -46,14 +47,9 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import static io.fabric8.kubernetes.client.utils.Serialization.asJson;
 import static io.syndesis.server.openshift.OpenShiftServiceImpl.openshiftName;
-
 import static org.assertj.core.api.Assertions.assertThat;
-
-import okhttp3.mockwebserver.RecordedRequest;
 
 public class OpenShiftServiceImplTest {
     @Rule
@@ -242,6 +238,8 @@ public class OpenShiftServiceImplTest {
 
         final Service expectedService = new ServiceBuilder()
             .withNewMetadata()
+                .withAnnotations(Collections.emptyMap())
+                .withLabels(Collections.emptyMap())
                 .withName(openshiftName(name))
             .endMetadata()
             .withNewSpec()
@@ -283,6 +281,8 @@ public class OpenShiftServiceImplTest {
 
         final Service expectedService = new ServiceBuilder()
             .withNewMetadata()
+                .withAnnotations(Collections.emptyMap())
+                .withLabels(Collections.emptyMap())
                 .withName(openshiftName(name))
             .endMetadata()
             .withNewSpec()


### PR DESCRIPTION
Related to Autodiscover Kafka broker doesn't work on OCP 4.5
https://issues.redhat.com/browse/ENTESB-14507

OCP 4.5 is based on k8s 1.18 and there are changes in k8s domain
model which fabric8 k8s client 4.6.1 throw errors trying to
deserialize