### PR TITLE
chore: Use no-transfer-progress option on integration-test Maven buil…

### DIFF
--- a/tools/bin/commands/integration-test
+++ b/tools/bin/commands/integration-test
@@ -24,7 +24,7 @@ integration-test::run() {
 }
 
 maven_args() {
-    local args=""
+    local args=" --no-transfer-progress"
 
     if [ "$(hasflag --clean -c)" ]; then
         args="$args clean"


### PR DESCRIPTION
…d by default [ci skip]

This should shrink the amount of log output on CircleCI significantly. We have reached log output limits of CircleCI before.

(cherry picked from commit 18d9d0283c2295ed5437821e9f7c6c13247fdb00)