### PR TITLE
ENTESB-15064: offline S2I build (1.11.x backport)

### DIFF
--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGenerator.java
@@ -218,7 +218,7 @@ public class ProjectGenerator implements IntegrationProjectGenerator {
 
         return ProjectGeneratorHelper.generate(
             new PomContext(
-                integration.getId().orElse(""),
+            	Optional.ofNullable(configuration.getArtifactId()).orElse("project"),
                 integration.getName(),
                 integration.getDescription().orElse(null),
                 dependencies,

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/ProjectGeneratorConfiguration.java
@@ -36,6 +36,16 @@ public class ProjectGeneratorConfiguration {
      */
     private final Templates templates = new Templates();
 
+	private String artifactId;
+
+    public void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	public String getArtifactId() {
+		return artifactId;
+	}
+
     public Boolean isSecretMaskingEnabled() {
         return secretMaskingEnabled;
     }
@@ -128,4 +138,5 @@ public class ProjectGeneratorConfiguration {
             }
         }
     }
+
 }

--- a/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/mvn/PomContext.java
+++ b/app/integration/project-generator/src/main/java/io/syndesis/integration/project/generator/mvn/PomContext.java
@@ -22,22 +22,22 @@ import java.util.Set;
 import io.syndesis.common.util.MavenProperties;
 
 public final class PomContext {
-    private final String id;
+    private final String artifactId;
     private final String name;
     private final String description;
     private final Collection<MavenGav> dependencies;
     private final MavenProperties mavenProperties;
 
-    public PomContext(String id, String name, String description, Collection<MavenGav> dependencies, MavenProperties mavenProperties) {
-        this.id = id;
+    public PomContext(String artifactId, String name, String description, Collection<MavenGav> dependencies, MavenProperties mavenProperties) {
+        this.artifactId = artifactId;
         this.name = name;
         this.description = description;
         this.dependencies = dependencies;
         this.mavenProperties = mavenProperties;
     }
 
-    public String getId() {
-        return id;
+    public String getArtifactId() {
+        return artifactId;
     }
 
     public String getName() {

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.syndesis.integrations</groupId>
-  <artifactId>project</artifactId>
+  <artifactId>{{artifactId}}</artifactId>
   <version>0.1-SNAPSHOT</version>
   <name>Syndesis Integrations :: {{name}}</name>
   {{#description}}<description>{{description}}</description>{{/description}}

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -376,7 +376,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies</goal>
+                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -36,6 +36,7 @@
   </properties>
 
   <dependencies>
+    <!-- This dependency will be run by the exec-maven-plugin below -->
     <dependency>
       <groupId>io.syndesis.server</groupId>
       <artifactId>server-builder-image-generator</artifactId>
@@ -244,7 +245,7 @@
             <!--
               Copies settings_local.xml to target directory, filtering
               the it to place the local Maven repository path in it.
-              This settings file is used when gethering the dependencies
+              This settings file is used when gathering the dependencies
               of the generated integration project for the second time
               and since the first invocation cached all dependencies
               needed in the local Maven repository it defines only that

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -376,7 +376,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies</goal>
+                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -17,7 +17,6 @@
 package io.syndesis.test.itest.amq;
 
 import javax.jms.ConnectionFactory;
-import java.time.Duration;
 
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
@@ -75,7 +74,7 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_POD))
             .build()
             .withNetwork(amqBrokerContainer.getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -17,7 +17,6 @@
 package io.syndesis.test.itest.amq;
 
 import javax.jms.ConnectionFactory;
-import java.time.Duration;
 
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
@@ -75,7 +74,7 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, TODO_SERVER_PORT))
             .build()
             .withNetwork(amqBrokerContainer.getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.test.itest.offline;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.test.SyndesisTestEnvironment;
+import io.syndesis.test.container.s2i.SyndesisS2iAssemblyContainer;
+import io.syndesis.test.integration.project.ProjectBuilder;
+import io.syndesis.test.integration.project.SpringBootProjectBuilder;
+
+import org.assertj.core.description.Description;
+import org.junit.Test;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.utility.LogUtils;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse.ContainerState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OfflineS2IBuild_IT {
+
+    final Integration integration = new Integration.Builder()
+        .name("offline-integration")
+        .build();
+
+    @Test
+    public void s2iBuildShouldBeOffline() throws IOException {
+        final ProjectBuilder builder = new SpringBootProjectBuilder("offline-project", SyndesisTestEnvironment.getSyndesisVersion());
+
+        final Path project = builder.build(() -> integration);
+
+        try (SyndesisS2iAssemblyContainer s2i = createContainerForProjectIn(project)) {
+            s2i.start();
+            final InspectContainerResponse containerInfo = s2i.getContainerInfo();
+
+            final String containerId = containerInfo.getId();
+
+            try (DockerClient docker = s2i.getDockerClient();
+                InspectContainerCmd inspectCmd = docker.inspectContainerCmd(containerId)) {
+
+                // for some reason containerInfo.getState().getExitCode() always
+                // returns 0 so we run the `docker inspect` command instead
+                final ContainerState state = inspectCmd.exec().getState();
+                assertThat(state.getExitCode())
+                    .describedAs(new Description() {
+                        @Override
+                        public String value() {
+                            return "When running without network the S2I build should complete without issues, "
+                                + "but the exit code of the assembly script is non zero. Output:\n"
+                                + LogUtils.getOutput(docker, containerId);
+                        }
+                    })
+                    .isEqualTo(0);
+            }
+        }
+    }
+
+    private static SyndesisS2iAssemblyContainer createContainerForProjectIn(final Path project) {
+        final WaitStrategy finished = new LogMessageWaitStrategy()
+            .withRegEx("(?:.*\\.\\.\\. done.*\\s)|(?:Aborting due to error code .* for Maven build.*)")
+            .withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout());
+
+        @SuppressWarnings("resource") // we're creating the resource here and
+                                      // should not return it closed
+        final SyndesisS2iAssemblyContainer s2i = new SyndesisS2iAssemblyContainer("offline-integration", project,
+            SyndesisTestEnvironment.getSyndesisImageTag())
+                .withNetworkMode("none");
+        s2i.setWaitStrategy(finished);
+
+        return s2i;
+    }
+
+}

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -17,7 +17,6 @@
 package io.syndesis.test.itest.sheets;
 
 import javax.sql.DataSource;
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.annotations.CitrusResource;
@@ -57,7 +56,7 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -17,7 +17,6 @@
 package io.syndesis.test.itest.sheets;
 
 import javax.sql.DataSource;
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.annotations.CitrusResource;
@@ -57,7 +56,7 @@ public class DBToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -17,7 +17,6 @@
 package io.syndesis.test.itest.sheets;
 
 import javax.sql.DataSource;
-import java.time.Duration;
 import java.util.Arrays;
 
 import com.consol.citrus.annotations.CitrusResource;
@@ -58,7 +57,7 @@ public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
                         String.format("http://%s:%s", GenericContainer.INTERNAL_HOST_HOSTNAME, GOOGLE_SHEETS_SERVER_PORT))
             .build()
             .withNetwork(getSyndesisDb().getNetwork())
-            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout())));
+            .waitingFor(Wait.defaultWaitStrategy().withStartupTimeout(SyndesisTestEnvironment.getContainerStartupTimeout()));
 
     @Test
     @CitrusTest

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -16,6 +16,8 @@
 
 package io.syndesis.test;
 
+import java.time.Duration;
+
 import io.syndesis.test.model.IntegrationRuntime;
 
 /**
@@ -118,9 +120,11 @@ public final class SyndesisTestEnvironment {
                 System.getenv(SYNDESIS_DEBUG_PORT_ENV) : SYNDESIS_DEBUG_PORT_DEFAULT));
     }
 
-    public static int getContainerStartupTimeout() {
-        return Integer.parseInt(System.getProperty(SYNDESIS_CONTAINER_STARTUP_TIMEOUT, System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) != null ?
+    public static Duration getContainerStartupTimeout() {
+        final int seconds = Integer.parseInt(System.getProperty(SYNDESIS_CONTAINER_STARTUP_TIMEOUT, System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) != null ?
                 System.getenv(SYNDESIS_CONTAINER_STARTUP_TIMEOUT_ENV) : SYNDESIS_CONTAINER_STARTUP_TIMEOUT_DEFAULT));
+
+        return Duration.ofSeconds(seconds);
     }
 
     public static String getOutputDirectory() {

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -124,7 +124,7 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
         private boolean enableLogging = SyndesisTestEnvironment.isLoggingEnabled();
         private boolean enableDebug = SyndesisTestEnvironment.isDebugEnabled();
 
-        private Duration startupTimeout = Duration.ofSeconds(SyndesisTestEnvironment.getContainerStartupTimeout());
+        private Duration startupTimeout = SyndesisTestEnvironment.getContainerStartupTimeout();
 
         private ProjectBuilder projectBuilder;
         private IntegrationSource integrationSource;


### PR DESCRIPTION
In addition to what was mentioned in #9150, this includes:

chore(test): backport integration test fixes (fcdf65d)

This is a partial backport from `master` of these commits:

1b3a19c: fix(test): testcontainers on CI
e1fa833: fix(test): copy project jar race condition
609208c: refactor(s2i): replace `ADD --chown` in Dockerfile

This is needed for integration tests to run on my setup and as explained
on CI if SELinux is enabled.

Parts that are not backported were not needed to run integration tests
on my environemnt (but could be needed for CI):

app/test/test-support/src/main/resources/testcontainers.properties (added)
app/s2i/src/main/docker/Dockerfile (permission changes)

