### PR TITLE
ENTESB-14875 Reload ConfigMaps to avoid manual pod respin

### DIFF
--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -382,6 +382,15 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- ===================================================================================== -->
 
@@ -630,6 +639,12 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-zipkin</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
       <scope>runtime</scope>
     </dependency>
 
@@ -889,20 +904,6 @@
     <dependency>
       <groupId>io.syndesis.common</groupId>
       <artifactId>jaeger-spring-boot-starter</artifactId>
-    </dependency>
-
-    <!--  ==== Test Scope === -->
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>spring-cloud-kubernetes-core</artifactId>
-      <version>0.1.6</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- === Micrometer ================================================================== -->

--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -63,6 +63,8 @@ management:
       enabled: false
     prometheus:
       enabled: true
+    restart:
+      enabled: true
 
 cors:
   allowedOrigins: "*"

--- a/app/server/runtime/src/main/resources/bootstrap.yml
+++ b/app/server/runtime/src/main/resources/bootstrap.yml
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring:
+  cloud:
+    kubernetes:
+      config:
+        enabled: true
+        name: syndesis-server-config
+      reload:
+        enabled: true


### PR DESCRIPTION
When the user changes properties on syndesis custom resource
that changes values in ConfigMaps, the spring context or spring app
should be restarted to take the changes into effect, otherwise the
user must manually respin the pod.