### PR TITLE
BACKPORT ENTESB-13275: Updates OLM csv generator to latest permission…

### DIFF
--- a/install/operator/pkg/syndesis/capabilities/capabilities.go
+++ b/install/operator/pkg/syndesis/capabilities/capabilities.go
@@ -62,6 +62,10 @@ func contains(a []string, x string) bool {
  * For testing the given platform's capabilities
  */
 func ApiCapabilities(clientTools *clienttools.ClientTools) (*ApiServerSpec, error) {
+	if clientTools == nil {
+		return &ApiServerSpec{}, nil
+	}
+
 	apiClient, err := clientTools.ApiClient()
 	if err != nil {
 		return nil, errs.Wrap(err, "Failed to initialise api client so cannot determine api capabilities")

--- a/install/operator/pkg/syndesis/olm/assets/alm-examples
+++ b/install/operator/pkg/syndesis/olm/assets/alm-examples
@@ -13,8 +13,7 @@
         "enabled": false
       },
       "jaeger": {
-        "enabled": false,
-        "clientOnly": true
+        "enabled": true
       }
     }
   }

--- a/install/operator/pkg/syndesis/olm/assets/productized/description
+++ b/install/operator/pkg/syndesis/olm/assets/productized/description
@@ -48,10 +48,7 @@ Within the addons section, users are able to enable specific addons. The availab
 - ops: enables monitoring, requires extra CRDs
 - todo: a simple todo application
 
-- When you enable Jaeger addon, you should link the previously created `syndesis-pull-secret` secret to jaeger service accounts.
-```
-oc secrets link jaeger-operator syndesis-pull-secret --for=pull
-oc secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull
-```
-
 To enable addons, set "addon_name": {"enabled": true} in the CR.
+
+For a more detailed set of instructions and a complete reference of config options,
+please refer to the product documentation at https://access.redhat.com/documentation/en-us/red_hat_fuse

--- a/install/operator/pkg/syndesis/olm/csv_test.go
+++ b/install/operator/pkg/syndesis/olm/csv_test.go
@@ -138,12 +138,14 @@ func Test_csv_loadClusterRoleFromTemplate(t *testing.T) {
 	// Mock olm support
 	//
 	conf.ApiServer.OlmSupport = true
+	conf.ApiServer.ConsoleLink = true
 
 	c := &csv{config: conf, operator: ""}
 	r, err := c.loadClusterRoleFromTemplate()
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 
-	_, ok := r.([]map[string]interface{})
+	roles, ok := r.([]map[string]interface{})
 	assert.True(t, ok, "Expected return value should be a map[string]interface{}")
+	assert.Equal(t, 8, len(roles)) // set of all the rule maps
 }


### PR DESCRIPTION
…s & settings

* capabilities.go
 * Stop the olm generator bombing out with a null pointer

* alm-examples
 * Enables jaeger by default in offered CR

* csv.go
 * Fixes truncation of permissions
 * Fixes marshalling of lowerCamelCase
 * Adds RelatedImages creation
 * Override ApiServer to set all to true