### PR TITLE
fix(ui): [ENTESB-11411] display a generic step icon when replacing a step

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorSidebar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorSidebar.tsx
@@ -57,11 +57,9 @@ export interface IEditorSidebarProps {
   activeIndex: number;
   initialExpanded?: boolean;
 }
-export const EditorSidebar: React.FunctionComponent<
-  IEditorSidebarProps & {
-    isAdding: boolean;
-  }
-> = ({ activeIndex, activeStep, initialExpanded, steps, isAdding }) => {
+export const EditorSidebar: React.FunctionComponent<IEditorSidebarProps & {
+  isAdding: boolean;
+}> = ({ activeIndex, activeStep, initialExpanded, steps, isAdding }) => {
   const UISteps = toUIStepCollection(steps);
   return (
     <IntegrationVerticalFlow initialExpanded={initialExpanded}>
@@ -123,6 +121,7 @@ export const EditorSidebar: React.FunctionComponent<
             <>
               {UISteps.map((s, idx) => {
                 const isActive = idx === activeIndex;
+                const step = isActive && activeStep ? activeStep : s;
                 const hasAddStep = isAdding && activeIndex === idx + 1;
                 const isAfterActiveAddStep = activeIndex - 1 < idx;
                 const position =
@@ -130,29 +129,41 @@ export const EditorSidebar: React.FunctionComponent<
 
                 return (
                   <React.Fragment key={idx}>
-                    <IntegrationFlowStepWithOverview
-                      icon={
-                        <EntityIcon
-                          alt={s.name}
-                          entity={s}
-                          width={24}
-                          height={24}
-                        />
-                      }
-                      i18nTitle={`${position}. ${s.name}`}
-                      i18nTooltip={`${position}. ${s.title}`}
-                      active={
-                        isAdding ? isActive && !isAfterActiveAddStep : isActive
-                      }
-                      showDetails={expanded}
-                      name={s.name}
-                      action={s.action && s.action.name!}
-                      dataType={
-                        idx === 0
-                          ? getDataShapeText(s.stepKind!, s.outputDataShape)
-                          : getDataShapeText(s.stepKind!, s.inputDataShape)
-                      }
-                    />
+                    {!isAdding && isActive && !activeStep ? (
+                      makeActiveStep(
+                        position,
+                        expanded,
+                        'Set up this step',
+                        'Choose a step',
+                        undefined
+                      )
+                    ) : (
+                      <IntegrationFlowStepWithOverview
+                        icon={
+                          <EntityIcon
+                            alt={step.name}
+                            entity={step}
+                            width={24}
+                            height={24}
+                          />
+                        }
+                        i18nTitle={`${position}. ${step.name}`}
+                        i18nTooltip={`${position}. ${step.title}`}
+                        active={
+                          isAdding
+                            ? isActive && !isAfterActiveAddStep
+                            : isActive
+                        }
+                        showDetails={expanded}
+                        name={step.name}
+                        action={step.action && step.action.name!}
+                        dataType={
+                          idx === 0
+                            ? getDataShapeText(step.stepKind!, step.outputDataShape)
+                            : getDataShapeText(step.stepKind!, step.inputDataShape)
+                        }
+                      />
+                    )}
                     {hasAddStep
                       ? makeActiveStep(
                           position + 1,


### PR DESCRIPTION
fixes [ENTESB-11411](https://issues.redhat.com/browse/ENTESB-11411) where the previous step still shows on the sidebar/vertical navigation after the user has selected for it to be replaced with a different step.

![Kapture 2021-01-27 at 14 41 14](https://user-images.githubusercontent.com/3844502/106121477-8369ed00-614f-11eb-94c8-2a1b61d92379.gif)
