### PR TITLE
fix: make sure closable resources are closed

### DIFF
--- a/app/extension/converter/pom.xml
+++ b/app/extension/converter/pom.xml
@@ -77,6 +77,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>
       <scope>test</scope>

--- a/app/extension/converter/src/test/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzerTest.java
+++ b/app/extension/converter/src/test/java/io/syndesis/extension/converter/DefaultBinaryExtensionAnalyzerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.converter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import io.syndesis.common.model.extension.Extension;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultBinaryExtensionAnalyzerTest {
+
+    static final byte[] ICON_BYTES = "<?xml version=\"1.0\" encoding=\"utf-8\"?><svg version=\"1.1\"></svg>".getBytes(StandardCharsets.US_ASCII);
+
+    static final byte[] DESCRIPTOR_BYTES = "{\"icon\":\"an icon\"}".getBytes(StandardCharsets.US_ASCII);
+
+    DefaultBinaryExtensionAnalyzer analyzer = new DefaultBinaryExtensionAnalyzer();
+
+    @Test
+    public void shouldReadExtension() throws IOException {
+        try (InputStream extensionStream = createExtension()) {
+            final Extension extension = analyzer.getExtension(extensionStream);
+
+            assertThat(extension.getIcon()).isEqualTo("an icon");
+        }
+    }
+
+    @Test
+    public void shouldReadIconStream() throws IOException {
+        try (InputStream extensionStream = createExtension()) {
+            Optional<InputStream> icon = analyzer.getIcon(extensionStream, "icon.svg");
+
+            assertThat(icon).hasValueSatisfying(s -> {
+                try (InputStream stream = s) {
+                    assertThat(stream).hasBinaryContent(ICON_BYTES);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        }
+    }
+
+    private static InputStream createExtension() {
+        try (ByteArrayOutputStream buff = new ByteArrayOutputStream();
+            ZipOutputStream zip = new ZipOutputStream(buff)) {
+
+            zip.putNextEntry(new ZipEntry("META-INF/syndesis/icon.svg"));
+            zip.write(ICON_BYTES);
+            zip.closeEntry();
+
+            zip.putNextEntry(new ZipEntry("META-INF/syndesis/syndesis-extension-definition.json"));
+            zip.write(DESCRIPTOR_BYTES);
+            zip.closeEntry();
+
+            return new ByteArrayInputStream(buff.toByteArray());
+        } catch (final IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -131,7 +131,7 @@
     <node-sass-version>4.12.0</node-sass-version>
 
     <!-- Common dependencies -->
-    <assertj-core.version>3.14.0</assertj-core.version>
+    <assertj-core.version>3.16.1</assertj-core.version>
     <shrinkwrap.version>2.2.6</shrinkwrap.version>
 
     <mailapi.version>1.6.4</mailapi.version>

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
@@ -48,7 +48,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
 
-import io.syndesis.common.util.json.JsonUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.slf4j.Logger;
@@ -80,6 +79,8 @@ import io.syndesis.common.model.integration.IntegrationOverview;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.common.util.Names;
+import io.syndesis.common.util.SuppressFBWarnings;
+import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.integration.api.IntegrationProjectGenerator;
 import io.syndesis.integration.api.IntegrationResourceManager;
 import io.syndesis.server.dao.file.FileDataManager;
@@ -168,53 +169,57 @@ public class IntegrationSupportHandler {
     @GET
     @Path("/export.zip")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public StreamingOutput export(@NotNull @QueryParam("id") @Parameter(required = true) List<String> requestedIds) throws IOException {
+    public StreamingOutput export(@NotNull @QueryParam("id") @Parameter(required = true) List<String> requestedIds) {
 
-        List<String> ids = requestedIds;
+        final List<String> ids = requestedIds;
         if ( ids ==null || ids.isEmpty() ) {
             throw new ClientErrorException("No 'integration' query parameter specified.", Response.Status.BAD_REQUEST);
         }
 
-        CloseableJsonDB memJsonDB = MemorySqlJsonDB.create(jsondb.getIndexes());
-        if( ids.contains("all") ) {
-            ids = new ArrayList<>();
-            for (Integration integration : dataManager.fetchAll(Integration.class)) {
-                ids.add(integration.getId().get());
-            }
-        }
-        LinkedHashSet<String> extensions = new LinkedHashSet<>();
-        LinkedHashSet<String> icons = new LinkedHashSet<>();
-        for (String id : ids) {
-            Integration integration = integrationHandler.getIntegration(id);
-            addToExport(memJsonDB, integration);
-            Collection<Dependency> dependencies = resourceManager.collectDependencies(integration.getFlows().stream()
-                    .flatMap(flow -> flow.getSteps().stream())
-                    .collect(Collectors.toList()), true);
-            dependencies.stream()
-                .filter(d -> d.isExtension() || d.isIcon() )
-                .map(Dependency::getId)
-                .forEach(extensions::add);
-        }
-        LOG.debug("Extensions: {}", extensions);
-        LOG.debug("Icons: {}", icons);
-
         return out -> {
-            try (ZipOutputStream tos = new ZipOutputStream(out) ) {
+            try (ZipOutputStream tos = new ZipOutputStream(out);
+                CloseableJsonDB memJsonDB = MemorySqlJsonDB.create(jsondb.getIndexes())) {
+
+                if( ids.contains("all") ) {
+                    ids.clear();
+                    for (Integration integration : dataManager.fetchAll(Integration.class)) {
+                        ids.add(integration.getId().get());
+                    }
+                }
+                LinkedHashSet<String> extensions = new LinkedHashSet<>();
+                LinkedHashSet<String> icons = new LinkedHashSet<>();
+                for (String id : ids) {
+                    Integration integration = integrationHandler.getIntegration(id);
+                    addToExport(memJsonDB, integration);
+                    Collection<Dependency> dependencies = resourceManager.collectDependencies(integration.getFlows().stream()
+                            .flatMap(flow -> flow.getSteps().stream())
+                            .collect(Collectors.toList()), true);
+                    dependencies.stream()
+                        .filter(d -> d.isExtension() || d.isIcon() )
+                        .map(Dependency::getId)
+                        .forEach(extensions::add);
+                }
+                LOG.debug("Extensions: {}", extensions);
+                LOG.debug("Icons: {}", icons);
+
                 ModelExport exportObject = ModelExport.of(Schema.VERSION);
                 addEntry(tos, EXPORT_MODEL_INFO_FILE_NAME, JsonUtils.writer().writeValueAsBytes(exportObject));
                 addEntry(tos, EXPORT_MODEL_FILE_NAME, memJsonDB.getAsByteArray("/"));
-                memJsonDB.close();
                 for (String extensionId : extensions) {
-                    addEntry(tos, "extensions/" + Names.sanitize(extensionId) + ".jar", IOUtils.toByteArray(
-                        extensionDataManager.getExtensionBinaryFile(extensionId)
-                    ));
+                    try (InputStream extensionStream = extensionDataManager.getExtensionBinaryFile(extensionId)) {
+                        final byte[] extensionBytes = IOUtils.toByteArray(extensionStream);
+                        addEntry(tos, "extensions/" + Names.sanitize(extensionId) + ".jar", extensionBytes);
+                    }
                 }
                 for (String iconId : icons) {
                     Icon icon = getDataManager().fetch(Icon.class, iconId);
                     String ext = MediaType.valueOf(icon.getMediaType()).getSubtype();
                     String name = iconId.substring(3);
-                    byte[] bytes = IOUtils.toByteArray(iconDao.read(name));
-                    addEntry(tos, "icons/" + name + "." + ext, bytes);
+
+                    try (InputStream iconStream = iconDao.read(name)) {
+                        byte[] bytes = IOUtils.toByteArray(iconStream);
+                        addEntry(tos, "icons/" + name + "." + ext, bytes);
+                    }
                 }
             }
         };
@@ -290,10 +295,10 @@ public class IntegrationSupportHandler {
                 }
 
                 if (EXPORT_MODEL_FILE_NAME.equals(entry.getName())) {
-                    CloseableJsonDB memJsonDB = MemorySqlJsonDB.create(jsondb.getIndexes());
-                    memJsonDB.set("/", nonClosing(zis));
-                    imported.putAll(importModels(sec, modelExport, memJsonDB));
-                    memJsonDB.close();
+                    try (CloseableJsonDB memJsonDB = MemorySqlJsonDB.create(jsondb.getIndexes())) {
+                        memJsonDB.set("/", nonClosing(zis));
+                        imported.putAll(importModels(sec, modelExport, memJsonDB));
+                    }
                 }
 
                 // import missing extensions that were in the model.
@@ -316,42 +321,49 @@ public class IntegrationSupportHandler {
         }
     }
 
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", "NP_LOAD_OF_KNOWN_NULL_VALUE", "NP_LOAD_OF_KNOWN_NULL_VALUE"})
     private void importMissingExtensions(ZipInputStream zis, ZipEntry entry,
             Map<String, List<WithResourceId>> imported) throws IOException {
 
-        if( entry.getName().startsWith("extensions/") ) {
-            for (WithResourceId extension : imported.getOrDefault("extensions", Collections.emptyList())) {
-                // use extension's correlation Id with extension ZipEntry
-                final String extensionId = ((Extension)extension).getExtensionId();
-                if( entry.getName().equals("extensions/" + Names.sanitize(extensionId) + ".jar") ) {
-                    // path in filestore uses id instead of extensionId
-                    String path = "/extensions/" + extension.getId().get();
-                    InputStream existing = extensionDataManager.getExtensionDataAccess().read(path);
-                    if( existing == null ) {
-                        // write blob in jsondb
-                        extensionDataManager.getExtensionDataAccess().write(path, zis);
+        if (!entry.getName().startsWith("extensions/")) {
+            return;
+        }
 
-                        // also activate the imported extension
-                        extensionActivator.activateExtension((Extension) extension);
-                    } else {
-                        existing.close();
-                    }
+        for (WithResourceId extension : imported.getOrDefault("extensions", Collections.emptyList())) {
+            // use extension's correlation Id with extension ZipEntry
+            final String extensionId = ((Extension) extension).getExtensionId();
+            final String extensionFileName = "extensions/" + Names.sanitize(extensionId) + ".jar";
+            if (!entry.getName().equals(extensionFileName)) {
+                continue;
+            }
+
+            // path in filestore uses id instead of extensionId
+            String path = "/extensions/" + extension.getId().get();
+            try (InputStream existing = extensionDataManager.getExtensionDataAccess().read(path)) {
+                if (existing != null) {
+                    continue;
                 }
+
+                // write blob in jsondb
+                extensionDataManager.getExtensionDataAccess().write(path, zis);
+
+                // also activate the imported extension
+                extensionActivator.activateExtension((Extension) extension);
             }
         }
     }
 
+    @SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", "NP_LOAD_OF_KNOWN_NULL_VALUE", "NP_LOAD_OF_KNOWN_NULL_VALUE"})
     private void importMissingCustomIcons(ZipInputStream zis, ZipEntry entry) throws IOException {
 
         if( entry.getName().startsWith("icons/") ) {
             String fileName = entry.getName().substring(6);
             String id = fileName.substring(0, fileName.indexOf('.'));
-            InputStream existing = iconDao.read(id);
-            if( existing == null) {
-                // write the icon to the (Sql)FileStore
-                iconDao.write(id, zis);
-            } else {
-                existing.close();
+            try (InputStream existing = iconDao.read(id)) {
+                if (existing == null) {
+                    // write the icon to the (Sql)FileStore
+                    iconDao.write(id, zis);
+                }
             }
         }
     }

--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -15,7 +15,7 @@
  */
 package io.syndesis.server.filestore.impl;
 
-import java.io.FilterInputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -339,7 +339,7 @@ public class SqlFileStore {
     /**
      * Allows closing a handle after the given {@link InputStream} has been fully read and closed.
      */
-    static class HandleCloserInputStream extends FilterInputStream {
+    static class HandleCloserInputStream extends BufferedInputStream {
 
         private final Handle handle;
 
@@ -353,9 +353,12 @@ public class SqlFileStore {
             try {
                 super.close();
             } finally {
-                handle.commit();
-
-                handle.close();
+                try {
+                    // Handle::commit() returns the same instance, this way we make sure it's closed
+                    handle.commit();
+                } finally {
+                    handle.close();
+                }
             }
         }
     }


### PR DESCRIPTION
When investigating ENTESB-15548[1] I've found several instances of
streams not being closed. Some of these streams are streams that are
obtained from the PostgreSQL JDBC driver and might lead to connection
leak. I haven't investigated if that's the case, other than what's
already noted on ENTESB-15548. I think this refactoring is safe.

[1] https://issues.redhat.com/browse/ENTESB-15548

(cherry picked from commit 54fd7ff931aafe7445a03daae4a9528d9baa9ad7)

```
# Conflicts:
#	app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/DefaultVerifierExtensionUploader.java
#	app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/support/IntegrationSupportHandler.java
```