### PR TITLE
chore: upgrade Camel to 2.23.2.fuse-780030

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
-    <camel.version>2.23.2.fuse-780022</camel.version>
+    <camel.version>2.23.2.fuse-780030</camel.version>
   </properties>
 
     <!-- Metadata need to publish to central -->

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
-    <camel.version>2.23.2.fuse-780022</camel.version>
+    <camel.version>2.23.2.fuse-780030</camel.version>
     <atlasmap.version>2.0.9</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -91,7 +91,7 @@
     <opentracing.spring.web.starter.version>3.0.0</opentracing.spring.web.starter.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.23.2.fuse-780022</camel.version>
+    <camel.version>2.23.2.fuse-780030</camel.version>
 
     <undertow.version>2.0.30.Final</undertow.version>
 


### PR DESCRIPTION
Camel needed to be upgraded because `io.swagger:*` version that was
forked in Fuse and depended upon from `:camel-parent` is no longer
available in JBoss EA repository. This version should contain all forked
dependencies pinned in JBoss EA repository.