### PR TITLE
[backport 1.11.x] - ENTESB-14905 - ui(fix) address SOAP connector detail page

### DIFF
--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailBody.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailBody.spec.tsx
@@ -14,6 +14,7 @@ it('Renders the expected connector name and description', () => {
       handleSubmit={onSubmit}
       i18nCancelLabel={'Cancel'}
       i18nEditLabel={'Edit'}
+      i18nLabelAddress={'Address'}
       i18nLabelBaseUrl={'Base URL'}
       i18nLabelDescription={'Description'}
       i18nLabelHost={'Host'}

--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfig.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfig.spec.tsx
@@ -19,6 +19,7 @@ it('Renders the component, its properties, and data-testids', () => {
 
   const { getByText, queryByTestId } = render(
     <ApiConnectorDetailConfig
+      i18nLabelAddress={'Address'}
       i18nLabelBaseUrl={'Base URL'}
       i18nLabelDescription={'Description'}
       i18nLabelHost={'Host'}

--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfigEdit.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfigEdit.spec.tsx
@@ -17,6 +17,7 @@ it('Renders the component, its properties, and data-testids', () => {
   const { queryByTestId } = render(
     <ApiConnectorDetailConfigEdit
       handleOnChange={handleOnChange}
+      i18nLabelAddress={'Address'}
       i18nLabelBaseUrl={'Base URL'}
       i18nLabelDescription={'Description'}
       i18nLabelHost={'Host'}

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailBody.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailBody.tsx
@@ -34,6 +34,7 @@ export interface IApiConnectorDetailBodyProps {
   /**
    * Property Labels
    */
+  i18nLabelAddress: string;
   i18nLabelBaseUrl: string;
   i18nLabelDescription: string;
   i18nLabelHost: string;
@@ -63,6 +64,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
   description,
   handleSubmit,
   host,
+  i18nLabelAddress,
   i18nLabelBaseUrl,
   i18nLabelDescription,
   i18nLabelHost,
@@ -109,6 +111,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
           {isEditing ? (
             <ApiConnectorDetailConfigEdit
               handleOnChange={onHandleChange}
+              i18nLabelAddress={i18nLabelAddress}
               i18nLabelBaseUrl={i18nLabelBaseUrl}
               i18nLabelDescription={i18nLabelDescription}
               i18nLabelHost={i18nLabelHost}
@@ -119,6 +122,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
             />
           ) : (
             <ApiConnectorDetailConfig
+              i18nLabelAddress={i18nLabelAddress}
               i18nLabelBaseUrl={i18nLabelBaseUrl}
               i18nLabelDescription={i18nLabelDescription}
               i18nLabelHost={i18nLabelHost}

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { IApiConnectorDetailValues } from './ApiConnectorDetailBody';
 
 export interface IApiConnectorDetailConfig {
+  i18nLabelAddress: string;
   i18nLabelBaseUrl: string;
   i18nLabelDescription: string;
   i18nLabelHost: string;
@@ -22,6 +23,7 @@ export interface IApiConnectorDetailConfig {
 }
 
 export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDetailConfig> = ({
+  i18nLabelAddress,
   i18nLabelBaseUrl,
   i18nLabelDescription,
   i18nLabelHost,
@@ -36,7 +38,10 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelName}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-name'}>
+            <TextListItem
+              component={TextListItemVariants.dd}
+              data-testid={'api-connector-detail-config-name'}
+            >
               {properties.name}
             </TextListItem>
           </>
@@ -46,8 +51,24 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelDescription}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-description'}>
+            <TextListItem
+              component={TextListItemVariants.dd}
+              data-testid={'api-connector-detail-config-description'}
+            >
               {properties.description}
+            </TextListItem>
+          </>
+        )}
+        {properties.address && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              {i18nLabelAddress}
+            </TextListItem>
+            <TextListItem
+              component={TextListItemVariants.dd}
+              data-testid={'api-connector-detail-config-address'}
+            >
+              {properties.address}
             </TextListItem>
           </>
         )}
@@ -56,7 +77,10 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelHost}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-host'}>
+            <TextListItem
+              component={TextListItemVariants.dd}
+              data-testid={'api-connector-detail-config-host'}
+            >
               {properties.host}
             </TextListItem>
           </>
@@ -66,7 +90,10 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelBaseUrl}
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd} data-testid={'api-connector-detail-config-path'}>
+            <TextListItem
+              component={TextListItemVariants.dd}
+              data-testid={'api-connector-detail-config-path'}
+            >
               {properties.basePath}
             </TextListItem>
           </>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
@@ -8,6 +8,7 @@ export interface IApiConnectorDetailConfigEdit {
   /**
    * Property labels
    */
+  i18nLabelAddress: string;
   i18nLabelBaseUrl: string;
   i18nLabelDescription: string;
   i18nLabelHost: string;
@@ -25,6 +26,7 @@ export interface IApiConnectorDetailConfigEdit {
 
 export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnectorDetailConfigEdit> = ({
   handleOnChange,
+  i18nLabelAddress,
   i18nLabelBaseUrl,
   i18nLabelDescription,
   i18nLabelHost,
@@ -56,68 +58,92 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
   return (
     <Form isHorizontal={true} data-testid={'api-connector-details-form'}>
       {i18nRequiredText}
-      <FormGroup
-        label={i18nLabelName}
-        isRequired={true}
-        fieldId="connector-name"
-        helperTextInvalid={i18nNameHelper}
-        validated={isValid}
-      >
-        <TextInput
-          value={properties.name}
+      {properties.name && (
+        <FormGroup
+          label={i18nLabelName}
           isRequired={true}
-          type="text"
-          id="connector-name"
-          aria-describedby="horizontal-form-name-helper"
-          data-testid={'api-connector-name-field'}
-          name="name"
-          onChange={onChange}
+          fieldId="connector-name"
+          helperTextInvalid={i18nNameHelper}
           validated={isValid}
-        />
-      </FormGroup>
-      <FormGroup 
-        label={i18nLabelDescription} 
-        fieldId="connector-description">
-        <TextArea
-          value={properties.description}
-          onChange={onChange}
-          data-testid={'api-connector-description-field'}
-          name="description"
-          id="connector-description"
-        />
-      </FormGroup>
-      <FormGroup
-        label={i18nLabelHost}
-        isRequired={false}
-        fieldId="connector-host"
-      >
-        <TextInput
-          value={properties.host}
+        >
+          <TextInput
+            value={properties.name}
+            isRequired={true}
+            type="text"
+            id="connector-name"
+            aria-describedby="horizontal-form-name-helper"
+            data-testid={'api-connector-name-field'}
+            name="name"
+            onChange={onChange}
+            validated={isValid}
+          />
+        </FormGroup>
+      )}
+      {properties.description && (
+        <FormGroup label={i18nLabelDescription} fieldId="connector-description">
+          <TextArea
+            value={properties.description}
+            onChange={onChange}
+            data-testid={'api-connector-description-field'}
+            name="description"
+            id="connector-description"
+          />
+        </FormGroup>
+      )}
+      {properties.address && (
+        <FormGroup
+          label={i18nLabelAddress}
           isRequired={false}
-          type="text"
-          id="connector-host"
-          data-testid={'api-connector-host-field'}
-          aria-describedby="horizontal-form-host-helper"
-          name="host"
-          onChange={onChange}
-        />
-      </FormGroup>
-      <FormGroup
-        label={i18nLabelBaseUrl}
-        isRequired={false}
-        fieldId="connector-baseurl"
-      >
-        <TextInput
-          value={properties.basePath}
+          fieldId="connector-address"
+        >
+          <TextInput
+            value={properties.address}
+            isRequired={false}
+            type="text"
+            id="connector-address"
+            data-testid={'api-connector-address-field'}
+            aria-describedby="horizontal-form-address-helper"
+            name="address"
+            onChange={onChange}
+          />
+        </FormGroup>
+      )}
+      {properties.host && (
+        <FormGroup
+          label={i18nLabelHost}
           isRequired={false}
-          type="text"
-          id="connector-baseurl"
-          data-testid={'api-connector-baseurl-field'}
-          aria-describedby="horizontal-form-baseurl-helper"
-          name="basePath"
-          onChange={onChange}
-        />
-      </FormGroup>
+          fieldId="connector-host"
+        >
+          <TextInput
+            value={properties.host}
+            isRequired={false}
+            type="text"
+            id="connector-host"
+            data-testid={'api-connector-host-field'}
+            aria-describedby="horizontal-form-host-helper"
+            name="host"
+            onChange={onChange}
+          />
+        </FormGroup>
+      )}
+      {properties.basePath && (
+        <FormGroup
+          label={i18nLabelBaseUrl}
+          isRequired={false}
+          fieldId="connector-baseurl"
+        >
+          <TextInput
+            value={properties.basePath}
+            isRequired={false}
+            type="text"
+            id="connector-baseurl"
+            data-testid={'api-connector-baseurl-field'}
+            aria-describedby="horizontal-form-baseurl-helper"
+            name="basePath"
+            onChange={onChange}
+          />
+        </FormGroup>
+      )}
     </Form>
   );
 };

--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -12,6 +12,7 @@
     },
     "shared": {
       "Actions": "Actions",
+      "Address": "Address",
       "Back": "Back",
       "BaseUrl": "Base URL",
       "Cancel": "Cancel",

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
@@ -169,6 +169,12 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                           />
                                           <>
                                             <ApiConnectorDetailBody
+                                              address={
+                                                (
+                                                  data.configuredProperties ||
+                                                  {}
+                                                ).address
+                                              }
                                               basePath={
                                                 (
                                                   data.configuredProperties ||
@@ -187,6 +193,9 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                                 'shared:Cancel'
                                               )}
                                               i18nEditLabel={t('shared:Edit')}
+                                              i18nLabelAddress={t(
+                                                'shared:Address'
+                                              )}
                                               i18nLabelBaseUrl={t(
                                                 'shared:BaseUrl'
                                               )}


### PR DESCRIPTION
backport of https://github.com/syndesisio/syndesis/pull/9107 for [ENTESB-14905](https://issues.redhat.com/browse/ENTESB-14905)

(reopened due to conflict with squashing commits)