### PR TITLE
ENTESB-13275: Updates OLM csv generator to latest permissions & settings

### DIFF
--- a/install/operator/deploy/crds/syndesis.io_syndeses_crd.yaml
+++ b/install/operator/deploy/crds/syndesis.io_syndeses_crd.yaml
@@ -2107,6 +2107,9 @@ spec:
                     type: object
                   meta:
                     properties:
+                      javaOptions:
+                        description: JAVA_OPTIONS environment variable
+                        type: string
                       resources:
                         properties:
                           limit:
@@ -2265,6 +2268,9 @@ spec:
                         required:
                         - maven
                         type: object
+                      javaOptions:
+                        description: JAVA_OPTIONS environment variable
+                        type: string
                       resources:
                         properties:
                           limit:

--- a/install/operator/pkg/syndesis/capabilities/capabilities.go
+++ b/install/operator/pkg/syndesis/capabilities/capabilities.go
@@ -62,6 +62,10 @@ func contains(a []string, x string) bool {
  * For testing the given platform's capabilities
  */
 func ApiCapabilities(clientTools *clienttools.ClientTools) (*ApiServerSpec, error) {
+	if clientTools == nil {
+		return &ApiServerSpec{}, nil
+	}
+
 	apiClient, err := clientTools.ApiClient()
 	if err != nil {
 		return nil, errs.Wrap(err, "Failed to initialise api client so cannot determine api capabilities")

--- a/install/operator/pkg/syndesis/olm/assets/alm-examples
+++ b/install/operator/pkg/syndesis/olm/assets/alm-examples
@@ -13,8 +13,7 @@
         "enabled": false
       },
       "jaeger": {
-        "enabled": false,
-        "clientOnly": true
+        "enabled": true
       }
     }
   }

--- a/install/operator/pkg/syndesis/olm/assets/productized/description
+++ b/install/operator/pkg/syndesis/olm/assets/productized/description
@@ -49,10 +49,4 @@ Within the addons section, users are able to enable specific addons. The availab
 - ops: enables monitoring, requires extra CRDs
 - todo: a simple todo application
 
-- When you enable Jaeger addon, you should link the previously created `syndesis-pull-secret` secret to jaeger service accounts.
-```
-oc secrets link jaeger-operator syndesis-pull-secret --for=pull
-oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull
-```
-
 To enable addons, set "addon_name": {"enabled": true} in the CR.

--- a/install/operator/pkg/syndesis/olm/csv.go
+++ b/install/operator/pkg/syndesis/olm/csv.go
@@ -17,6 +17,7 @@
 package olm
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
@@ -50,14 +51,14 @@ type csv struct {
 }
 
 type CSVOut struct {
-	APIVersion string `json:"apiVersion"`
+	APIVersion string `yaml:"apiVersion"`
 	Kind       string
 	Metadata   Metadata
 	Spec       Spec
 }
 
 type Spec struct {
-	DisplayName               string
+	DisplayName               string `yaml:"displayName"`
 	Description               string
 	Keywords                  []string
 	Version                   string
@@ -68,10 +69,10 @@ type Spec struct {
 	Selector                  Selector
 	Icon                      []Icon
 	Links                     []Link
-	RelatedImages             []Image
-	InstallModes              []InstallMode
+	InstallModes              []InstallMode `yaml:"installModes"`
 	Install                   Install
 	Customresourcedefinitions CustomResourceDefinitions
+	RelatedImages             []Image `yaml:"relatedImages"`
 }
 
 type Metadata struct {
@@ -84,12 +85,12 @@ type MetadataAnnotations struct {
 	Capabilities   string
 	Categories     string
 	Certified      string
-	CreatedAt      string
-	ContainerImage string
+	CreatedAt      string `yaml:"createdAt"`
+	ContainerImage string `yaml:"containerImage"`
 	Support        string
 	Description    string
 	Repository     string
-	Alm            string
+	AlmExamples    string `yaml:"alm-examples"`
 }
 
 type Maintainer struct {
@@ -115,8 +116,8 @@ type Link struct {
 }
 
 type Image struct {
-	Name   string
-	Images string
+	Name  string
+	Image string
 }
 
 type InstallMode struct {
@@ -171,6 +172,13 @@ func (c *csv) setVariables() {
 	c.version = c.config.Version
 	c.maturity = "alpha"
 
+	// Both of these are required to ensure permissions are correctly added to manifest
+	c.config.ApiServer.ImageStreams = true
+	c.config.ApiServer.Routes = true
+	c.config.ApiServer.EmbeddedProvider = true
+	c.config.ApiServer.OlmSupport = true
+	c.config.ApiServer.ConsoleLink = true
+
 	// Dependant on whether it is community or productized
 	c.name = "fuse-online-operator"
 	c.displayName = "Red Hat Integration - Fuse Online"
@@ -217,6 +225,11 @@ func (c *csv) build() (err error) {
 		return err
 	}
 
+	relatedImages, err := c.assembleRelatedImages()
+	if err != nil {
+		return err
+	}
+
 	co := CSVOut{
 		APIVersion: "operators.coreos.com/v1alpha1",
 		Kind:       "ClusterServiceVersion",
@@ -232,7 +245,7 @@ func (c *csv) build() (err error) {
 				Support:        c.support,
 				Description:    c.description,
 				Repository:     "https://github.com/syndesisio/syndesis/",
-				Alm:            string(alm),
+				AlmExamples:    string(alm),
 			},
 		},
 		Spec: Spec{
@@ -309,6 +322,7 @@ func (c *csv) build() (err error) {
 					Description: "Syndesis CRD",
 				}},
 			},
+			RelatedImages: relatedImages,
 		},
 	}
 
@@ -369,6 +383,7 @@ func (c *csv) loadClusterRoleFromTemplate() (r interface{}, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	resources = append(resources, olm...)
 
 	pubapi, err := generator.Render("./install/cluster_role_public_api.yml.tmpl", context)
@@ -385,20 +400,21 @@ func (c *csv) loadClusterRoleFromTemplate() (r interface{}, err error) {
 	for _, resource := range resources {
 		rules, exists, _ := unstructured.NestedFieldNoCopy(resource.UnstructuredContent(), "rules")
 		if !exists {
-			continue
+			return nil, fmt.Errorf("Cannot validate 'rules' in %s", resource.GetName())
 		}
 
 		ruleMaps, ok := rules.([]interface{})
 		if !ok || len(ruleMaps) == 0 {
-			continue
+			return nil, fmt.Errorf("Cannot validate rule maps in %s", resource.GetName())
 		}
 
-		ruleMap, ok := ruleMaps[0].(map[string]interface{})
-		if !ok {
-			continue
+		for _, ruleMap := range ruleMaps {
+			ruleMap, ok := ruleMap.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("Cannot validate 'rule map' in %s", resource.GetName())
+			}
+			m = append(m, ruleMap)
 		}
-
-		m = append(m, ruleMap)
 	}
 
 	r = m
@@ -424,7 +440,7 @@ func (c *csv) loadDeploymentFromTemplate() (r interface{}, err error) {
 		ExporterImage   string
 	}{
 		RelatedImages:   true,
-		OperatorImage:   "",
+		OperatorImage:   c.operator,
 		DatabaseImage:   c.config.Syndesis.Components.Database.Image,
 		CamelKImage:     c.config.Syndesis.Addons.CamelK.Image,
 		TodoImage:       c.config.Syndesis.Addons.Todo.Image,
@@ -456,4 +472,23 @@ func (c *csv) loadDeploymentFromTemplate() (r interface{}, err error) {
 
 	r = m["spec"]
 	return
+}
+
+func (c *csv) assembleRelatedImages() ([]Image, error) {
+	images := []Image{}
+
+	images = append(images, Image{Name: "syndesis-operator", Image: c.operator})
+	images = append(images, Image{Name: "postgres-version", Image: c.config.Syndesis.Components.Database.Image})
+	images = append(images, Image{Name: "todo", Image: c.config.Syndesis.Addons.Todo.Image})
+	images = append(images, Image{Name: "oauth", Image: c.config.Syndesis.Components.Oauth.Image})
+	images = append(images, Image{Name: "ui", Image: c.config.Syndesis.Components.UI.Image})
+	images = append(images, Image{Name: "s2i", Image: c.config.Syndesis.Components.S2I.Image})
+	images = append(images, Image{Name: "prometheus", Image: c.config.Syndesis.Components.Prometheus.Image})
+	images = append(images, Image{Name: "upgrade", Image: c.config.Syndesis.Components.Upgrade.Image})
+	images = append(images, Image{Name: "meta", Image: c.config.Syndesis.Components.Meta.Image})
+	images = append(images, Image{Name: "database", Image: c.config.Syndesis.Components.Database.Image})
+	images = append(images, Image{Name: "psql_exporter", Image: c.config.Syndesis.Components.Database.Exporter.Image})
+	images = append(images, Image{Name: "server", Image: c.config.Syndesis.Components.Server.Image})
+	images = append(images, Image{Name: "amq", Image: c.config.Syndesis.Components.AMQ.Image})
+	return images, nil
 }

--- a/install/operator/pkg/syndesis/olm/csv_test.go
+++ b/install/operator/pkg/syndesis/olm/csv_test.go
@@ -138,12 +138,14 @@ func Test_csv_loadClusterRoleFromTemplate(t *testing.T) {
 	// Mock olm support
 	//
 	conf.ApiServer.OlmSupport = true
+	conf.ApiServer.ConsoleLink = true
 
 	c := &csv{config: conf, operator: ""}
 	r, err := c.loadClusterRoleFromTemplate()
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 
-	_, ok := r.([]map[string]interface{})
+	roles, ok := r.([]map[string]interface{})
 	assert.True(t, ok, "Expected return value should be a map[string]interface{}")
+	assert.Equal(t, 8, len(roles)) // set of all the rule maps
 }


### PR DESCRIPTION
* capabilities.go
 * Stop the olm generator bombing out with a null pointer

* alm-examples
 * Enables jaeger by default in offered CR

* csv.go
 * Fixes truncation of permissions
 * Fixes marshalling of lowerCamelCase
 * Adds RelatedImages creation
 * Override ApiServer to set all to true