### PR TITLE
chore: flag for incremental build of staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "scripts": {
     "pre-commit:lint-staged": "lint-staged",
     "pre-commit:ui-react": "cd app/ui-react && yarn pre-commit",
-    "pre-push:ui-react": "./tools/bin/syndesis -m ui-react --incremental"
+    "pre-push:ui-react": "./tools/bin/syndesis -m ui-react --incremental --incremental-staged"
   }
 }

--- a/tools/bin/commands/util/common_funcs
+++ b/tools/bin/commands/util/common_funcs
@@ -240,7 +240,12 @@ has_changes() {
     local ref="${2:-master}"
     local hash="${CIRCLE_SHA1:-$(git rev-parse HEAD)}"
 
-    local changed_paths="$(git diff ..${ref} --name-only | tr '\n' ' ') $(git status --porcelain=v1 | cut -c 4- | tr '\n' ' ')"
+    local git_status_args=''
+    if [ $(hasflag --incremental-staged) ]; then
+      git_status_args='--untracked-files=no'
+    fi
+
+    local changed_paths="$(git diff ..${ref} --name-only | tr '\n' ' ') $(git status --porcelain=v1 ${git_status_args} | cut -c 4- | tr '\n' ' ')"
 
     # when on `master` on CircleCI, compute changed paths for the commit being built
     if [ "master" == "${CIRCLE_BRANCH:-}" ]; then


### PR DESCRIPTION
When husky runs pre-push script it often triggers on unstaged files in
the ui-react module, this adds `--incremental-staged` flag to `syndesis`
CLI so that build is run only for staged changes, i.e. unstaged changes
are ignored.