### PR TITLE
feature(e2e): Run integration tests as github actions on each PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,21 @@
+name: Integration Tests 1.x branch
+
+on: pull_request
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Build Syndesis
+        run: tools/bin/syndesis build --backend --dependencies --flash --clean
+      - name: Build Docker images
+        run: tools/bin/syndesis build -m s2i --image --flash --docker
+      - name: Run integration tests
+        run: tools/bin/syndesis integration-test --s2i --logging
+


### PR DESCRIPTION
The integration tests job is only available on the master branch. Let's enable it for 1.11.x too.