### PR TITLE
Reload ConfigMaps to avoid manual pod respin

### DIFF
--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -299,7 +299,7 @@
               <sourceDocumentName>index.adoc</sourceDocumentName>
               <outputDirectory>${apidocs.output.dir}/internal</outputDirectory>
               <attributes>
-                <source-highlighter>coderay</source-highlighter> 
+                <source-highlighter>coderay</source-highlighter>
                 <generated>${apidocs.dir}/asciidoc/internal</generated>
                 <toc>left</toc>
                 <sectnums>true</sectnums>
@@ -320,7 +320,7 @@
               <sourceDocumentName>index.adoc</sourceDocumentName>
               <outputDirectory>${apidocs.output.dir}</outputDirectory>
               <attributes>
-                <source-highlighter>coderay</source-highlighter> 
+                <source-highlighter>coderay</source-highlighter>
                 <generated>${apidocs.dir}/asciidoc</generated>
                 <toc>left</toc>
                 <sectnums>true</sectnums>
@@ -379,6 +379,15 @@
 
     </plugins>
   </build>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- ===================================================================================== -->
@@ -638,6 +647,12 @@
 
     <dependency>
       <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-security</artifactId>
       <scope>runtime</scope>
     </dependency>
@@ -891,20 +906,6 @@
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <classifier>annotations</classifier>
-    </dependency>
-
-    <!--  ==== Test Scope === -->
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>spring-cloud-kubernetes-core</artifactId>
-      <version>0.1.6</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- === Micrometer ================================================================== -->

--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -62,6 +62,8 @@ management:
       enabled: false
     prometheus:
       enabled: true
+    restart:
+      enabled: true
 
 cors:
   allowedOrigins: "*"

--- a/app/server/runtime/src/main/resources/bootstrap.yml
+++ b/app/server/runtime/src/main/resources/bootstrap.yml
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring:
+  cloud:
+    kubernetes:
+      config:
+        enabled: true
+        name: syndesis-server-config
+      reload:
+        enabled: true


### PR DESCRIPTION
Allow syndesis-server to reload the spring-context automatically in case the syndesis-server-config ConfigMap changes, as spring-boot application.yml is mapped from the ConfigMap.
This change allows higher availability of syndesis-server as there is no need to restart the pod to reload the changes in syndesis-server-config ConfigMap.