### PR TITLE
fix: tolerate repeated close of extension stream

### DIFF
--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -356,6 +356,11 @@ public class SqlFileStore {
 
         @Override
         public void close() throws IOException {
+            if (in == null) {
+                // we closed already;
+                return;
+            }
+
             try {
                 super.close();
             } finally {


### PR DESCRIPTION
The stream we pass from the database to the HTTP client will be closed
by the HTTP client, it might be closed only for happy day cases or it
might be closed for both happy and error cases, we don't have control
over that. If we use try-with-resources, as we do currently, we might
try to close the same stream twice: once by the HTTP client once by the
try-with-resources.

This allows the stream to be closed multiple times.

Ref. https://issues.redhat.com/browse/ENTESB-15671