### PR TITLE
fix(ui) [ENTESB-15132] - check defaultValue for address, basePath + host

### DIFF
--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
@@ -85,9 +85,18 @@ export const DetailsPage: React.FunctionComponent = () => {
               name={state.specification.name}
               description={state.specification.description}
               connectorTemplateId={state.connectorTemplateId}
-              basePath={state.specification.configuredProperties!.basePath}
-              host={state.specification.configuredProperties!.host}
-              address={state.specification.configuredProperties!.address}
+              basePath={
+                state.specification.configuredProperties?.basePath ||
+                state.specification.properties?.basePath?.defaultValue
+              }
+              host={
+                state.specification.configuredProperties?.host ||
+                state.specification.properties?.host?.defaultValue
+              }
+              address={
+                state.specification.configuredProperties?.address ||
+                state.specification.properties?.address?.defaultValue
+              }
               handleSubmit={onSubmit}
             >
               {({


### PR DESCRIPTION
Fix for [ENTESB-15132](https://issues.redhat.com/browse/ENTESB-15132) where the `basePath` + `host` fields are not filled in when creating an API Client Connector. Changed it for both OpenAPI + SOAP to first check `configuredProperties`, otherwise use `defaultValue` provided.

OpenAPI Connector

![Screen Shot 2020-11-02 at 11 12 06](https://user-images.githubusercontent.com/3844502/97864940-500af400-1d01-11eb-9db8-f6fb8ea5b515.png)

![Screen Shot 2020-11-02 at 11 56 57](https://user-images.githubusercontent.com/3844502/97865714-88f79880-1d02-11eb-966e-0046f4f14dc9.png)

SOAP Connector

![Screen Shot 2020-11-02 at 10 32 35](https://user-images.githubusercontent.com/3844502/97864946-5305e480-1d01-11eb-9b6f-a9679360c726.png)
