### PR TITLE
ENTESB-15064: offline S2I build

### DIFF
--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -218,7 +218,7 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
 
         return ProjectGeneratorHelper.generate(
             new PomContext(
-                integration.getId().orElse(""),
+                Optional.ofNullable(configuration.getArtifactId()).orElse("project"),
                 integration.getName(),
                 integration.getDescription().orElse(null),
                 dependencies,

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
@@ -36,6 +36,16 @@ public class ProjectGeneratorConfiguration {
      */
     private final Templates templates = new Templates();
 
+    private String artifactId;
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
     public Boolean isSecretMaskingEnabled() {
         return secretMaskingEnabled;
     }
@@ -128,4 +138,5 @@ public class ProjectGeneratorConfiguration {
             }
         }
     }
+
 }

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/mvn/PomContext.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/mvn/PomContext.java
@@ -22,22 +22,22 @@ import java.util.Set;
 import io.syndesis.common.util.MavenProperties;
 
 public final class PomContext {
-    private final String id;
+    private final String artifactId;
     private final String name;
     private final String description;
     private final Collection<MavenGav> dependencies;
     private final MavenProperties mavenProperties;
 
-    public PomContext(String id, String name, String description, Collection<MavenGav> dependencies, MavenProperties mavenProperties) {
-        this.id = id;
+    public PomContext(String artifactId, String name, String description, Collection<MavenGav> dependencies, MavenProperties mavenProperties) {
+        this.artifactId = artifactId;
         this.name = name;
         this.description = description;
         this.dependencies = dependencies;
         this.mavenProperties = mavenProperties;
     }
 
-    public String getId() {
-        return id;
+    public String getArtifactId() {
+        return artifactId;
     }
 
     public String getName() {

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.syndesis.integrations</groupId>
-  <artifactId>project</artifactId>
+  <artifactId>{{artifactId}}</artifactId>
   <version>0.1-SNAPSHOT</version>
   <name>Syndesis Integrations :: {{name}}</name>
   {{#description}}<description>{{description}}</description>{{/description}}

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -376,7 +376,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies</goal>
+                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -36,6 +36,7 @@
   </properties>
 
   <dependencies>
+    <!-- This dependency will be run by the exec-maven-plugin below -->
     <dependency>
       <groupId>io.syndesis.server</groupId>
       <artifactId>server-builder-image-generator</artifactId>
@@ -244,7 +245,7 @@
             <!--
               Copies settings_local.xml to target directory, filtering
               the it to place the local Maven repository path in it.
-              This settings file is used when gethering the dependencies
+              This settings file is used when gathering the dependencies
               of the generated integration project for the second time
               and since the first invocation cached all dependencies
               needed in the local Maven repository it defines only that

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -376,7 +376,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies</goal>
+                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.test.itest.offline;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.test.SyndesisTestEnvironment;
+import io.syndesis.test.container.s2i.SyndesisS2iAssemblyContainer;
+import io.syndesis.test.integration.project.Project;
+import io.syndesis.test.integration.project.ProjectBuilder;
+import io.syndesis.test.integration.project.SpringBootProjectBuilder;
+
+import org.assertj.core.description.Description;
+import org.junit.Test;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.utility.LogUtils;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse.ContainerState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OfflineS2IBuild_IT {
+
+    final Integration integration = new Integration.Builder()
+        .name("offline-integration")
+        .build();
+
+    @Test
+    public void s2iBuildShouldBeOffline() throws IOException {
+        final ProjectBuilder builder = new SpringBootProjectBuilder("offline-project", SyndesisTestEnvironment.getSyndesisVersion());
+
+        final Project project = builder.build(() -> integration);
+
+        try (SyndesisS2iAssemblyContainer s2i = createContainerForProjectIn(project.getProjectPath())) {
+            s2i.start();
+            final InspectContainerResponse containerInfo = s2i.getContainerInfo();
+
+            final String containerId = containerInfo.getId();
+
+            try (DockerClient docker = s2i.getDockerClient();
+                InspectContainerCmd inspectCmd = docker.inspectContainerCmd(containerId)) {
+
+                // for some reason containerInfo.getState().getExitCode() always
+                // returns 0 so we run the `docker inspect` command instead
+                final ContainerState state = inspectCmd.exec().getState();
+                assertThat(state.getExitCode())
+                    .describedAs(new Description() {
+                        @Override
+                        public String value() {
+                            return "When running without network the S2I build should complete without issues, "
+                                + "but the exit code of the assembly script is non zero. Output:\n"
+                                + LogUtils.getOutput(docker, containerId);
+                        }
+                    })
+                    .isEqualTo(0);
+            }
+        }
+    }
+
+    private static SyndesisS2iAssemblyContainer createContainerForProjectIn(final Path project) {
+        final WaitStrategy finished = new LogMessageWaitStrategy()
+            .withRegEx("(?:.*\\.\\.\\. done.*\\s)|(?:Aborting due to error code .* for Maven build.*)")
+            .withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout());
+
+        @SuppressWarnings("resource") // we're creating the resource here and
+                                      // should not return it closed
+        final SyndesisS2iAssemblyContainer s2i = new SyndesisS2iAssemblyContainer("offline-integration", project,
+            SyndesisTestEnvironment.getSyndesisImageTag())
+                .withNetworkMode("none");
+        s2i.setWaitStrategy(finished);
+
+        return s2i;
+    }
+
+}


### PR DESCRIPTION
From commit messages:

fix(s2i): broad inclusion of dependencies (4a025cf)

When two connectors, usually by means of transitive dependencies, depend
on the same artefact of different versions, Maven version resolution[1]
will pick the newest of version.

When we build the S2I image we generate an Integration that contains all
known Connectors and Connector templates, with the intent on gathering
all dependencies.

Because of the version resolution only one of the versions needed will
be included. This poses a problem when a Connector depending on a older
version of the artefact is used without the Connector depending on the
newer version of the artefact. The older version would then be fetched
from a Maven repository.

The S2I image should contain all artefacts needed in order to allow
for offline S2I builds. In this case having the older version missing
jeopardizes that.

This addresses that issue by generating a multi-module project with a
module for every Container/Container template in an atempt to circumvent
cases when two Connectors depend on an artefact of different versions.
This way all version of such artefact should be present as the version
resolution is not needed for a Maven module containing only the single
dependency tree for a single Connector.

As there should not be any need to add individual actions to an
Integration whose project is to be built, with regards to gathering
dependencies -- actions do not hold additional dependencies; that bit of
logic was removed, so that single project (Maven module) is generated
for each Connector/Connector template.

Integratio test was added to launch the S2I build without networking to
make sure dependencies needed during the build are contained in the S2I
image. The test builds a trivial Integration, further refinement of the
test could include launching the S2I build for each of the containers.
In as such, the test caught a missing dependency in the S2I image built
without the changes in the image generator builder.

Ref. issues.redhat.com/browse/ENTESB-15064

[1] cwiki.apache.org/confluence/display/MAVENOLD/Versioning

fix(s2i): fail if dependencies can't be downloaded (b9f84f9)

When gathering dependencies via go-offline-maven-plugin for the S2I
image build we need to fail the build if any of the dependencies can't
be downloaded. Otherwise we might end up with a S2I image containing
partial dependencies.

chore(deps): go-offline-maven-plugin 1.2.7 (fd2f7b2)

Updates go-offline-maven-plugin to version 1.2.7.

chore(image-generator): fix typos, clarify (91c6e4e)

refactor(project-generator): custom artifactId (2550c2a)

This refactors project generator to allow for a custom artifactId in the
generated project. This help with generating Maven modules for each
generated project so that several generated projects can be included in
a multi-module Maven build.