### PR TITLE
fix(ui) [ENTESB-11603] prevent configured properties from being cleared in integration + API connector editors

### DIFF
--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
@@ -46,10 +46,16 @@ export const SecurityPage: React.FunctionComponent = () => {
   });
 
   const defaultValues: ICreateConnectorProps = {
-    authenticationType: properties!.authenticationType?.defaultValue,
-    authorizationEndpoint: properties!.authorizationEndpoint?.defaultValue,
-    passwordType: properties!.passwordType?.defaultValue,
-    tokenEndpoint: properties!.tokenEndpoint?.defaultValue,
+    authenticationType:
+      configured?.authenticationType ||
+      properties!.authenticationType?.defaultValue,
+    authorizationEndpoint:
+      configured?.authorizationEndpoint ||
+      properties!.authorizationEndpoint?.defaultValue,
+    passwordType:
+      configured?.passwordType || properties!.passwordType?.defaultValue,
+    tokenEndpoint:
+      configured?.tokenEndpoint || properties!.tokenEndpoint?.defaultValue,
   };
 
   const dropdowns = {

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
@@ -194,7 +194,10 @@ export const ReviewPage: React.FunctionComponent = () => {
                       footer={
                         <ConnectionCreatorFooter
                           backHref={resolvers.create.configureConnector({
-                            connector,
+                            connector: {
+                              ...connector,
+                              configuredProperties: state.configuredProperties!,
+                            },
                           })}
                           cancelHref={resolvers.connections()}
                           onNext={submitForm}


### PR DESCRIPTION
fixes [ENTESB-11603](https://issues.redhat.com/browse/ENTESB-11603)

- for the Create Connection fix, include `configuredProperties` in `backHref` of the `ReviewPage`, since there is already a check in place for configured fields in `ConfigurationPage`
- went ahead and fixed this for the Security step of the API client connector as well, which, conversely, did _not_ check for configured fields in `SecurityPage`, so this check was added

![Kapture 2021-01-18 at 15 12 45](https://user-images.githubusercontent.com/3844502/104935144-c6cf9900-59a2-11eb-9e77-a4c850779af1.gif)
