### PR TITLE
fix: s2i image build

### DIFF
--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -203,6 +203,8 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
+              <skipAggregateDownloadLicenses>false</skipAggregateDownloadLicenses>
+              <executeOnlyOnRootModule>false</executeOnlyOnRootModule>
               <licensesOutputDirectory>${image.build.directory}/licenses</licensesOutputDirectory>
               <licensesOutputFile>${image.build.directory}/licenses.xml</licensesOutputFile>
             </configuration>


### PR DESCRIPTION
Running the S2I image build as a part of a multi-module build would lead
to an error from Docker build:

```
Error while trying to build the image: Unable to build image [syndesis/syndesis-s2i:latest] : "ADD failed: no source files were specified"
```

The `ADD` in question was missing the license files that were to be
generated by the license-maven-plugin. The execution of plugin was
skipped, as can be seen in the Maven output:

```
[INFO] --- license-maven-plugin:2.0.0:aggregate-download-licenses (collect-licenses) @ s2i ---
[INFO] skip flag is on, will skip goal.
```

As by default license-maven-plugin would execute only on root (parent)
module of a multi-module build and at the same time if the
`skipAggregateDownloadLicenses` flag is set to `false`.

By default in the `syndesis` script we build the s2i image individually,
i.e. we invoke `./mvnw -f s2i ...` so it is not part of a multi-module
build. So when needed to be run in a multi-module build without
`executeOnlyOnRootModule=false`, and regardless of
`skipAggregateDownloadLicenses=false` being set, execution would be
skipped.

This configures both `skipAggregateDownloadLicenses=false` and
`executeOnlyOnRootModule=false` to force license-maven-plugin to execute
regardless of how it's run.

(cherry picked from commit 95e0f612c73b257459f70382374eeefdb413444c)