### PR TITLE
chore: Update to AtlasMap 2.0.8 

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-780022</camel.version>
-    <atlasmap.version>2.0.7</atlasmap.version>
+    <atlasmap.version>2.0.8</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,7 +39,7 @@
     <deploy.archives>false</deploy.archives>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>2.0.7</atlasmap.version>
+    <atlasmap.version>2.0.8</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -84,7 +84,7 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.0.7",
+    "@atlasmap/atlasmap": "^2.0.8",
     "react-fast-compare": "^2.0.2"
   },
   "jest": {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -226,19 +226,19 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.0.7.tgz#0720571e801c049441a56a2cb5d746c67b67532e"
-  integrity sha512-fuOGQxI6M7lQPpmhuE6JMKSFhHvxx22ROjxUdEpPs40r++6PhPO6QqIn6+0YOlYBMIUzJmgTlajM6wOCvlEi6w==
+"@atlasmap/atlasmap@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.0.8.tgz#88b5d2ce66b88961302fa8fba6f02b08f9c8ee66"
+  integrity sha512-y1lj9WCMK+JzQhu/6DymFISqVC8D1T5LVulgQZcDP8pBH7vi64MlJTA/4ypFakigWpdpQQFjoxQsq4C5l/re3w==
   dependencies:
-    "@atlasmap/core" "^2.0.7"
+    "@atlasmap/core" "^2.0.8"
     react-sage "^0.0.42"
     use-debounce "^3.4.2"
 
-"@atlasmap/core@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.0.7.tgz#8306cd3462e7ea118c8b3115d3016197b9f73385"
-  integrity sha512-SLZit+ljAKUYbB2OtPB9EQ9hfMaQMGZ2GKFhjYzgf67ab8Zlra3aXBLB1REQeTMrN8+K30MDPbNKoR6MMnMLlQ==
+"@atlasmap/core@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.0.8.tgz#40b007897c3c88879fd0ea5f2991c99cddb4b9dd"
+  integrity sha512-nYV/VGcNC34eFnzwPVLsqJNvkzoLQBkLD7j7ixSNm1BkWgFQMqlcp/veSMeFt5iFtI2FwAfhSGorN6LaID+Jlg==
   dependencies:
     file-saver "2.0.2"
     loglevel "^1.6.7"


### PR DESCRIPTION
Includes: atlasmap/atlasmap#2372 XML schema doesn't load properly when anonymous complex type exists