### PR TITLE
Set AWS dependencies to 1.11.714

### DIFF
--- a/app/connector/pom.xml
+++ b/app/connector/pom.xml
@@ -118,6 +118,19 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -487,6 +487,19 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>${aws-java-sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -161,7 +161,7 @@
     <micrometer.version>1.5.5</micrometer.version>
     <teiid.version>14.0.0</teiid.version>
     <teiid.springboot.version>1.5.0</teiid.springboot.version>
-    <aws-java-sdk-core.version>1.11.415</aws-java-sdk-core.version>
+    <aws-java-sdk.version>1.11.714</aws-java-sdk.version>
     <version.javax.activation>1.2.2</version.javax.activation>
 
     <javac.werror>-Werror</javac.werror>
@@ -3688,19 +3688,13 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>
-        <version>${aws-java-sdk-core.version}</version>
+        <version>${aws-java-sdk.version}</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>DynamoDBLocal</artifactId>
-        <version>${aws-dynamodb-local.version}</version>
       </dependency>
 
       <!-- Telegram -->


### PR DESCRIPTION
Camel 3.4.4 brings 1.11.714 while syndesis was using 1.11.415 and at runtime there were mixed versions.
This is to consolidate on 1.11.714