### PR TITLE
fix(connector/api): check for error handling

### DIFF
--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
@@ -73,12 +73,12 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
 
     private static Processor statusCodeUpdater(Integer httpResponseCode) {
         return exchange -> {
+            if (httpResponseCode != null) {
+                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
+            }
             if (exchange.getException() != null) {
                 //making sure we don't return anything
                 exchange.getIn().setBody("");
-                if (httpResponseCode != null) {
-                    exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
-                }
             }
         };
     }

--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
@@ -73,10 +73,12 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
 
     private static Processor statusCodeUpdater(Integer httpResponseCode) {
         return exchange -> {
-            //making sure we don't return anything
-            exchange.getIn().setBody("");
-            if (httpResponseCode != null) {
-                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
+            if (exchange.getException() != null) {
+                //making sure we don't return anything
+                exchange.getIn().setBody("");
+                if (httpResponseCode != null) {
+                    exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
+                }
             }
         };
     }


### PR DESCRIPTION
A regression was introduced during latest code refactory. A missing check condition was always setting the output result to an empty string.

Fix #9161 