### PR TITLE
fix: don't include deleted extensions

### DIFF
--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/DefaultVerifierExtensionUploader.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/DefaultVerifierExtensionUploader.java
@@ -84,7 +84,7 @@ public class DefaultVerifierExtensionUploader implements VerifierExtensionUpload
 
         Boolean isDeployed = target.request().post(entity, Boolean.class);
         if (isDeployed) {
-            openShiftClient.deploymentConfigs().withName("syndesis-meta").deployLatest();
+            redeployMeta();
         }
     }
 
@@ -96,7 +96,11 @@ public class DefaultVerifierExtensionUploader implements VerifierExtensionUpload
 
         Boolean isDeleted = target.request().delete(Boolean.class);
         if (isDeleted) {
-            openShiftClient.deploymentConfigs().withName("syndesis-meta").deployLatest();
+            redeployMeta();
         }
+    }
+
+    protected void redeployMeta() {
+        openShiftClient.deploymentConfigs().withName("syndesis-meta").deployLatest();
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/NoopVerifierExtensionUploader.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/NoopVerifierExtensionUploader.java
@@ -31,5 +31,6 @@ public class NoopVerifierExtensionUploader extends DefaultVerifierExtensionUploa
 
     @Override
     protected void redeployMeta() {
+        // nop
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/NoopVerifierExtensionUploader.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/NoopVerifierExtensionUploader.java
@@ -15,26 +15,21 @@
  */
 package io.syndesis.server.endpoint.v1.handler.extension;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.syndesis.server.dao.file.FileDataManager;
+import io.syndesis.server.verifier.MetadataConfigurationProperties;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import io.syndesis.common.model.extension.Extension;
-
 @Component
-@ConditionalOnProperty(value = "openshift.enabled", havingValue = "false", matchIfMissing=false)
-public class NoopVerifierExtensionUploader implements VerifierExtensionUploader {
+@ConditionalOnProperty(value = "openshift.enabled", havingValue = "false", matchIfMissing = false)
+public class NoopVerifierExtensionUploader extends DefaultVerifierExtensionUploader {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NoopVerifierExtensionUploader.class);
-
-    @Override
-    public void uploadToVerifier(Extension extension) {
-        LOGGER.info("Upload {} extension to verifier", ExtensionActivator.getConnectorIdForExtension(extension));
+    public NoopVerifierExtensionUploader(final MetadataConfigurationProperties verificationConfig, final FileDataManager fileDataManager) {
+        super(verificationConfig, fileDataManager, null);
     }
 
     @Override
-    public void deleteFromVerifier(Extension extension) {
-        LOGGER.info("Delete {} extension from verifier", ExtensionActivator.getConnectorIdForExtension(extension));
+    protected void redeployMeta() {
     }
 }

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/IntegrationConfiguration.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/IntegrationConfiguration.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.common.model.extension.Extension;
+import io.syndesis.common.model.extension.Extension.Status;
 import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.dao.file.FileDataManager;
@@ -62,7 +63,7 @@ public class IntegrationConfiguration {
                 return dataManager.fetchAll(Extension.class,
                     resultList -> new ListResult.Builder<Extension>()
                         .items(resultList.getItems().stream()
-                            .filter(extension -> extension.getTags().contains(tag))
+                            .filter(extension -> extension.getStatus().orElse(Status.Installed) != Status.Deleted && extension.getTags().contains(tag))
                             .collect(Collectors.toList()))
                         .totalCount(resultList.getTotalCount())
                         .build()


### PR DESCRIPTION
I'm not exactly sure if this plays any effect in [ENTESB-12512](https://issues.redhat.com/browse/ENTESB-12512) as I cannot reproduce it. It might be an oversight, it might not be.

433af5e helps with running outside OpenShift/Kubernetes.