### PR TITLE
fix(olm): Incomplete assets generation for olm virtual filesystem

### DIFF
--- a/install/operator/pkg/build/pkg.go
+++ b/install/operator/pkg/build/pkg.go
@@ -2,6 +2,11 @@ package build
 
 import (
 	"os"
+	"path/filepath"
+)
+
+var (
+	GoModDirectory string
 )
 
 func FileExists(name string) bool {
@@ -12,4 +17,31 @@ func FileExists(name string) bool {
 		}
 	}
 	return !stat.IsDir()
+}
+
+func init() {
+
+	// Save the original directory the process started in.
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	initialDir, err := filepath.Abs(wd)
+	if err != nil {
+		panic(err)
+	}
+
+	// Find the module dir..
+	current := ""
+	for next := initialDir; current != next; next = filepath.Dir(current) {
+		current = next
+		if FileExists(filepath.Join(current, "go.mod")) && FileExists(filepath.Join(current, "go.sum")) {
+			GoModDirectory = current
+			break
+		}
+	}
+
+	if GoModDirectory == "" {
+		panic("could not find the root module directory")
+	}
 }

--- a/install/operator/pkg/syndesis/olm/assets.go
+++ b/install/operator/pkg/syndesis/olm/assets.go
@@ -22,26 +22,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/shurcooL/httpfs/filter"
-	"github.com/syndesisio/syndesis/install/operator/pkg/util"
 )
-
-func GetAssetsFS() http.FileSystem {
-	assetsDir := filepath.Join("assets")
-	return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
-		if fi.Name() == "assets_generate.go" {
-			return false
-		}
-		return true
-	}), func(fi os.FileInfo) (os.FileInfo, error) {
-		return &zeroTimeFileInfo{fi}, nil
-	})
-}
 
 func AssetAsBytes(path string) ([]byte, error) {
 	file, err := GetAssetsFS().Open(path)

--- a/install/operator/pkg/syndesis/olm/dev/dev.go
+++ b/install/operator/pkg/syndesis/olm/dev/dev.go
@@ -12,7 +12,7 @@ import (
 )
 
 func GetAssetsFS() http.FileSystem {
-	assetsDir := filepath.Join(build.GoModDirectory, "pkg", "generator", "assets")
+	assetsDir := filepath.Join(build.GoModDirectory, "pkg", "syndesis", "olm", "assets")
 	return util.NewFileInfoMappingFS(filter.Keep(http.Dir(assetsDir), func(path string, fi os.FileInfo) bool {
 		if fi.Name() == ".DS_Store" {
 			return false

--- a/install/operator/pkg/syndesis/olm/mode_dev.go
+++ b/install/operator/pkg/syndesis/olm/mode_dev.go
@@ -1,0 +1,13 @@
+// +build dev
+
+package olm
+
+import (
+	"net/http"
+
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/olm/dev"
+)
+
+func GetAssetsFS() http.FileSystem {
+	return dev.GetAssetsFS()
+}

--- a/install/operator/pkg/syndesis/olm/mode_prod.go
+++ b/install/operator/pkg/syndesis/olm/mode_prod.go
@@ -1,0 +1,11 @@
+// +build !dev
+
+package olm
+
+import (
+	"net/http"
+)
+
+func GetAssetsFS() http.FileSystem {
+	return assets
+}


### PR DESCRIPTION
Note: this does not affect syndesis builds since the bug only arises whilst running `syndesis-operator olm ...`, which is a one-time operation for generating the olm manifest. At the moment, the latter is being generated then committed to separate repos so therefore separately managed.

This allows `syndesis-operator olm ...` to be executed from any directory and not just the pkg/syndesis/olm directory.

* pkg.go
 * Brought downstream - creates a var containing the process' directory

* generator/dev/dev.go
 * Corrects http.Dir in line with upstream using the GoModDirectory var

* assets.go
 * Removes the incorrect GetAssetsFS() function in favour of 2 versions,
   ie. 1 dev and 1 prod.
 * The dev version uses the existing real assets directory while building
   the binary
 * The prod version uses the virtual fs constructed from the assets dir