### PR TITLE
fix(s2i): make sure cached artifacts are used

### DIFF
--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/settings.xml
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/settings.xml
@@ -23,6 +23,16 @@
       <id>additional-repositories</id>
       <repositories>
         <repository>
+          <id>_local</id>
+          <url>file:///tmp/artifacts/m2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+        <repository>
           <id>central</id>
           <name>Maven Central</name>
           <url>https://repo.maven.apache.org/maven2/</url>
@@ -60,6 +70,16 @@
         </repository>
       </repositories>
       <pluginRepositories>
+        <pluginRepository>
+          <id>_local</id>
+          <url>file:///tmp/artifacts/m2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
         <pluginRepository>
           <id>central</id>
           <name>Maven Central</name>

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -407,7 +407,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies</goal>
+                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -326,8 +326,7 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
                     .add(SyndesisTestEnvironment.getProjectMountPath() + "/configuration/settings.xml")
                     .add("-f")
                     .add(SyndesisTestEnvironment.getProjectMountPath())
-                    .add(SyndesisTestEnvironment.getIntegrationRuntime().getCommand())
-                    .add("-Dmaven.repo.local=/tmp/artifacts/m2");
+                    .add(SyndesisTestEnvironment.getIntegrationRuntime().getCommand());
 
             if (enableDebug) {
                 commandLine.add(getDebugJvmArguments());


### PR DESCRIPTION
When the image for the integration is build via S2I we need to use the
artifacts that have been cached in the `/tmp/artifacts/m2` in the
Syndesis S2I image.

Previously passing `-Dmaven.repo.local=/tmp/artifacts/m2` in the Build
seemed to have done just that, but for _whatever_ reason, perhaps[1],
this started failing recently. Or we noticed it failing recently.

So if the specifying `maven.repo.local` is no longer helpful, the
solution here is to specify the `/tmp/artifacts/m2` repository within
the `settings.xml` placed in `configuration` directory of the generated
project.

[1] https://lists.apache.org/thread.html/f8790f0dcc7195c841fd2717605c96036c82a01d5a45842ac9bfe2fd%40%3Cusers.maven.apache.org%3E