### PR TITLE
Fix ignored modules

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -171,7 +171,7 @@
     <module>server</module>
     <module>s2i</module>
     <module>meta</module>
-<!--    <module>ui-react</module>-->
+    <module>ui-react</module>
   </modules>
 
   <profiles>
@@ -330,7 +330,7 @@
       </activation>
 
       <modules>
-<!--        <module>../doc</module>-->
+        <module>../doc</module>
         <module>test</module>
       </modules>
     </profile>


### PR DESCRIPTION
The ui-react and docs were ignored by a previous commit.
That was an accident, so reverting that change.