### PR TITLE
[fix] ENTESB-14258 overriding the postgres driver version from spring boot

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -155,7 +155,7 @@
     <immutables.version>2.8.8</immutables.version>
 
     <jdbi.version>2.78</jdbi.version>
-    <postgresql.version>9.1-901-1.jdbc4</postgresql.version>
+    <postgresql.version>42.2.16</postgresql.version>
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.3.3</micrometer.version>
     <teiid.version>14.0.0</teiid.version>
@@ -2102,6 +2102,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgresql.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-undertow</artifactId>
         <version>${spring-boot.version}</version>
@@ -2109,6 +2115,10 @@
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-14258

The postgres driver version is brought in my spring-boot. With the current pull request we are overriding the 42.2.11 to 42.2.16 (currently the  latest) 