### PR TITLE
chore(deps): upgrade testcontainers to 1.15.1

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -144,7 +144,8 @@
     <junit.version>4.13.1</junit.version>
     <junit5.version>5.6.2</junit5.version>
     <powermock.version>2.0.7</powermock.version>
-    <testcontainers.version>1.14.3</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
+    <docker-java.version>3.2.7</docker-java.version>
     <citrus.version>3.0.0-M1</citrus.version>
     <mockito.version>3.3.3</mockito.version>
 
@@ -3403,6 +3404,12 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>mariadb</artifactId>
         <version>${testcontainers.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-api</artifactId>
+        <version>${docker-java.version}</version>
       </dependency>
 
       <!-- Citrus -->

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -227,6 +227,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/offline/OfflineS2IBuild_IT.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.test.itest.offline;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 import io.syndesis.common.model.integration.Integration;
@@ -45,7 +44,7 @@ public class OfflineS2IBuild_IT {
         .build();
 
     @Test
-    public void s2iBuildShouldBeOffline() throws IOException {
+    public void s2iBuildShouldBeOffline() {
         final ProjectBuilder builder = new SpringBootProjectBuilder("offline-project", SyndesisTestEnvironment.getSyndesisVersion());
 
         final Project project = builder.build(() -> integration);
@@ -56,13 +55,14 @@ public class OfflineS2IBuild_IT {
 
             final String containerId = containerInfo.getId();
 
-            try (DockerClient docker = s2i.getDockerClient();
-                InspectContainerCmd inspectCmd = docker.inspectContainerCmd(containerId)) {
+            @SuppressWarnings("resource") // global docker client, we musn't close it
+            final DockerClient docker = s2i.getDockerClient(); 
+            try (InspectContainerCmd inspectCmd = docker.inspectContainerCmd(containerId)) {
 
                 // for some reason containerInfo.getState().getExitCode() always
                 // returns 0 so we run the `docker inspect` command instead
                 final ContainerState state = inspectCmd.exec().getState();
-                assertThat(state.getExitCode())
+                assertThat(state.getExitCodeLong())
                     .describedAs(new Description() {
                         @Override
                         public String value() {

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -161,6 +161,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
Not sure why we can't pull testcontainers/ryuk image in GitHub actions
perhaps upgrading testcontainers would help with this.