### PR TITLE
fix: configured vs default values in API connector

### DIFF
--- a/app/ui-react/packages/history/.size-snapshot.json
+++ b/app/ui-react/packages/history/.size-snapshot.json
@@ -1,27 +1,27 @@
 {
   "esm/history.js": {
-    "bundled": 28557,
-    "minified": 12544,
-    "gzipped": 3664,
+    "bundled": 28919,
+    "minified": 12638,
+    "gzipped": 3718,
     "treeshaked": {
       "rollup": {
-        "code": 208,
-        "import_statements": 132
+        "code": 221,
+        "import_statements": 145
       },
       "webpack": {
-        "code": 1324
+        "code": 1370
       }
     }
   },
   "umd/history.js": {
-    "bundled": 33486,
-    "minified": 12084,
-    "gzipped": 3983
+    "bundled": 265608,
+    "minified": 56979,
+    "gzipped": 18044
   },
   "umd/history.min.js": {
-    "bundled": 30925,
-    "minified": 10134,
-    "gzipped": 3566
+    "bundled": 263047,
+    "minified": 55021,
+    "gzipped": 17525
   },
   "esm/@syndesis/history.js": {
     "bundled": 28122,

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
@@ -175,24 +175,24 @@ export const ApiConnectorDetailsPage: React.FunctionComponent<IApiConnectorDetai
                                           <>
                                             <ApiConnectorDetailBody
                                               address={
-                                                (
-                                                  data.configuredProperties ||
-                                                  {}
-                                                ).address
+                                                data.configuredProperties
+                                                  ?.address ||
+                                                data.properties?.address
+                                                  ?.defaultValue
                                               }
                                               basePath={
-                                                (
-                                                  data.configuredProperties ||
-                                                  {}
-                                                ).basePath
+                                                data.configuredProperties
+                                                  ?.basePath ||
+                                                data.properties?.basePath
+                                                  ?.defaultValue
                                               }
                                               description={data.description}
                                               handleSubmit={onSubmit}
                                               host={
-                                                (
-                                                  data.configuredProperties ||
-                                                  {}
-                                                ).host
+                                                data.configuredProperties
+                                                  ?.host ||
+                                                data.properties?.host
+                                                  ?.defaultValue
                                               }
                                               i18nCancelLabel={t(
                                                 'shared:Cancel'

--- a/app/ui-react/syndesis/src/modules/connections/__test__/utils.spec.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/__test__/utils.spec.tsx
@@ -1,0 +1,61 @@
+import { substituteDefaultWithConfiguredProperties } from '../utils';
+
+describe('utilities', () => {
+  test('should not substitute if no configured properties given', async () => {
+    const property = {};
+    expect(
+      substituteDefaultWithConfiguredProperties('property', property, undefined)
+    ).toBe(property);
+  });
+
+  test('should not substitute when no configured property value is given', async () => {
+    const property = {
+      defaultValue: 'default value',
+    };
+    const configured = {
+      different: 'configured',
+    };
+    expect(
+      substituteDefaultWithConfiguredProperties(
+        'property',
+        property,
+        configured
+      )
+    ).toBe(property);
+  });
+
+  test('should substitute when configured property value is given', async () => {
+    const property = {
+      defaultValue: 'default value',
+    };
+    const configured = {
+      property: 'configured',
+    };
+    const expected = {
+      defaultValue: 'configured',
+    };
+    expect(
+      substituteDefaultWithConfiguredProperties(
+        'property',
+        property,
+        configured
+      )
+    ).toEqual(expected);
+  });
+
+  test('should not substitute if configured property value is equal to default value', async () => {
+    const property = {
+      defaultValue: 'value',
+    };
+    const configured = {
+      property: 'value',
+    };
+    expect(
+      substituteDefaultWithConfiguredProperties(
+        'property',
+        property,
+        configured
+      )
+    ).toBe(property);
+  });
+});

--- a/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
@@ -11,7 +11,11 @@ import {
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../../i18n';
-import { parseValidationResult, stringifyJsonArray } from '../utils';
+import {
+  parseValidationResult,
+  stringifyJsonArray,
+  substituteDefaultWithConfiguredProperties,
+} from '../utils';
 
 export interface IWithConnectorFormChildrenProps {
   /**
@@ -123,7 +127,11 @@ export const WithConnectorForm: React.FunctionComponent<IWithConnectorFormProps>
   >([]);
   const properties = connector.properties || {};
   const definition = Object.keys(properties).reduce((def, key) => {
-    const d = properties[key];
+    const d = substituteDefaultWithConfiguredProperties(
+      key,
+      properties[key],
+      connector.configuredProperties
+    );
     def[key] = {
       ...d,
       disabled,

--- a/app/ui-react/syndesis/src/modules/connections/utils.ts
+++ b/app/ui-react/syndesis/src/modules/connections/utils.ts
@@ -1,4 +1,5 @@
-import { Result } from '@syndesis/models';
+import { Result, StringMap } from '@syndesis/models';
+import { ConfigurationProperty } from '@syndesis/models/dist/models';
 import { IConnectorConfigurationFormValidationResult } from '@syndesis/ui';
 import i18n from '../../i18n';
 
@@ -93,4 +94,22 @@ export function stringifyJsonArray(
   });
 
   return newObj;
+}
+
+export function substituteDefaultWithConfiguredProperties(
+  key: string,
+  property: ConfigurationProperty,
+  configuredProperties?: StringMap<string>
+): ConfigurationProperty {
+  if (
+    !configuredProperties?.[key] ||
+    configuredProperties?.[key] === property.defaultValue
+  ) {
+    return property;
+  }
+
+  const substituted = { ...property };
+  substituted.defaultValue = configuredProperties[key];
+
+  return substituted;
 }


### PR DESCRIPTION
On the custom API Client Connector's detail page we want to show the
configured property value or if it doesn't exist the default value of
the property.

Similarly on the configuring a connection we want to use the
configured property first and then the the default value.

ref. https://issues.redhat.com/browse/ENTESB-15292