### PR TITLE
chore(sql): support UUID column type in PostgreSQL

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <scope>compile</scope>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/common/util/pom.xml
+++ b/app/common/util/pom.xml
@@ -94,6 +94,8 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/app/connector/activemq/pom.xml
+++ b/app/connector/activemq/pom.xml
@@ -105,6 +105,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/amqp/pom.xml
+++ b/app/connector/amqp/pom.xml
@@ -69,6 +69,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/app/connector/aws-ddb/pom.xml
+++ b/app/connector/aws-ddb/pom.xml
@@ -104,6 +104,11 @@
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/aws-s3/pom.xml
+++ b/app/connector/aws-s3/pom.xml
@@ -68,6 +68,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/box/pom.xml
+++ b/app/connector/box/pom.xml
@@ -74,6 +74,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <classifier>annotations</classifier>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/fhir/pom.xml
+++ b/app/connector/fhir/pom.xml
@@ -131,7 +131,11 @@
       <artifactId>hapi-fhir-client</artifactId>
       <version>${hapi-fhir-version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>

--- a/app/connector/google-sheets/pom.xml
+++ b/app/connector/google-sheets/pom.xml
@@ -115,6 +115,11 @@
       <artifactId>common-model</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>commons-lang3</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/kafka/pom.xml
+++ b/app/connector/kafka/pom.xml
@@ -92,8 +92,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
-
-
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>

--- a/app/connector/kudu/pom.xml
+++ b/app/connector/kudu/pom.xml
@@ -112,6 +112,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <classifier>annotations</classifier>
+        </dependency>
+
         <!-- logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -110,6 +110,11 @@
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/app/connector/odata-v2/pom.xml
+++ b/app/connector/odata-v2/pom.xml
@@ -216,6 +216,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <!-- Test -->

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -174,6 +174,11 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-olingo4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -136,6 +136,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- testing -->
     <dependency>

--- a/app/connector/salesforce/pom.xml
+++ b/app/connector/salesforce/pom.xml
@@ -98,6 +98,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/servicenow/pom.xml
+++ b/app/connector/servicenow/pom.xml
@@ -111,6 +111,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/app/connector/soap/pom.xml
+++ b/app/connector/soap/pom.xml
@@ -120,6 +120,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- testing -->
     <dependency>

--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -87,17 +87,17 @@
       <artifactId>jackson-module-jsonSchema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <!--  supported drivers -->

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/ColumnMetaData.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/ColumnMetaData.java
@@ -17,14 +17,37 @@ package io.syndesis.connector.sql.common;
 
 import java.sql.JDBCType;
 
-import lombok.Data;
-
-@Data
 public class ColumnMetaData {
 
-    private String name;
-    private JDBCType type;
-    private int position;
-    private boolean isAutoIncrement;
+    private final boolean isAutoIncrement;
+
+    private final String name;
+
+    private final int position;
+
+    private final JDBCType type;
+
+    public ColumnMetaData(final String name, final JDBCType type, final int position, final boolean isAutoIncrement) {
+        this.name = name;
+        this.type = type;
+        this.position = position;
+        this.isAutoIncrement = isAutoIncrement;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public JDBCType getType() {
+        return type;
+    }
+
+    public boolean isAutoIncrement() {
+        return isAutoIncrement;
+    }
 
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
@@ -24,26 +24,22 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import lombok.Data;
-
-@Data
+@SuppressWarnings("PMD.GodClass") // TODO refactor
 public class SqlParam {
 
-    private String name;
+    private final String name;
     private String column;
     private JDBCType jdbcType;
     private int columnPos;
     private TypeValue<?> typeValue;
-    private Boolean isConstant;
-    private String value;
-
-    public SqlParam() {
-        super();
-    }
 
     public SqlParam(String name) {
-        super();
+        this(name, null);
+    }
+
+    public SqlParam(String name, JDBCType type) {
         this.name = name;
+        this.jdbcType = type;
     }
 
     public void setJdbcType(JDBCType jdbcType) {
@@ -51,27 +47,56 @@ public class SqlParam {
         this.typeValue = javaType(jdbcType);
     }
 
+    public String getName() {
+        return name;
+    }
 
-    @Data
+    public String getColumn() {
+        return column;
+    }
+
+    public JDBCType getJdbcType() {
+        return jdbcType;
+    }
+
+    public int getColumnPos() {
+        return columnPos;
+    }
+
+    public TypeValue<?> getTypeValue() {
+        return typeValue;
+    }
+
     public static class TypeValue<T> {
 
-        private Class<T> clazz;
-        private T sampleValue;
+        private final Class<T> clazz;
+        private final T sampleValue;
 
         public TypeValue(Class<T> clazz, T sampleValue) {
-            super();
             this.clazz = clazz;
             this.sampleValue = sampleValue;
+        }
+
+        public Class<T> getClazz() {
+            return clazz;
+        }
+
+        public T getSampleValue() {
+            return sampleValue;
         }
     }
 
     public static final class SqlSampleValue {
         public static final List<String> ARRAY_VALUE = Collections.unmodifiableList(Arrays.asList("1","2","3"));
+        @SuppressWarnings("MutablePublicArray")
         public static final byte[] BINARY_VALUE = {1,2,3};
         public static final String STRING_VALUE = "abc";
         public static final Character CHAR_VALUE = 'a';
+        @SuppressWarnings("JdkObsolete")
         public static final Date DATE_VALUE = new Date(new java.util.Date().getTime());
+        @SuppressWarnings("JdkObsolete")
         public static final Time TIME_VALUE = new Time(new java.util.Date().getTime());
+        @SuppressWarnings("JdkObsolete")
         public static final Timestamp TIMESTAMP_VALUE = new Timestamp(new java.util.Date().getTime());
         public static final BigDecimal DECIMAL_VALUE = BigDecimal.ZERO;
         public static final Boolean BOOLEAN_VALUE = Boolean.TRUE;
@@ -144,6 +169,14 @@ public class SqlParam {
         default:
             return new TypeValue<>(String.class, SqlSampleValue.STRING_VALUE);
         }
+    }
+
+    public void setColumn(String column) {
+        this.column = column;
+    }
+
+    public void setColumnPos(int columnPos) {
+        this.columnPos = columnPos;
     }
 
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementMetaData.java
@@ -22,11 +22,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import lombok.Data;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Data
 public class SqlStatementMetaData {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStatementMetaData.class);
 
@@ -34,16 +32,15 @@ public class SqlStatementMetaData {
     private List<SqlParam> inParams = new ArrayList<>();
     private List<SqlParam> outParams = new ArrayList<>();
     private List<String> tableNames = new ArrayList<>();
-    private String sqlStatement;
+    private final String sqlStatement;
     private String camelSqlStatement;
     private Set<String> tablesInSchema;
-    private String schema;
+    private final String schema;
     private String defaultedSqlStatement;
     private String autoIncrementColumnName;
     private boolean batch;
 
     public SqlStatementMetaData(String sqlStatement, String schema) {
-        super();
         this.sqlStatement = sqlStatement;
         this.schema = schema;
     }
@@ -64,7 +61,7 @@ public class SqlStatementMetaData {
 
     public int numberOfInputParams() {
         int fromIndex = 0;
-        int numberOfInputParams=0;
+        int numberOfInputParams = 0;
         while (fromIndex >= 0) {
             fromIndex = sqlStatement.indexOf(':', fromIndex);
             numberOfInputParams++;
@@ -90,10 +87,10 @@ public class SqlStatementMetaData {
             for (SqlParam param : inParams) {
                 if (stringTypes.contains(param.getTypeValue().getClazz())) {
                     defaultedSqlStatement = defaultedSqlStatement.replace(":#" +
-                            param.getName(), "'" + param.getTypeValue().getSampleValue().toString() + "'");
+                        param.getName(), "'" + param.getTypeValue().getSampleValue().toString() + "'");
                 } else {
                     defaultedSqlStatement = defaultedSqlStatement.replace(":#" +
-                            param.getName(), param.getTypeValue().getSampleValue().toString());
+                        param.getName(), param.getTypeValue().getSampleValue().toString());
                 }
             }
         }
@@ -114,6 +111,62 @@ public class SqlStatementMetaData {
         }
 
         return batch;
+    }
+
+    public void setTablesInSchema(Set<String> tablesInSchema) {
+        this.tablesInSchema = tablesInSchema;
+    }
+
+    public String getSqlStatement() {
+        return sqlStatement;
+    }
+
+    public List<SqlParam> getInParams() {
+        return inParams;
+    }
+
+    public void setStatementType(StatementType statementType) {
+        this.statementType = statementType;
+    }
+
+    public Set<String> getTablesInSchema() {
+        return tablesInSchema;
+    }
+
+    public void setInParams(List<SqlParam> inParams) {
+        this.inParams = inParams;
+    }
+
+    public void setOutParams(List<SqlParam> outParams) {
+        this.outParams = outParams;
+    }
+
+    public List<SqlParam> getOutParams() {
+        return outParams;
+    }
+
+    public void setAutoIncrementColumnName(String autoIncrementColumnName) {
+        this.autoIncrementColumnName = autoIncrementColumnName;
+    }
+
+    public void setTableNames(List<String> tableNames) {
+        this.tableNames = tableNames;
+    }
+
+    public List<String> getTableNames() {
+        return tableNames;
+    }
+
+    public String getAutoIncrementColumnName() {
+        return autoIncrementColumnName;
+    }
+
+    public void setBatch(boolean batch) {
+        this.batch = batch;
+    }
+
+    public StatementType getStatementType() {
+        return statementType;
     }
 
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataRetrievalTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/SqlMetadataRetrievalTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql;
+
+import java.sql.JDBCType;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class SqlMetadataRetrievalTest {
+
+    private final JDBCType jdbcType;
+
+    private final JsonSchema jsonSchema;
+
+    public SqlMetadataRetrievalTest(final JDBCType jdbcType, final JsonSchema jsonSchema) {
+        this.jdbcType = jdbcType;
+        this.jsonSchema = jsonSchema;
+    }
+
+    @Test
+    public void shouldGenerateExpectedSchema() {
+        assertThat(SqlMetadataRetrieval.schemaFor(jdbcType)).isEqualTo(jsonSchema);
+    }
+
+    @Parameters(name = "{index}: {0} -> {1}")
+    public static Iterable<Object[]> expectedSchemasForColumnTypes() {
+        final JsonSchemaFactory factory = new JsonSchemaFactory();
+
+        final ArraySchema binary = factory.arraySchema();
+        binary.setItemsSchema(factory.integerSchema());
+
+        final StringSchema date = factory.stringSchema();
+        date.setFormat(JsonValueFormat.DATE_TIME);
+        return Arrays.asList(new Object[][] {
+            {JDBCType.ARRAY, factory.arraySchema()},
+            {JDBCType.BINARY, binary},
+            {JDBCType.BLOB, binary},
+            {JDBCType.LONGVARBINARY, binary},
+            {JDBCType.VARBINARY, binary},
+            {JDBCType.BIT, factory.booleanSchema()},
+            {JDBCType.BOOLEAN, factory.booleanSchema()},
+            {JDBCType.CHAR, factory.stringSchema()},
+            {JDBCType.CLOB, factory.stringSchema()},
+            {JDBCType.DATALINK, factory.stringSchema()},
+            {JDBCType.LONGNVARCHAR, factory.stringSchema()},
+            {JDBCType.LONGVARCHAR, factory.stringSchema()},
+            {JDBCType.NCHAR, factory.stringSchema()},
+            {JDBCType.NCLOB, factory.stringSchema()},
+            {JDBCType.NVARCHAR, factory.stringSchema()},
+            {JDBCType.ROWID, factory.stringSchema()},
+            {JDBCType.SQLXML, factory.stringSchema()},
+            {JDBCType.VARCHAR, factory.stringSchema()},
+            {JDBCType.DATE, date},
+            {JDBCType.TIME, date},
+            {JDBCType.TIMESTAMP, date},
+            {JDBCType.TIMESTAMP_WITH_TIMEZONE, date},
+            {JDBCType.TIME_WITH_TIMEZONE, date},
+            {JDBCType.DECIMAL, factory.numberSchema()},
+            {JDBCType.DOUBLE, factory.numberSchema()},
+            {JDBCType.FLOAT, factory.numberSchema()},
+            {JDBCType.NUMERIC, factory.numberSchema()},
+            {JDBCType.REAL, factory.numberSchema()},
+            {JDBCType.INTEGER, factory.integerSchema()},
+            {JDBCType.BIGINT, factory.integerSchema()},
+            {JDBCType.SMALLINT, factory.integerSchema()},
+            {JDBCType.TINYINT, factory.integerSchema()},
+            {JDBCType.NULL, factory.nullSchema()},
+            {JDBCType.DISTINCT, factory.anySchema()},
+            {JDBCType.JAVA_OBJECT, factory.anySchema()},
+            {JDBCType.OTHER, factory.anySchema()},
+            {JDBCType.REF, factory.anySchema()},
+            {JDBCType.REF_CURSOR, factory.anySchema()},
+            {JDBCType.STRUCT, factory.anySchema()}
+        });
+    }
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/PostgreSqlMetaDataITCase.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/PostgreSqlMetaDataITCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PostgreSqlMetaDataITCase {
+
+    @Rule
+    public final JdbcDatabaseContainer<?> postgresql = new PostgreSQLContainer<>();
+
+    @Test
+    public void shouldCreateMetadataForPostgreSqlSpecificDataTypes() throws SQLException {
+        try (Connection connection = postgresql.createConnection("")) {
+            try (Statement stmt = connection.createStatement()) {
+                final String createTable = "CREATE TABLE TEST (uuid UUID)";
+                stmt.executeUpdate(createTable);
+            }
+
+            final SqlStatementParser parser = new SqlStatementParser(connection, "INSERT INTO TEST VALUES (:#uuid)");
+            final SqlStatementMetaData info = parser.parse();
+            final List<SqlParam> inParams = info.getInParams();
+
+            final DbMetaDataHelper helper = new DbMetaDataHelper(connection);
+            final List<SqlParam> paramList = helper.getJDBCInfoByColumnOrder(null, null, "TEST", inParams);
+
+            assertThat(paramList).hasSize(1);
+
+            final SqlParam sqlParam = paramList.get(0);
+            assertThat(sqlParam.getJdbcType()).isEqualTo(JDBCType.VARCHAR);
+        }
+    }
+
+}

--- a/app/connector/support/maven-plugin/pom.xml
+++ b/app/connector/support/maven-plugin/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <scope>provided</scope>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/connector/support/test/pom.xml
+++ b/app/connector/support/test/pom.xml
@@ -82,6 +82,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
   </dependencies>
 

--- a/app/connector/support/verifier/pom.xml
+++ b/app/connector/support/verifier/pom.xml
@@ -56,6 +56,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/app/connector/timer/pom.xml
+++ b/app/connector/timer/pom.xml
@@ -33,6 +33,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/connector/webhook/pom.xml
+++ b/app/connector/webhook/pom.xml
@@ -54,7 +54,12 @@
       <groupId>io.syndesis.connector</groupId>
       <artifactId>connector-support-util</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>

--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- Test -->
 
     <!-- The extension-api module is needed only for tests -->

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -291,6 +291,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/integration/api/pom.xml
+++ b/app/integration/api/pom.xml
@@ -47,6 +47,12 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/app/integration/component-proxy/pom.xml
+++ b/app/integration/component-proxy/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <scope>provided</scope>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/integration/project-generator/pom.xml
+++ b/app/integration/project-generator/pom.xml
@@ -108,6 +108,11 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/app/integration/runtime-springboot/pom.xml
+++ b/app/integration/runtime-springboot/pom.xml
@@ -141,6 +141,12 @@
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -104,6 +104,12 @@
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/app/integration/support/camel-acme/pom.xml
+++ b/app/integration/support/camel-acme/pom.xml
@@ -68,6 +68,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <annotationProcessorPath>
+               <groupId>org.apache.camel</groupId>
+               <artifactId>apt</artifactId>
+               <version>${camel.version}</version>
+            </annotationProcessorPath>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -202,6 +202,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- === Micrometer ================================================================== -->
 
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -611,6 +611,18 @@
                 <arg>${errorprone.autofix.arg1}</arg>
                 <arg>${errorprone.autofix.arg2}</arg>
               </compilerArgs>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>org.immutables</groupId>
+                  <artifactId>value</artifactId>
+                  <version>${immutables.version}</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <groupId>com.google.auto.value</groupId>
+                  <artifactId>auto-value</artifactId>
+                  <version>1.7.1</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
             </configuration>
             <dependencies>
               <dependency>
@@ -946,18 +958,6 @@
                 <packages>
                     <package>io.swagger.v3.jaxrs2.integration</package>
                 </packages>
-              </exception>
-              <exception>
-                <conflictingDependencies>
-                  <dependency>
-                    <groupId>org.immutables</groupId>
-                    <artifactId>value-annotations</artifactId>
-                  </dependency>
-                  <dependency>
-                    <groupId>org.immutables</groupId>
-                    <artifactId>value</artifactId>
-                  </dependency>
-                </conflictingDependencies>
               </exception>
             </exceptions>
             <ignoredDependencies>
@@ -2674,6 +2674,14 @@
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>${immutables.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>${immutables.version}</version>
+        <classifier>annotations</classifier>
         <scope>provided</scope>
       </dependency>
 

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/builder/image-generator/pom.xml
+++ b/app/server/builder/image-generator/pom.xml
@@ -158,6 +158,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/server/builder/maven-plugin/pom.xml
+++ b/app/server/builder/maven-plugin/pom.xml
@@ -355,6 +355,13 @@
       <artifactId>jakarta.el</artifactId>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/server/controller/pom.xml
+++ b/app/server/controller/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
-      <scope>provided</scope>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/credential/pom.xml
+++ b/app/server/credential/pom.xml
@@ -115,6 +115,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/dao/pom.xml
+++ b/app/server/dao/pom.xml
@@ -122,6 +122,12 @@
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- === Test ============================================================================ -->
 
     <dependency>

--- a/app/server/endpoint/pom.xml
+++ b/app/server/endpoint/pom.xml
@@ -141,6 +141,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/jsondb/pom.xml
+++ b/app/server/jsondb/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/logging/jaeger/pom.xml
+++ b/app/server/logging/jaeger/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/logging/jsondb/pom.xml
+++ b/app/server/logging/jsondb/pom.xml
@@ -85,6 +85,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/metrics/jsondb/pom.xml
+++ b/app/server/metrics/jsondb/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/metrics/prometheus/pom.xml
+++ b/app/server/metrics/prometheus/pom.xml
@@ -104,6 +104,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/monitoring/pom.xml
+++ b/app/server/monitoring/pom.xml
@@ -94,6 +94,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/openshift/pom.xml
+++ b/app/server/openshift/pom.xml
@@ -91,6 +91,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -906,6 +906,12 @@
       <artifactId>jaeger-spring-boot-starter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- === Micrometer ================================================================== -->
 
     <dependency>

--- a/app/server/update-controller/pom.xml
+++ b/app/server/update-controller/pom.xml
@@ -106,6 +106,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
     <!-- === Test ============================================================================ -->
 
     <dependency>

--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
     </dependency>
 
     <dependency>

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -258,6 +258,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -155,6 +155,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <classifier>annotations</classifier>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
When we encounter a column of JDBC type `OTHER` we now look at the type
name to see if it equals `UUID` (regardless of case), and report the
column having `VARCHAR` JDBC type instead.

Ref. issues.redhat.com/browse/ENTESB-13689

(cherry picked from commit 96a2189)

Also includes:

chore(build): explicit annotation processors

Makes annotation processor configuration explicit and removes Lombok
from SQL connector. This way we can depend on only the annotations of
Immutables and this clears a path for configuring ErrorProne/Immutables
on Java 9+.

(cherry picked from commit 8dd3dbdb7dc08692962d3fd2969181b82ca031b7)

```
# Conflicts:
#	app/connector/debezium/pom.xml
#	app/connector/fhir/pom.xml
#	app/connector/kafka/pom.xml
#	app/connector/knative/pom.xml
#	app/connector/webhook/pom.xml
#	app/extension/maven-plugin/pom.xml
#	app/server/builder/image-generator/pom.xml
#	app/server/builder/maven-plugin/pom.xml
#	app/server/update-controller/pom.xml
```