### PR TITLE
chore: Update to AtlasMap 2.1.2

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <camel.version>3.4.4</camel.version>
-    <atlasmap.version>2.1.1</atlasmap.version>
+    <atlasmap.version>2.1.2</atlasmap.version>
     <jackson.version>2.11.3</jackson.version>
   </properties>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -41,7 +41,7 @@
     <assembly.skip>false</assembly.skip>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>2.1.1</atlasmap.version>
+    <atlasmap.version>2.1.2</atlasmap.version>
 
     <!-- Image namespace - can be overridden on cli -->
     <image.namespace>syndesis</image.namespace>

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -84,7 +84,7 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.1.1",
+    "@atlasmap/atlasmap": "^2.1.2",
     "react-fast-compare": "^3.1.1"
   },
   "jest": {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -226,19 +226,19 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.1.1.tgz#b22b3f2e3c0c4e854a47360004b32786d9bccb1a"
-  integrity sha512-9JgiiH6UME2WLDoH0uaAdzR8vdkIsnsrNuA0elmskYj5W0ZZjgyb1gyzxOXtNoRMOjZ+pRxT5hz/bxPwuxreoQ==
+"@atlasmap/atlasmap@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.1.2.tgz#63a37f05000d071f3ced4a8ee3f263bad2435709"
+  integrity sha512-tvPZ2aUmbE0CKYtT+4H0zt+UcO441AjRYeT2C9TZnpGAjgj4HdtJY21r19POIw+prx0EM6IVjCoKBTcESxP1Pg==
   dependencies:
-    "@atlasmap/core" "^2.1.1"
+    "@atlasmap/core" "^2.1.2"
     react-sage "^0.0.42"
     use-debounce "^3.4.2"
 
-"@atlasmap/core@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.1.1.tgz#a9a3226e4ca76a5572ff177873b1f71dc02434ce"
-  integrity sha512-lWxYBaKY/1+ismzlag3xTeg3UShxDwHy0JX5u+C0jcNuCM50hKmN9eaFERvfC50DPR82WtYvXi5URXItWkyb/Q==
+"@atlasmap/core@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.1.2.tgz#f92875d07dc40266835c0fd894cd21e9fd8dea42"
+  integrity sha512-RDZN3CFJPEmMCZoeCHuPY3TZO3O2lK0wmeKnSlq+tXWBfrZ00KPhIp/kIvCM3lZD/3S6zmfLYyj6dhYDeaSq/g==
   dependencies:
     file-saver "2.0.2"
     loglevel "^1.6.7"


### PR DESCRIPTION
Release Note: https://github.com/atlasmap/atlasmap/releases/tag/atlasmap-2.1.2