### PR TITLE
fix: make sure closable resources are closed

### DIFF
--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -77,6 +77,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>
       <scope>test</scope>

--- a/app/extension/converter/src/test/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzerTest.java
+++ b/app/extension/converter/src/test/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.converter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import io.syndesis.common.model.extension.Extension;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultBinaryExtensionAnalyzerTest {
+
+    static final byte[] ICON_BYTES = "<?xml version=\"1.0\" encoding=\"utf-8\"?><svg version=\"1.1\"></svg>".getBytes(StandardCharsets.US_ASCII);
+
+    static final byte[] DESCRIPTOR_BYTES = "{\"icon\":\"an icon\"}".getBytes(StandardCharsets.US_ASCII);
+
+    DefaultBinaryExtensionAnalyzer analyzer = new DefaultBinaryExtensionAnalyzer();
+
+    @Test
+    public void shouldReadExtension() throws IOException {
+        try (InputStream extensionStream = createExtension()) {
+            final Extension extension = analyzer.getExtension(extensionStream);
+
+            assertThat(extension.getIcon()).isEqualTo("an icon");
+        }
+    }
+
+    @Test
+    public void shouldReadIconStream() throws IOException {
+        try (InputStream extensionStream = createExtension()) {
+            Optional<InputStream> icon = analyzer.getIcon(extensionStream, "icon.svg");
+
+            assertThat(icon).hasValueSatisfying(s -> {
+                try (InputStream stream = s) {
+                    assertThat(stream).hasBinaryContent(ICON_BYTES);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+    }
+
+    private static InputStream createExtension() {
+        try (ByteArrayOutputStream buff = new ByteArrayOutputStream();
+            ZipOutputStream zip = new ZipOutputStream(buff)) {
+
+            zip.putNextEntry(new ZipEntry("META-INF/syndesis/icon.svg"));
+            zip.write(ICON_BYTES);
+            zip.closeEntry();
+
+            zip.putNextEntry(new ZipEntry("META-INF/syndesis/syndesis-extension-definition.json"));
+            zip.write(DESCRIPTOR_BYTES);
+            zip.closeEntry();
+
+            return new ByteArrayInputStream(buff.toByteArray());
+        } catch (final IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorIconHandler.java
@@ -45,8 +45,11 @@ import io.syndesis.common.model.icon.Icon;
 import io.syndesis.server.endpoint.v1.handler.BaseHandler;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.ResponseBody;
 import okio.BufferedSink;
+import okio.BufferedSource;
 import okio.Okio;
+import okio.Sink;
 import okio.Source;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
@@ -131,7 +134,6 @@ public final class ConnectorIconHandler extends BaseHandler {
     }
 
     @GET
-    @SuppressWarnings("PMD.CyclomaticComplexity")
     public Response get() {
         String connectorIcon = connector.getIcon();
         if (connectorIcon == null) {
@@ -140,36 +142,10 @@ public final class ConnectorIconHandler extends BaseHandler {
 
         if (connectorIcon.startsWith("db:")) {
             String connectorIconId = connectorIcon.substring(3);
-            Icon icon = getDataManager().fetch(Icon.class, connectorIconId);
-            if (icon == null) {
-                return Response.status(Response.Status.NOT_FOUND).build();
-            }
-            //grab icon file from the (Sql)FileStore
-            final StreamingOutput streamingOutput = (out) -> {
-                try (BufferedSink sink = Okio.buffer(Okio.sink(out));
-                    Source source = Okio.source(iconDao.read(connectorIconId))) {
-                    sink.writeAll(source);
-                }
-            };
-            return Response.ok(streamingOutput, icon.getMediaType()).build();
+            return fromDatabase(connectorIconId);
         } else if (connectorIcon.startsWith("extension:")) {
             String iconFile = connectorIcon.substring(10);
-            Optional<InputStream> extensionIcon = connector.getDependencies().stream()
-                .filter(Dependency::isExtension)
-                .map(Dependency::getId)
-                .findFirst()
-                .flatMap(extensionId -> extensionDataManager.getExtensionIcon(extensionId, iconFile));
-
-            if (extensionIcon.isPresent()) {
-                final StreamingOutput streamingOutput = (out) -> {
-                    try (BufferedSink sink = Okio.buffer(Okio.sink(out)); InputStream iconStream = extensionIcon.get()) {
-                        sink.writeAll(Okio.source(iconStream));
-                    }
-                };
-                return Response.ok(streamingOutput, extensionDataManager.getExtensionIconMediaType(iconFile)).build();
-            } else {
-                return Response.status(Response.Status.NOT_FOUND).build();
-            }
+            return fromExtension(iconFile);
         }
 
         // If the specified icon is a data URL, or a non-URL like value (e.g.
@@ -185,9 +161,12 @@ public final class ConnectorIconHandler extends BaseHandler {
             final String contentLength = externalResponse.header(CONTENT_LENGTH);
 
             final StreamingOutput streamingOutput = (out) -> {
-                final BufferedSink sink = Okio.buffer(Okio.sink(out));
-                sink.writeAll(externalResponse.body().source());
-                sink.close();
+                try (Sink iosink = Okio.sink(out);
+                    BufferedSink sink = Okio.buffer(iosink);
+                    ResponseBody body = externalResponse.body();
+                    BufferedSource source = body.source()) {
+                    sink.writeAll(source);
+                }
             };
 
             final Response.ResponseBuilder actualResponse = Response.ok(streamingOutput, contentType);
@@ -199,5 +178,44 @@ public final class ConnectorIconHandler extends BaseHandler {
         } catch (final IOException e) {
             throw new SyndesisServerException(e);
         }
+    }
+
+    private Response fromExtension(String iconFile) {
+        Optional<InputStream> extensionIcon = connector.getDependencies().stream()
+            .filter(Dependency::isExtension)
+            .map(Dependency::getId)
+            .findFirst()
+            .flatMap(extensionId -> extensionDataManager.getExtensionIcon(extensionId, iconFile));
+
+        if (!extensionIcon.isPresent()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        final StreamingOutput streamingOutput = (out) -> {
+            try (Sink iosink = Okio.sink(out);
+                BufferedSink sink = Okio.buffer(iosink);
+                InputStream iconStream = extensionIcon.get();
+                Source source = Okio.source(iconStream)) {
+                sink.writeAll(source);
+            }
+        };
+        return Response.ok(streamingOutput, extensionDataManager.getExtensionIconMediaType(iconFile)).build();
+    }
+
+    private Response fromDatabase(String connectorIconId) {
+        Icon icon = getDataManager().fetch(Icon.class, connectorIconId);
+        if (icon == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        //grab icon file from the (Sql)FileStore
+        final StreamingOutput streamingOutput = (out) -> {
+            try (Sink iosink = Okio.sink(out);
+                BufferedSink sink = Okio.buffer(iosink);
+                InputStream iconStream = iconDao.read(connectorIconId);
+                Source source = Okio.source(iconStream)) {
+                sink.writeAll(source);
+            }
+        };
+        return Response.ok(streamingOutput, icon.getMediaType()).build();
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/DefaultVerifierExtensionUploader.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/DefaultVerifierExtensionUploader.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.server.endpoint.v1.handler.extension;
 
+import java.io.IOException;
 import java.io.InputStream;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -27,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 
 import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import io.syndesis.common.model.extension.Extension;
+import io.syndesis.common.util.SyndesisServerException;
 import io.syndesis.server.dao.file.FileDataManager;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -76,15 +78,18 @@ public class DefaultVerifierExtensionUploader implements VerifierExtensionUpload
         String fileName = ExtensionActivator.getConnectorIdForExtension(extension);
         multipart.addFormData("fileName", fileName, MediaType.TEXT_PLAIN_TYPE);
 
-        InputStream is = fileDataManager.getExtensionBinaryFile(extension.getExtensionId());
-        multipart.addFormData("file", is, MediaType.APPLICATION_OCTET_STREAM_TYPE);
+        try (InputStream is = fileDataManager.getExtensionBinaryFile(extension.getExtensionId())) {
+            multipart.addFormData("file", is, MediaType.APPLICATION_OCTET_STREAM_TYPE);
 
-        GenericEntity<MultipartFormDataOutput> genericEntity = new GenericEntity<MultipartFormDataOutput>(multipart) {};
-        Entity<?> entity = Entity.entity(genericEntity, MediaType.MULTIPART_FORM_DATA_TYPE);
+            GenericEntity<MultipartFormDataOutput> genericEntity = new GenericEntity<MultipartFormDataOutput>(multipart) {};
+            Entity<?> entity = Entity.entity(genericEntity, MediaType.MULTIPART_FORM_DATA_TYPE);
 
-        Boolean isDeployed = target.request().post(entity, Boolean.class);
-        if (isDeployed) {
-            redeployMeta();
+            Boolean isDeployed = target.request().post(entity, Boolean.class);
+            if (isDeployed) {
+                redeployMeta();
+            }
+        } catch (IOException e) {
+            throw SyndesisServerException.launderThrowable(e);
         }
     }
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
@@ -77,6 +77,9 @@ import io.syndesis.server.endpoint.v1.operations.PaginationOptionsFromQueryParam
 import io.syndesis.server.endpoint.v1.util.PredicateFilter;
 import okio.BufferedSink;
 import okio.Okio;
+import okio.Sink;
+import okio.Source;
+
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -257,21 +260,28 @@ public class ExtensionHandler extends BaseHandler implements Getter<Extension>, 
     @Path("/{id}/stepIcon")
     public Response getStepIcon(@NotNull @PathParam("id") final String id) {
         Extension extension = getDataManager().fetch(Extension.class, id);
-        String extensionIconVal = extension.getIcon();
-        if (extensionIconVal.startsWith("extension:")) {
-            String iconFile = extensionIconVal.substring(10);
-            Optional<InputStream> extensionIcon = extensionDataManager.getExtensionIcon(extension.getExtensionId(), iconFile);
 
-            if (extensionIcon.isPresent()) {
-                final StreamingOutput streamingOutput = (out) -> {
-                    try (BufferedSink sink = Okio.buffer(Okio.sink(out)); InputStream iconStream = extensionIcon.get()) {
-                        sink.writeAll(Okio.source(iconStream));
-                    }
-                };
-                return Response.ok(streamingOutput, extensionDataManager.getExtensionIconMediaType(iconFile)).build();
-            }
+        String extensionIconVal = extension.getIcon();
+        if (!extensionIconVal.startsWith("extension:")) {
+            return Response.status(Response.Status.NOT_FOUND).build();
         }
-        return Response.status(Response.Status.NOT_FOUND).build();
+
+        String iconFile = extensionIconVal.substring(10);
+
+        Optional<InputStream> extensionIcon = extensionDataManager.getExtensionIcon(extension.getExtensionId(), iconFile);
+        if (!extensionIcon.isPresent()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        final StreamingOutput streamingOutput = (out) -> {
+            try (Sink iosink = Okio.sink(out);
+                BufferedSink sink = Okio.buffer(iosink);
+                InputStream iconStream = extensionIcon.get();
+                Source source = Okio.source(iconStream)) {
+                sink.writeAll(source);
+            }
+        };
+        return Response.ok(streamingOutput, extensionDataManager.getExtensionIconMediaType(iconFile)).build();
     }
 
 
@@ -290,33 +300,28 @@ public class ExtensionHandler extends BaseHandler implements Getter<Extension>, 
     private void storeFile(String location, MultipartFormDataInput dataInput) {
         // Store the artifact into the filestore
         try (InputStream file = getBinaryArtifact(dataInput)) {
+            if (file == null) {
+                throw new IllegalArgumentException("Can't find a valid 'file' part in the multipart request");
+            }
+
             fileStore.write(location, file);
         } catch (IOException ex) {
             throw SyndesisServerException.launderThrowable("Unable to store the file into the filestore", ex);
         }
     }
 
-    @Nonnull
-    @SuppressWarnings("PMD.CyclomaticComplexity")
     private static InputStream getBinaryArtifact(MultipartFormDataInput input) {
         if (input == null || input.getParts() == null || input.getParts().isEmpty()) {
             throw new IllegalArgumentException("Multipart request is empty");
         }
 
         try {
-            InputStream result;
             if (input.getParts().size() == 1) {
                 InputPart filePart = input.getParts().iterator().next();
-                result = filePart.getBody(InputStream.class, null);
-            } else {
-                result = input.getFormDataPart("file", InputStream.class, null);
+                return filePart.getBody(InputStream.class, null);
             }
 
-            if (result == null) {
-                throw new IllegalArgumentException("Can't find a valid 'file' part in the multipart request");
-            }
-
-            return result;
+            return input.getFormDataPart("file", InputStream.class, null);
         } catch (IOException e) {
             throw new IllegalArgumentException("Error while reading multipart request", e);
         }

--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.server.filestore.impl;
 
-import java.io.FilterInputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -345,7 +345,7 @@ public class SqlFileStore {
     /**
      * Allows closing a handle after the given {@link InputStream} has been fully read and closed.
      */
-    static class HandleCloserInputStream extends FilterInputStream {
+    static class HandleCloserInputStream extends BufferedInputStream {
 
         private final Handle handle;
 
@@ -359,9 +359,12 @@ public class SqlFileStore {
             try {
                 super.close();
             } finally {
-                handle.commit();
-
-                handle.close();
+                try {
+                    // Handle::commit() returns the same instance, this way we make sure it's closed
+                    handle.commit();
+                } finally {
+                    handle.close();
+                }
             }
         }
     }


### PR DESCRIPTION
When investigating ENTESB-15548[1] I've found several instances of
streams not being closed. Some of these streams are streams that are
obtained from the PostgreSQL JDBC driver and might lead to connection
leak. I haven't investigated if that's the case, other than what's
already noted on ENTESB-15548. I think this refactoring is safe.

[1] https://issues.redhat.com/browse/ENTESB-15548