### PR TITLE
fix(meta): managed mongodb drivers

### DIFF
--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -48,22 +48,6 @@
         <artifactId>de.flapdoodle.embed.process</artifactId>
         <version>2.1.2</version>
       </dependency>
-      <!-- We need to force these managed dependencies -->
-      <dependency>
-       <groupId>org.mongodb</groupId>
-       <artifactId>mongodb-driver-core</artifactId>
-       <version>4.0.1</version>
-     </dependency>
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-sync</artifactId>
-        <version>4.1.0</version>
-      </dependency>
-     <dependency>
-       <groupId>org.mongodb</groupId>
-       <artifactId>bson</artifactId>
-       <version>4.0.1</version>
-     </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -118,6 +102,10 @@
       <artifactId>connector-support-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.syndesis.connector</groupId>
+      <artifactId>connector-support-verifier</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -132,14 +120,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-    </dependency>
-    <!-- Connection verification support -->
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>connector-support-verifier</artifactId>
-      <version>${project.version}</version>
-      <optional>true</optional>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
@@ -165,11 +145,6 @@
     <dependency>
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.syndesis.connector</groupId>
-      <artifactId>connector-support-verifier</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -80,6 +80,7 @@
     <swagger-maven-plugin.version>3.1.8</swagger-maven-plugin.version>
 
     <activemq.version>5.15.9</activemq.version>
+    <mongodb-driver.version>4.0.4</mongodb-driver.version>
 
     <arquillian.version>1.6.0.Final</arquillian.version>
     <arquillian.cube.version>1.18.2</arquillian.cube.version>
@@ -3726,6 +3727,23 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <!-- Spring boot BOM is managing older mongodb driver versions, so we need to override -->
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-core</artifactId>
+        <version>${mongodb-driver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-sync</artifactId>
+        <version>${mongodb-driver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson</artifactId>
+        <version>${mongodb-driver.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Spring boot BOM is declaring a different set of mongodb drivers compared to the one declared and needed by Camel MongoDB component. We need to explicitly override those managed dependencies in order to align with Camel.

Fix #9106