### PR TITLE
[Backport] fix(connector/api): status code setting

### DIFF
--- a/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
+++ b/app/connector/api-provider/src/main/java/io/syndesis/connector/apiprovider/ApiProviderReturnPathCustomizer.java
@@ -73,12 +73,12 @@ public class ApiProviderReturnPathCustomizer implements ComponentProxyCustomizer
 
     private static Processor statusCodeUpdater(Integer httpResponseCode) {
         return exchange -> {
+            if (httpResponseCode != null) {
+                exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
+            }
             if (exchange.getException() != null) {
                 //making sure we don't return anything
                 exchange.getIn().setBody("");
-                if (httpResponseCode != null) {
-                    exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, httpResponseCode);
-                }
             }
         };
     }


### PR DESCRIPTION
Integration tests were showing a different status code, because we only updated it if an error was raised. Moving the status code update outside the error check solves the issue.

Ref ENTESB-15131