### PR TITLE
fix(version-test): This 1.10 was was missing from the 1.11.x change

### DIFF
--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -32,7 +32,7 @@ public final class SyndesisTestEnvironment {
     private static final String CAMEL_VERSION = "camel.version";
     private static final String CAMEL_VERSION_ENV = "CAMEL_VERSION";
 
-    private static final String SYNDESIS_VERSION_DEFAULT = "1.10-SNAPSHOT";
+    private static final String SYNDESIS_VERSION_DEFAULT = "1.11-SNAPSHOT";
     private static final String SYNDESIS_VERSION = SYNDESIS_PREFIX + "version";
     private static final String SYNDESIS_VERSION_ENV = SYNDESIS_ENV_PREFIX + "VERSION";
 


### PR DESCRIPTION
The configuration for the tests was using an old version.