### PR TITLE
Update dependencies ENTESB-10454 (1.11.x)

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -87,7 +87,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/activemq/pom.xml
+++ b/app/connector/activemq/pom.xml
@@ -133,7 +133,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/amqp/pom.xml
+++ b/app/connector/amqp/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.qpid</groupId>
       <artifactId>qpid-jms-client</artifactId>
-      <version>0.30.0</version>
+      <version>0.51.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>

--- a/app/connector/api-provider/pom.xml
+++ b/app/connector/api-provider/pom.xml
@@ -41,8 +41,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -97,7 +97,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/aws-ddb/pom.xml
+++ b/app/connector/aws-ddb/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/aws-s3/pom.xml
+++ b/app/connector/aws-s3/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/aws-sns/pom.xml
+++ b/app/connector/aws-sns/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/aws-sqs/pom.xml
+++ b/app/connector/aws-sqs/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -111,7 +111,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -133,11 +133,6 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/fhir/pom.xml
+++ b/app/connector/fhir/pom.xml
@@ -160,7 +160,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/flow/pom.xml
+++ b/app/connector/flow/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/gmail/pom.xml
+++ b/app/connector/gmail/pom.xml
@@ -49,6 +49,27 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>${google-api-client-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-jdk5</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${google-api-client-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${google-api-client-version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -84,7 +105,14 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.22.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -112,7 +140,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -172,6 +200,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>com.google.api-client:google-api-client</dependency>
+            <dependency>com.google.http-client:google-http-client-jackson2</dependency>
+          </usedDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/app/connector/google-calendar/pom.xml
+++ b/app/connector/google-calendar/pom.xml
@@ -46,6 +46,27 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>${google-api-client-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-jdk5</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${google-api-client-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${google-api-client-version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -79,9 +100,16 @@
       <version>v3-rev291-1.22.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.22.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -105,7 +133,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -165,6 +193,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>com.google.api-client:google-api-client</dependency>
+            <dependency>com.google.http-client:google-http-client-jackson2</dependency>
+          </usedDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -29,7 +29,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <google-api-client-version>1.22.0</google-api-client-version>
     <google-api-services-sheets-version>v4-rev551-1.22.0</google-api-services-sheets-version>
   </properties>
 
@@ -60,6 +59,16 @@
             <artifactId>guava-jdk5</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${google-api-client-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${google-api-client-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -119,7 +128,10 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>${google-api-client-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
@@ -143,7 +155,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -218,6 +230,15 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>com.google.http-client:google-http-client-jackson2</dependency>
+          </usedDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -42,6 +42,17 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-http4</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -92,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/irc/pom.xml
+++ b/app/connector/irc/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/kafka/pom.xml
+++ b/app/connector/kafka/pom.xml
@@ -141,7 +141,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/app/connector/log/pom.xml
+++ b/app/connector/log/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -143,7 +143,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/odata-v2/pom.xml
+++ b/app/connector/odata-v2/pom.xml
@@ -231,7 +231,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -350,11 +350,6 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <scope>test</scope>
@@ -400,8 +395,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -188,7 +188,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -307,8 +307,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/pom.xml
+++ b/app/connector/pom.xml
@@ -78,6 +78,29 @@
     <module>mongodb</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -30,6 +30,22 @@
   <name>Connector :: REST Swagger</name>
   <packaging>jar</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-http4</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.syndesis.integration</groupId>
@@ -161,7 +177,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/salesforce/pom.xml
+++ b/app/connector/salesforce/pom.xml
@@ -127,7 +127,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/app/connector/servicenow/pom.xml
+++ b/app/connector/servicenow/pom.xml
@@ -103,8 +103,8 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/app/connector/soap/pom.xml
+++ b/app/connector/soap/pom.xml
@@ -30,6 +30,22 @@
   <name>Connector :: SOAP CXF</name>
   <packaging>jar</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-cxf</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.syndesis.integration</groupId>
@@ -169,7 +185,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -171,7 +171,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/support/maven-plugin/pom.xml
+++ b/app/connector/support/maven-plugin/pom.xml
@@ -106,7 +106,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/connector/support/processor/pom.xml
+++ b/app/connector/support/processor/pom.xml
@@ -56,8 +56,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/connector/telegram/pom.xml
+++ b/app/connector/telegram/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/timer/pom.xml
+++ b/app/connector/timer/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -91,7 +91,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/extension/archetype/java/src/main/resources/archetype-resources/pom.xml
+++ b/app/extension/archetype/java/src/main/resources/archetype-resources/pom.xml
@@ -41,7 +41,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-bom</artifactId>
         <version>${syndesis.version}</version>
         <type>pom</type>
@@ -54,14 +54,14 @@
   <dependencies>
     <!-- annotation processing -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-annotation-processor</artifactId>
       <optional>true</optional>
     </dependency>
 
     <!-- runtime -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -109,7 +109,7 @@
       </plugin>
 
       <plugin>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-maven-plugin</artifactId>
         <version>${syndesis.version}</version>
         <executions>

--- a/app/extension/archetype/java/src/main/resources/archetype-resources/src/main/java/__extension-name__Extension.java
+++ b/app/extension/archetype/java/src/main/resources/archetype-resources/src/main/java/__extension-name__Extension.java
@@ -20,10 +20,11 @@ import org.apache.camel.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.syndesis.extension.api.SyndesisActionProperty;
-import io.syndesis.extension.api.SyndesisExtensionAction;
+import io.syndesis.extension.api.Step;
+import io.syndesis.extension.api.annotations.Action;
+import io.syndesis.extension.api.annotations.ConfigurationProperty;
 
-@SyndesisExtensionAction(
+@Action(
     id = "my-step",
     name = "My Logging Step",
     description = "A simple logging step"
@@ -31,7 +32,7 @@ import io.syndesis.extension.api.SyndesisExtensionAction;
 public class ${extension-name}Extension {
     private static final Logger LOGGER = LoggerFactory.getLogger(${extension-name}Extension.class);
 
-    @SyndesisActionProperty(
+    @ConfigurationProperty(
         name = "trace",
         displayName = "Trace",
         description = "Log the body as TRACE level, default INFO")

--- a/app/extension/archetype/spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/app/extension/archetype/spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -41,7 +41,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-bom</artifactId>
         <version>${syndesis.version}</version>
         <type>pom</type>
@@ -54,14 +54,14 @@
   <dependencies>
     <!-- annotation processing -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-annotation-processor</artifactId>
       <optional>true</optional>
     </dependency>
 
     <!-- runtime -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -109,7 +109,7 @@
       </plugin>
 
       <plugin>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-maven-plugin</artifactId>
         <version>${syndesis.version}</version>
         <executions>

--- a/app/extension/archetype/xml/src/main/resources/archetype-resources/pom.xml
+++ b/app/extension/archetype/xml/src/main/resources/archetype-resources/pom.xml
@@ -41,7 +41,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-bom</artifactId>
         <version>${syndesis.version}</version>
         <type>pom</type>
@@ -54,14 +54,14 @@
   <dependencies>
     <!-- annotation processing -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-annotation-processor</artifactId>
       <optional>true</optional>
     </dependency>
 
     <!-- runtime -->
     <dependency>
-      <groupId>io.syndesis</groupId>
+      <groupId>io.syndesis.extension</groupId>
       <artifactId>extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -109,7 +109,7 @@
       </plugin>
 
       <plugin>
-        <groupId>io.syndesis</groupId>
+        <groupId>io.syndesis.extension</groupId>
         <artifactId>extension-maven-plugin</artifactId>
         <version>${syndesis.version}</version>
         <executions>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-780022</camel.version>
   </properties>
 

--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -102,7 +102,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.4</version>
         <exclusions>
           <exclusion>
             <groupId>javax.inject</groupId>
@@ -238,7 +238,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/ExcludeFilter.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/ExcludeFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+
+public class ExcludeFilter implements ArtifactsFilter {
+
+    private final String excludedArtifactId;
+
+    private final String excludedGroupId;
+
+    ExcludeFilter(final String excludedGroupId, final String excludedArtifactId) {
+        this.excludedGroupId = excludedGroupId;
+        this.excludedArtifactId = excludedArtifactId;
+    }
+
+    @Override
+    public Set<Artifact> filter(final Set<Artifact> artifacts) throws ArtifactFilterException {
+        final Set<Artifact> included = new HashSet<>();
+        for (final Artifact given : artifacts) {
+            if (isArtifactIncluded(given)) {
+                included.add(given);
+            }
+        }
+
+        return included;
+    }
+
+    @Override
+    public boolean isArtifactIncluded(final Artifact artifact) {
+        return !(artifact.getGroupId().equals(excludedGroupId) && artifact.getArtifactId().equals(excludedArtifactId));
+    }
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
@@ -38,7 +38,7 @@ import org.springframework.boot.maven.RepackageMojo;
 @SuppressWarnings({"PMD.EmptyMethodInAbstractClassShouldBeAbstract"})
 public abstract class SupportMojo extends RepackageMojo {
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    protected MavenProject project;
+    protected MavenProject mvnProject;
     @Parameter(defaultValue = "${project.build.directory}", required = true)
     protected File outputDirectory;
     @Parameter(defaultValue = "${project.build.finalName}", required = true)
@@ -57,7 +57,7 @@ public abstract class SupportMojo extends RepackageMojo {
     protected final void writePrivateFields() throws MojoFailureException {
         try {
 
-            writeFieldViaReflection("project", project);
+            writeFieldViaReflection("project", mvnProject);
             writeFieldViaReflection("outputDirectory", outputDirectory);
             writeFieldViaReflection("finalName", finalName);
 

--- a/app/integration/api/pom.xml
+++ b/app/integration/api/pom.xml
@@ -68,7 +68,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -27,7 +27,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-780022</camel.version>
     <atlasmap.version>2.0.9</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -122,7 +122,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/integration/runtime-springboot/pom.xml
+++ b/app/integration/runtime-springboot/pom.xml
@@ -124,10 +124,15 @@
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -214,17 +219,12 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -91,8 +91,8 @@
       <artifactId>camel-http-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -163,7 +163,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -150,8 +150,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/app/meta/src/main/resources/application.yml
+++ b/app/meta/src/main/resources/application.yml
@@ -26,7 +26,9 @@ management:
   metrics:
     web:
       server:
-        auto-time-requests: false
+        request:
+          autotime:
+            enabled: false
   endpoints:
     web:
       base-path: /

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -55,17 +55,18 @@
     <node.version>v10.15.1</node.version>
     <yarn.version>v1.13.0</yarn.version>
 
-    <hibernate.validator.version>6.0.16.Final</hibernate.validator.version>
+    <hibernate.validator.version>6.0.20.Final</hibernate.validator.version>
 
     <jackson.version>2.11.2</jackson.version>
     <json-patch.version>1.9</json-patch.version>
     <kubernetes.client.version>4.9.0</kubernetes.client.version>
 
-    <spring.version>5.1.8.RELEASE</spring.version>
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <spring.version>5.2.9.RELEASE</spring.version>
+    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
-    <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+    <spring-cloud.version>Hoxton.SR8</spring-cloud.version>
+    <spring-security.version>5.3.3.RELEASE</spring-security.version>
 
     <okhttp3.version>3.12.1</okhttp3.version>
 
@@ -144,7 +145,6 @@
     <mockito.version>2.19.0</mockito.version>
     <mongodb.version>3.9.0</mongodb.version>
 
-    <spring-security.version>5.2.1.RELEASE</spring-security.version>
     <resteasy.version>4.5.6.Final</resteasy.version>
     <resteasy-spring-boot-starter.version>4.6.1.Final</resteasy-spring-boot-starter.version>
 
@@ -153,12 +153,14 @@
     <jdbi.version>2.78</jdbi.version>
     <postgresql.version>42.2.16</postgresql.version>
     <logback.version>1.2.3</logback.version>
-    <micrometer.version>1.2.0</micrometer.version>
+    <micrometer.version>1.5.3</micrometer.version>
     <teiid.version>13.0.2</teiid.version>
     <aws-java-sdk-core.version>1.11.415</aws-java-sdk-core.version>
     <version.javax.activation>1.2.1</version.javax.activation>
 
     <javac.werror>-Werror</javac.werror>
+    <jetty.version>9.4.30.v20200611</jetty.version>
+    <google-api-client-version>1.22.0</google-api-client-version>
   </properties>
 
   <modules>
@@ -169,7 +171,7 @@
     <module>server</module>
     <module>s2i</module>
     <module>meta</module>
-    <module>ui-react</module>
+<!--    <module>ui-react</module>-->
   </modules>
 
   <profiles>
@@ -328,7 +330,7 @@
       </activation>
 
       <modules>
-        <module>../doc</module>
+<!--        <module>../doc</module>-->
         <module>test</module>
       </modules>
     </profile>
@@ -1966,6 +1968,10 @@
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
             <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -2068,8 +2074,8 @@
         <scope>runtime</scope>
         <exclusions>
           <exclusion>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -2088,6 +2094,10 @@
           <exclusion>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -2450,8 +2460,8 @@
             <artifactId>aopalliance</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -3046,6 +3056,10 @@
           <exclusion>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -134,12 +134,6 @@
     </dependency>
 
     <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
       <scope>runtime</scope>
@@ -243,7 +237,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/builder/image-generator/pom.xml
+++ b/app/server/builder/image-generator/pom.xml
@@ -154,7 +154,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/server/builder/maven-plugin/pom.xml
+++ b/app/server/builder/maven-plugin/pom.xml
@@ -117,8 +117,8 @@
             <artifactId>spring-beans</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.springframework.boot</groupId>
@@ -249,8 +249,8 @@
         <version>${maven.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>javax.interceptor</groupId>
@@ -352,16 +352,9 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
-
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/app/server/cli/pom.xml
+++ b/app/server/cli/pom.xml
@@ -175,7 +175,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/server/controller/pom.xml
+++ b/app/server/controller/pom.xml
@@ -103,8 +103,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -139,7 +139,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -108,8 +108,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -234,7 +234,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/dao/pom.xml
+++ b/app/server/dao/pom.xml
@@ -138,7 +138,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -149,8 +149,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -204,8 +204,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -387,7 +387,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/jsondb/pom.xml
+++ b/app/server/jsondb/pom.xml
@@ -131,7 +131,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/logging/jaeger/pom.xml
+++ b/app/server/logging/jaeger/pom.xml
@@ -122,7 +122,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/logging/jsondb/pom.xml
+++ b/app/server/logging/jsondb/pom.xml
@@ -63,10 +63,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
-
 
     <dependency>
       <groupId>org.springframework</groupId>
@@ -144,7 +143,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/metrics/jsondb/pom.xml
+++ b/app/server/metrics/jsondb/pom.xml
@@ -76,8 +76,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -167,7 +167,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/metrics/prometheus/pom.xml
+++ b/app/server/metrics/prometheus/pom.xml
@@ -132,8 +132,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/monitoring/pom.xml
+++ b/app/server/monitoring/pom.xml
@@ -57,8 +57,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -131,7 +131,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/openshift/pom.xml
+++ b/app/server/openshift/pom.xml
@@ -126,7 +126,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -546,8 +546,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -684,8 +684,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -29,10 +29,11 @@ server:
   compression:
     enabled: true
     mime-types: text/html,text/css,application/javascript,application/json
-  useForwardHeaders: true
+  forward-headers-strategy: native
   undertow:
-    ioThreads: 2
-    workerThreads: 10
+    threads:
+      io: 2
+      worker: 10
 
 management:
   server:
@@ -43,7 +44,9 @@ management:
   metrics:
     web:
       server:
-        auto-time-requests: false
+        request:
+          autotime:
+            enabled: false
   endpoints:
     web:
       base-path: /

--- a/app/server/update-controller/pom.xml
+++ b/app/server/update-controller/pom.xml
@@ -120,7 +120,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -76,8 +76,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -59,6 +59,24 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -74,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
     </dependency>
 
     <!-- Citrus -->
@@ -206,8 +224,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -247,7 +265,7 @@
 
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -265,6 +283,27 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -45,6 +45,32 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-core</artifactId>
+        <version>${camel.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.syndesis.integration</groupId>
+        <artifactId>integration-project-generator</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -143,7 +169,7 @@
     <!-- Test scope -->
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This is related to "ENTESB-10454 Syndesis alignment problems"
https://issues.redhat.com/browse/ENTESB-10454

Changes to maven-plugin, the AbstractMojo from spring-boot-maven-plugin already provides a
project attribute, but once the plugin runs, the project attribute is
not set. So, renaming just works.

Chnages to jakarta artifacts are related to springboot upgrade,
the artifact javax.el is deprecated.