### PR TITLE
fix: consider 'none' data shape present

### DIFF
--- a/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
+++ b/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
@@ -1,0 +1,50 @@
+import { DataShape, Step } from '@syndesis/models';
+import { DataShapeKinds } from '../../constants';
+import { hasDataShape } from '../integrationFunctions';
+
+describe('integration functions', () => {
+  test.each`
+    kind                   | place       | expected
+    ${undefined}           | ${'input'}  | ${'not present'}
+    ${undefined}           | ${'output'} | ${'not present'}
+    ${DataShapeKinds.NONE} | ${'input'}  | ${'present'}
+    ${DataShapeKinds.NONE} | ${'output'} | ${'not present'}
+    ${DataShapeKinds.ANY}  | ${'input'}  | ${'present'}
+    ${DataShapeKinds.ANY}  | ${'output'} | ${'present'}
+  `(
+    '$kind $place data shape should be asserted as $expected',
+    ({ kind, place, expected }) => {
+      const step = {
+        action: {
+          descriptor: {},
+        },
+      } as Step;
+
+      const dataShape = {
+        kind: kind as DataShapeKinds,
+      } as DataShape;
+
+      const isInput = place === 'input';
+      if (isInput) {
+        step.action!.descriptor!.inputDataShape = dataShape;
+      } else {
+        step.action!.descriptor!.outputDataShape = dataShape;
+      }
+
+      expect(hasDataShape(step, isInput)).toBe(expected === 'present');
+    }
+  );
+
+  it(`steps without actions don't have shapes`, () => {
+    const step = {};
+    expect(hasDataShape(step, true)).toBe(false);
+  });
+
+  it(`steps without action descriptors don't have shapes`, () => {
+    const step = {
+      action: {},
+    } as Step;
+
+    expect(hasDataShape(step, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
For cases where action's descriptor has data shape of type 'none' we
would assert that the data shape does not exist. This would cause us not
to recommend adding a mapping step between a input step with data shape
of 'none' and a step containing a data shape other than 'none'. In that
case we do wish to suggest adding a mapping step as mapper can operate
without inputs, i.e. it can add constant values and map those to the
output.

Fixes #3807
Ref https://issues.redhat.com/browse/ENTESB-11568

(cherry picked from commit bd1169884fc1aab7de130ba64350aba07680c1fa)