### PR TITLE
fix(ui) ENTESB-15273 - API Client Connector

### DIFF
--- a/app/ui-react/packages/api/src/WithApiConnectorHelpers.tsx
+++ b/app/ui-react/packages/api/src/WithApiConnectorHelpers.tsx
@@ -11,6 +11,7 @@ export interface IWithApiConnectorHelpersChildrenProps {
     apiConnector: Connector,
     name?: string,
     description?: string,
+    address?: string,
     host?: string,
     basePath?: string,
     icon?: string
@@ -75,6 +76,7 @@ export class WithApiConnectorHelpersWrapped extends React.Component<
     apiConnector: Connector,
     newName: string,
     newDescription?: string,
+    newAddress?: string,
     newHost?: string,
     newBasePath?: string,
     newIcon?: string
@@ -95,13 +97,26 @@ export class WithApiConnectorHelpersWrapped extends React.Component<
           draft.configuredProperties = noHost;
         }
 
+        if (newAddress) {
+          draft.configuredProperties.address = newAddress;
+        } else if (draft.configuredProperties.address) {
+          const { address, ...noAddress } = draft.configuredProperties;
+          draft.configuredProperties = noAddress;
+        }
+
         if (newBasePath) {
           draft.configuredProperties.basePath = newBasePath;
         } else if (draft.configuredProperties.basePath) {
           const { basePath, ...noBasePath } = draft.configuredProperties;
           draft.configuredProperties = noBasePath;
         }
-      } else if (newHost || newBasePath) {
+      } else if (newAddress || newHost || newBasePath) {
+        if (newAddress) {
+          draft.configuredProperties = {
+            address: newAddress,
+          };
+        }
+
         if (newHost) {
           draft.configuredProperties = {
             host: newHost,
@@ -130,9 +145,7 @@ export class WithApiConnectorHelpersWrapped extends React.Component<
   }
 }
 
-export const WithApiConnectorHelpers: React.FunctionComponent<
-  IWithApiConnectorHelpersProps
-> = props => (
+export const WithApiConnectorHelpers: React.FunctionComponent<IWithApiConnectorHelpersProps> = props => (
   <ApiContext.Consumer>
     {apiContext => (
       <WithApiConnectorHelpersWrapped {...props} {...apiContext} />

--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailBody.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailBody.spec.tsx
@@ -25,6 +25,7 @@ it('Renders the expected connector name and description', () => {
       i18nTitle={expectedName + ' Configuration'}
       icon={expectedIcon}
       name={expectedName}
+      propertyKeys={['description', 'name']}
     />
   );
 

--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfig.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfig.spec.tsx
@@ -25,6 +25,7 @@ it('Renders the component, its properties, and data-testids', () => {
       i18nLabelHost={'Host'}
       i18nLabelName={'Name'}
       properties={properties}
+      propertyKeys={['description', 'basePath', 'host', 'name']}
     />
   );
 

--- a/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfigEdit.spec.tsx
+++ b/app/ui-react/packages/ui/__tests__/Customization/ApiConnectorDetailConfigEdit.spec.tsx
@@ -25,6 +25,7 @@ it('Renders the component, its properties, and data-testids', () => {
       i18nNameHelper={'Please provide a name for the API Connector'}
       i18nRequiredText={'The fields marked with * are required.'}
       properties={properties}
+      propertyKeys={['description', 'name']}
     />
   );
 

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailBody.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailBody.tsx
@@ -22,7 +22,7 @@ export interface IApiConnectorDetailValues {
 
 export interface IApiConnectorDetailBodyProps {
   /**
-   * Properties
+   * Configured Properties
    */
   address?: string;
   basePath?: string;
@@ -56,6 +56,11 @@ export interface IApiConnectorDetailBodyProps {
    * @param e
    */
   handleSubmit: (e: any) => void;
+
+  /**
+   * An array of strings with possible properties
+   */
+  propertyKeys: string[];
 }
 
 export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetailBodyProps> = ({
@@ -77,6 +82,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
   i18nTitle,
   icon,
   name,
+  propertyKeys,
 }) => {
   const [configured, setConfigured] = React.useState<IApiConnectorDetailValues>(
     { address, basePath, description, host, icon, name }
@@ -119,6 +125,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
               i18nNameHelper={i18nNameHelper}
               i18nRequiredText={i18nRequiredText}
               properties={configured}
+              propertyKeys={propertyKeys}
             />
           ) : (
             <ApiConnectorDetailConfig
@@ -128,6 +135,7 @@ export const ApiConnectorDetailBody: React.FunctionComponent<IApiConnectorDetail
               i18nLabelHost={i18nLabelHost}
               i18nLabelName={i18nLabelName}
               properties={configured}
+              propertyKeys={propertyKeys}
             />
           )}
         </CardBody>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfig.tsx
@@ -20,6 +20,11 @@ export interface IApiConnectorDetailConfig {
    * typically set when creating the connector
    */
   properties: IApiConnectorDetailValues;
+
+  /**
+   * An array of strings with possible properties
+   */
+  propertyKeys: string[];
 }
 
 export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDetailConfig> = ({
@@ -29,6 +34,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
   i18nLabelHost,
   i18nLabelName,
   properties,
+  propertyKeys,
 }) => {
   return (
     <TextContent data-testid={'api-connector-detail-config'}>
@@ -59,7 +65,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             </TextListItem>
           </>
         )}
-        {properties.address && (
+        {propertyKeys.includes('address') && (
           <>
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelAddress}
@@ -72,7 +78,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             </TextListItem>
           </>
         )}
-        {properties.host && (
+        {propertyKeys.includes('host') && (
           <>
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelHost}
@@ -85,7 +91,7 @@ export const ApiConnectorDetailConfig: React.FunctionComponent<IApiConnectorDeta
             </TextListItem>
           </>
         )}
-        {properties.basePath && (
+        {propertyKeys.includes('basePath') && (
           <>
             <TextListItem component={TextListItemVariants.dt}>
               {i18nLabelBaseUrl}

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/detail/ApiConnectorDetailConfigEdit.tsx
@@ -22,6 +22,11 @@ export interface IApiConnectorDetailConfigEdit {
    * typically set when creating the connector
    */
   properties: IApiConnectorDetailValues;
+
+  /**
+   * An array of strings with possible properties
+   */
+  propertyKeys: string[];
 }
 
 export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnectorDetailConfigEdit> = ({
@@ -34,6 +39,7 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
   i18nNameHelper,
   i18nRequiredText,
   properties,
+  propertyKeys,
 }) => {
   type IValidation = 'default' | 'error' | 'success' | undefined;
   const [isValid, setIsValid] = React.useState<IValidation>('default');
@@ -58,39 +64,35 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
   return (
     <Form isHorizontal={true} data-testid={'api-connector-details-form'}>
       {i18nRequiredText}
-      {properties.name && (
-        <FormGroup
-          label={i18nLabelName}
+      <FormGroup
+        label={i18nLabelName}
+        isRequired={true}
+        fieldId="connector-name"
+        helperTextInvalid={i18nNameHelper}
+        validated={isValid}
+      >
+        <TextInput
+          value={properties.name}
           isRequired={true}
-          fieldId="connector-name"
-          helperTextInvalid={i18nNameHelper}
+          type="text"
+          id="connector-name"
+          aria-describedby="horizontal-form-name-helper"
+          data-testid={'api-connector-name-field'}
+          name="name"
+          onChange={onChange}
           validated={isValid}
-        >
-          <TextInput
-            value={properties.name}
-            isRequired={true}
-            type="text"
-            id="connector-name"
-            aria-describedby="horizontal-form-name-helper"
-            data-testid={'api-connector-name-field'}
-            name="name"
-            onChange={onChange}
-            validated={isValid}
-          />
-        </FormGroup>
-      )}
-      {properties.description && (
-        <FormGroup label={i18nLabelDescription} fieldId="connector-description">
-          <TextArea
-            value={properties.description}
-            onChange={onChange}
-            data-testid={'api-connector-description-field'}
-            name="description"
-            id="connector-description"
-          />
-        </FormGroup>
-      )}
-      {properties.address && (
+        />
+      </FormGroup>
+      <FormGroup label={i18nLabelDescription} fieldId="connector-description">
+        <TextArea
+          value={properties.description}
+          onChange={onChange}
+          data-testid={'api-connector-description-field'}
+          name="description"
+          id="connector-description"
+        />
+      </FormGroup>
+      {propertyKeys.includes('address') && (
         <FormGroup
           label={i18nLabelAddress}
           isRequired={false}
@@ -108,7 +110,7 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
           />
         </FormGroup>
       )}
-      {properties.host && (
+      {propertyKeys.includes('host') && (
         <FormGroup
           label={i18nLabelHost}
           isRequired={false}
@@ -126,7 +128,7 @@ export const ApiConnectorDetailConfigEdit: React.FunctionComponent<IApiConnector
           />
         </FormGroup>
       )}
-      {properties.basePath && (
+      {propertyKeys.includes('basePath') && (
         <FormGroup
           label={i18nLabelBaseUrl}
           isRequired={false}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
@@ -105,6 +105,7 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                     data,
                                     values.name,
                                     values.description,
+                                    values.address,
                                     values.host,
                                     values.basePath,
                                     values.icon
@@ -151,6 +152,10 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                     }
                                   >
                                     {() => {
+                                      const propertyKeys = Object.keys(
+                                        data.properties!
+                                      );
+
                                       return (
                                         <>
                                           <ApiConnectorDetailHeader
@@ -219,6 +224,7 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                               )}
                                               icon={data.icon}
                                               name={data.name}
+                                              propertyKeys={propertyKeys}
                                             />
                                             &nbsp;
                                             {data.actionsSummary ? (


### PR DESCRIPTION
Fixes [ENTESB-15273](https://issues.redhat.com/browse/ENTESB-15273) - When the fields are empty during editing API Connector, they disappear.

Since we are not using Autoform for the API Client Connector wizard and we want to make as few drastic changes as possible, I grabbed the keys from the `properties` object to determine which fields should be shown/hidden in the respective UI components. Fields that have no value set are hidden from the View mode, but available in Edit mode. Name and description fields are always shown. It's not my favorite solution to this problem, but it's lower risk, because it ensures that the fields are only shown if they are specified within the `properties` property.

I also discovered another bug where you are not able to edit the Address field of a SOAP Connector, verified by @mkralik3, which is fixed in this PR.

- [Video/GIF of OpenAPI connector fix](https://issues.redhat.com/secure/attachment/12501471/Kapture%202020-11-05%20at%2013.41.08.gif)
- [Video/GIF of SOAP connector fix](https://issues.redhat.com/secure/attachment/12501481/Kapture%202020-11-05%20at%2014.50.05.gif)