### PR TITLE
feat(integration): support pollEnrich

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
@@ -58,7 +58,7 @@ public interface Action extends WithResourceId, WithKind, WithName, WithTags, Wi
     String TYPE_CONNECTOR = "connector";
     String TYPE_STEP = "step";
 
-    enum Pattern { From, Pipe, To }
+    enum Pattern { From, Pipe, To, PollEnrich }
 
     @Override
     default Kind getKind() {
@@ -71,7 +71,7 @@ public interface Action extends WithResourceId, WithKind, WithName, WithTags, Wi
 
     ActionDescriptor getDescriptor();
 
-    Pattern getPattern();
+    Optional<Pattern> getPattern();
 
     @JsonIgnore
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/app/connector/support/maven-plugin/src/main/resources/connector-schema.json
+++ b/app/connector/support/maven-plugin/src/main/resources/connector-schema.json
@@ -143,7 +143,8 @@
               "type": "string"
             },
             "pattern": {
-              "type": "string"
+              "type": "string",
+              "enum": ["From", "Pipe", "To", "PollEnrich"]
             },
             "tags": {
               "type": "array",

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyEndpoint.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyEndpoint.java
@@ -18,6 +18,7 @@ package io.syndesis.integration.component.proxy;
 import org.apache.camel.Consumer;
 import org.apache.camel.DelegateEndpoint;
 import org.apache.camel.Endpoint;
+import org.apache.camel.PollingConsumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.api.management.ManagedAttribute;
@@ -64,6 +65,14 @@ public class ComponentProxyEndpoint extends DefaultEndpoint implements DelegateE
         // create consumer with the pipeline
         final Processor pipeline = Pipeline.newInstance(getCamelContext(), beforeConsumer, processor, afterConsumer);
         final Consumer consumer = endpoint.createConsumer(pipeline);
+        configureConsumer(consumer);
+
+        return consumer;
+    }
+
+    @Override
+    public PollingConsumer createPollingConsumer() throws Exception {
+        final PollingConsumer consumer = endpoint.createPollingConsumer();
         configureConsumer(consumer);
 
         return consumer;

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/Processors.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/Processors.java
@@ -18,7 +18,9 @@ package io.syndesis.integration.component.proxy;
 import java.util.Collection;
 
 import org.apache.camel.Processor;
+import org.apache.camel.model.language.ConstantExpression;
 import org.apache.camel.processor.Pipeline;
+import org.apache.camel.processor.PollEnricher;
 
 public final class Processors {
 
@@ -86,4 +88,10 @@ public final class Processors {
         }
     }
 
+    public static Processor pollEnricher(final String endpointUri, final ComponentProxyComponent proxyComponent) {
+        final PollEnricher pollEnricher = new PollEnricher(new ConstantExpression(endpointUri), -1);
+        pollEnricher.setDefaultAggregationStrategy();
+
+        return Pipeline.newInstance(proxyComponent.getCamelContext(), proxyComponent.getBeforeConsumer(), pollEnricher, proxyComponent.getAfterConsumer());
+    }
 }

--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -192,7 +192,12 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockftpserver</groupId>
+      <artifactId>MockFtpServer</artifactId>
+      <version>2.7.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerPollEnrichIT.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerPollEnrichIT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.integration.runtime.handlers;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import io.syndesis.common.model.action.Action.Pattern;
+import io.syndesis.common.model.action.ActionDescriptor.ActionDescriptorStep;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.connection.Connection;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.common.model.integration.StepKind;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.properties.PropertiesComponent;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockftpserver.fake.FakeFtpServer;
+import org.mockftpserver.fake.UserAccount;
+import org.mockftpserver.fake.filesystem.DirectoryEntry;
+import org.mockftpserver.fake.filesystem.FileEntry;
+import org.mockftpserver.fake.filesystem.FileSystem;
+import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
+
+import static io.syndesis.integration.runtime.IntegrationTestSupport.newIntegrationRouteBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectorStepHandlerPollEnrichIT {
+
+    private static final ConnectorAction FTP_ACTION_FETCH = new ConnectorAction.Builder()
+        .id("io.syndesis.ftp:fetch")
+        .pattern(Pattern.PollEnrich)
+        .descriptor(new ConnectorDescriptor.Builder()
+            .addConnectorCustomizer(TestCustomizer.class.getName())
+            .addPropertyDefinitionStep(new ActionDescriptorStep.Builder()
+                .putProperty("directory", new ConfigurationProperty.Builder()
+                    .kind("path")
+                    .build())
+                .putProperty("fileName", new ConfigurationProperty.Builder()
+                    .kind("parameter")
+                    .build())
+                .build())
+            .build())
+        .build();
+
+    private static final Connector FTP_CONNECTOR = new Connector.Builder()
+        .id("ftp")
+        .componentScheme("ftp")
+        .putProperty("host", new ConfigurationProperty.Builder()
+            .kind("path")
+            .componentProperty(true)
+            .build())
+        .putProperty("port", new ConfigurationProperty.Builder()
+            .kind("path")
+            .componentProperty(true)
+            .build())
+        .putProperty("username", new ConfigurationProperty.Builder()
+            .kind("parameter")
+            .componentProperty(true)
+            .build())
+        .putProperty("password", new ConfigurationProperty.Builder()
+            .kind("parameter")
+            .secret(true)
+            .componentProperty(true)
+            .build())
+        .addAction(FTP_ACTION_FETCH)
+        .build();
+
+    private static int port;
+
+    private static FakeFtpServer server;
+
+    private static final ConnectorAction TIMER_ACTION_PERIOD = new ConnectorAction.Builder()
+        .id("io.syndesis:timer-action")
+        .pattern(Pattern.From)
+        .descriptor(new ConnectorDescriptor.Builder()
+            .componentScheme("timer")
+            .addPropertyDefinitionStep(new ActionDescriptorStep.Builder()
+                .putProperty("period", new ConfigurationProperty.Builder()
+                    .kind("parameter")
+                    .build())
+                .build())
+            .putConfiguredProperty("timerName", "tick")
+            .build())
+        .build();
+
+    private static final Connector TIMER_CONNECTOR = new Connector.Builder()
+        .id("timer")
+        .addAction(TIMER_ACTION_PERIOD)
+        .build();
+
+    public static class TestCustomizer implements ComponentProxyCustomizer {
+
+        static boolean afterInvoked;
+
+        static boolean beforeInvoked;
+
+        @Override
+        public void customize(final ComponentProxyComponent component, final Map<String, Object> options) {
+            component.setBeforeConsumer(exchange -> {
+                beforeInvoked = true;
+                assertThat(exchange.getProperty(Exchange.TIMER_COUNTER, Integer.class)).isNotZero();
+            });
+            component.setAfterConsumer(exchange -> {
+                afterInvoked = true;
+                assertThat(exchange.getIn().getBody(String.class)).isEqualTo("Hi there");
+            });
+        }
+    }
+
+    @Test
+    public void shouldSupportPollEnriching() throws Exception {
+        final DefaultCamelContext context = new DefaultCamelContext();
+
+        final PropertiesComponent propertiesComponent = new PropertiesComponent();
+
+        final Properties extra = new Properties();
+        extra.put("flow-0.ftp-1.password", "password");
+        propertiesComponent.setOverrideProperties(extra);
+
+        propertiesComponent.setInitialProperties(extra);
+        context.addComponent("properties", propertiesComponent);
+
+        try {
+            final RouteBuilder routes = newIntegrationRouteBuilder(
+                new Step.Builder()
+                    .stepKind(StepKind.endpoint)
+                    .action(TIMER_ACTION_PERIOD)
+                    .connection(
+                        new Connection.Builder()
+                            .connector(TIMER_CONNECTOR)
+                            .build())
+                    .putConfiguredProperty("period", "1000")
+                    .build(),
+                new Step.Builder()
+                    .stepKind(StepKind.endpoint)
+                    .action(FTP_ACTION_FETCH)
+                    .connection(
+                        new Connection.Builder()
+                            .connector(FTP_CONNECTOR)
+                            .putConfiguredProperty("username", "user")
+                            .putConfiguredProperty("password", "/*encrypted*/")
+                            .putConfiguredProperty("host", "localhost")
+                            .putConfiguredProperty("port", String.valueOf(port))
+                            .build())
+                    .putConfiguredProperty("directory", "/home/user")
+                    .putConfiguredProperty("fileName", "test.txt")
+                    .build(),
+                new Step.Builder()
+                    .stepKind(StepKind.endpoint)
+                    .action(new ConnectorAction.Builder()
+                        .descriptor(new ConnectorDescriptor.Builder()
+                            .componentScheme("mock")
+                            .putConfiguredProperty("name", "result")
+                            .build())
+                        .build())
+                    .build());
+
+            context.addRoutes(routes);
+            context.start();
+
+            final MockEndpoint result = (MockEndpoint) context.getEndpoints().stream().filter(e -> e instanceof MockEndpoint).findFirst().get();
+
+            MockEndpoint.assertWait(2, TimeUnit.SECONDS, result);
+
+            result.expectedBodiesReceived("Hi there");
+
+            MockEndpoint.assertIsSatisfied(context);
+
+            assertThat(TestCustomizer.beforeInvoked).isTrue();
+            assertThat(TestCustomizer.afterInvoked).isTrue();
+        } finally {
+            context.stop();
+        }
+    }
+
+    @BeforeClass
+    public static void startFtpServer() {
+        server = new FakeFtpServer();
+        server.setServerControlPort(0);
+        server.addUserAccount(new UserAccount("user", "password", "/home/user"));
+
+        final FileSystem files = new UnixFakeFileSystem();
+        files.add(new DirectoryEntry("/home/user"));
+        files.add(new FileEntry("/home/user/test.txt", "Hi there"));
+        server.setFileSystem(files);
+
+        server.start();
+
+        port = server.getServerControlPort();
+    }
+
+    @AfterClass
+    public static void stopFtpServer() {
+        server.stop();
+    }
+}

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
@@ -138,7 +138,7 @@ public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTes
             assertThat(a.getActionType()).isEqualTo(ConnectorAction.TYPE_CONNECTOR);
             assertThat(a.getName()).isNotEmpty();
             assertThat(a.getDescription()).isNotEmpty();
-            assertThat(a.getPattern()).isEqualTo(Action.Pattern.To);
+            assertThat(a.getPattern()).contains(Action.Pattern.To);
 
             final ConnectorDescriptor descriptor = a.getDescriptor();
             assertThat(descriptor).isNotNull();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandler.java
@@ -136,9 +136,8 @@ public class ConnectionActionHandler {
             .forEach(step -> step.getProperties().forEach((k, v) -> parameters.putIfAbsent(k, null)));
 
         // add the pattern as a property
-        if (action.getPattern() != null) {
-            parameters.put(action.getPattern().getDeclaringClass().getSimpleName(), action.getPattern().name());
-        }
+        action.getPattern().ifPresent(pattern -> parameters.put("Pattern", pattern.name()));
+
         // lastly put all connection properties
         parameters.putAll(encryptionComponent.decrypt(connection.getConfiguredProperties()));
 

--- a/app/ui-react/packages/api/src/WithConnection.tsx
+++ b/app/ui-react/packages/api/src/WithConnection.tsx
@@ -1,19 +1,15 @@
 import { Action, ConnectionOverview } from '@syndesis/models';
 import * as React from 'react';
 import { IFetchState } from './Fetch';
-import {
-  getActionsWithFrom,
-  getActionsWithPipe,
-  getActionsWithTo,
-} from './helpers';
+import { getActionsWithPattern } from './helpers';
 import { SyndesisFetch } from './SyndesisFetch';
 
 export interface IConnectionOverviewExtended extends ConnectionOverview {
   readonly actionsWithFrom: Action[];
   readonly actionsWithPipe: Action[];
   readonly actionsWithTo: Action[];
+  readonly actionsWithPollEnrich: Action[];
 }
-
 
 export interface IWithConnectionProps {
   id: string;
@@ -36,13 +32,20 @@ export class WithConnection extends React.Component<IWithConnectionProps> {
             ...response,
             data: {
               ...response.data,
-              actionsWithFrom: getActionsWithFrom(
+              actionsWithFrom: getActionsWithPattern(
+                'From',
                 response.data.connector ? response.data.connector.actions : []
               ),
-              actionsWithPipe: getActionsWithPipe(
+              actionsWithPipe: getActionsWithPattern(
+                'Pipe',
                 response.data.connector ? response.data.connector.actions : []
               ),
-              actionsWithTo: getActionsWithTo(
+              actionsWithPollEnrich: getActionsWithPattern(
+                'PollEnrich',
+                response.data.connector ? response.data.connector.actions : []
+              ),
+              actionsWithTo: getActionsWithPattern(
+                'To',
                 response.data.connector ? response.data.connector.actions : []
               ),
             },

--- a/app/ui-react/packages/api/src/helpers/__test__/connectionFunctions.spec.ts
+++ b/app/ui-react/packages/api/src/helpers/__test__/connectionFunctions.spec.ts
@@ -1,0 +1,29 @@
+import { Action } from '@syndesis/models';
+import { getActionsWithPattern } from '../connectionFunctions';
+
+describe('connection functions', () => {
+  it(`filters actions by pattern`, () => {
+    const actions = [
+      'Pipe',
+      'From',
+      'To',
+      'From',
+      'To',
+      'From',
+      'From',
+      'To',
+      'Pipe',
+      'PollEnrich',
+    ].map(
+      p =>
+        ({
+          pattern: p,
+        } as Action)
+    );
+
+    expect(getActionsWithPattern('From', actions)).toHaveLength(4);
+    expect(getActionsWithPattern('To', actions)).toHaveLength(3);
+    expect(getActionsWithPattern('Pipe', actions)).toHaveLength(2);
+    expect(getActionsWithPattern('PollEnrich', actions)).toHaveLength(1);
+  });
+});

--- a/app/ui-react/packages/api/src/helpers/connectionFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/connectionFunctions.ts
@@ -11,16 +11,8 @@ import {
 } from '@syndesis/models';
 import { getMetadataValue } from './integrationFunctions';
 
-export function getActionsWithFrom(actions: Action[] = []) {
-  return actions.filter(a => a.pattern === 'From');
-}
-
-export function getActionsWithTo(actions: Action[] = []) {
-  return actions.filter(a => a.pattern === 'To');
-}
-
-export function getActionsWithPipe(actions: Action[] = []) {
-  return actions.filter(a => a.pattern === 'Pipe');
+export function getActionsWithPattern(pattern: string, actions: Action[] = []) {
+  return actions.filter(a => a.pattern === pattern);
 }
 
 export function getConnectionMetadataValue(

--- a/app/ui-react/packages/api/src/useConnection.tsx
+++ b/app/ui-react/packages/api/src/useConnection.tsx
@@ -1,11 +1,5 @@
 import { IConnectionOverview } from '@syndesis/models';
-import {
-  getActionsWithFrom,
-  getActionsWithPipe,
-  getActionsWithTo,
-  isConfigRequired,
-  isDerived,
-} from './helpers';
+import { getActionsWithPattern, isConfigRequired, isDerived } from './helpers';
 import { useApiResource } from './useApiResource';
 import { transformConnectorResponse } from './useConnector';
 import { useServerEvents } from './useServerEvents';
@@ -19,9 +13,22 @@ export const transformConnectionResponse = (
     : undefined;
   return {
     ...connection,
-    actionsWithFrom: getActionsWithFrom(connector ? connector.actions : []),
-    actionsWithPipe: getActionsWithPipe(connector ? connector.actions : []),
-    actionsWithTo: getActionsWithTo(connector ? connector.actions : []),
+    actionsWithFrom: getActionsWithPattern(
+      'From',
+      connector ? connector.actions : []
+    ),
+    actionsWithPipe: getActionsWithPattern(
+      'Pipe',
+      connector ? connector.actions : []
+    ),
+    actionsWithPollEnrich: getActionsWithPattern(
+      'PollEnrich',
+      connector ? connector.actions : []
+    ),
+    actionsWithTo: getActionsWithPattern(
+      'To',
+      connector ? connector.actions : []
+    ),
     connector,
     derived: isDerived(connection),
     isConfigRequired: isConfigRequired(connection),

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -3212,7 +3212,7 @@
           },
           "pattern": {
             "type": "string",
-            "enum": ["From", "Pipe", "To"]
+            "enum": ["From", "Pipe", "To", "PollEnrich"]
           },
           "metadata": {
             "type": "object",
@@ -3665,7 +3665,7 @@
           },
           "pattern": {
             "type": "string",
-            "enum": ["From", "Pipe", "To"]
+            "enum": ["From", "Pipe", "To", "PollEnrich"]
           },
           "metadata": {
             "type": "object",

--- a/app/ui-react/packages/models/openapi.json
+++ b/app/ui-react/packages/models/openapi.json
@@ -947,7 +947,7 @@
           },
           "pattern": {
             "type": "string",
-            "enum": ["From", "Pipe", "To"]
+            "enum": ["From", "Pipe", "To", "PollEnrich"]
           },
           "metadata": {
             "type": "object",
@@ -1958,7 +1958,7 @@
           },
           "pattern": {
             "type": "string",
-            "enum": ["From", "Pipe", "To"]
+            "enum": ["From", "Pipe", "To", "PollEnrich"]
           },
           "metadata": {
             "type": "object",

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -66,13 +66,20 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                     );
                     // if we're looking at the 1st step, only show
                     // actions with 'From'.  If we're looking at the
-                    // last step, only show actions with 'To'.
-                    // Otherwise, show actions with 'To' and 'Pipe'.
+                    // last step, only show actions with 'To' or 'PollEnrich'.
+                    // Otherwise, show actions with 'To', 'Pipe' or 'PollEnrich'.
                     const actions =
                       positionAsNumber > 0
                         ? positionAsNumber === steps.length
-                          ? data.actionsWithTo
-                          : [...data.actionsWithTo, ...data.actionsWithPipe]
+                          ? [
+                              ...data.actionsWithTo,
+                              ...data.actionsWithPollEnrich,
+                            ]
+                          : [
+                              ...data.actionsWithTo,
+                              ...data.actionsWithPipe,
+                              ...data.actionsWithPollEnrich,
+                            ]
                         : data.actionsWithFrom;
                     return (
                       <>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -435,7 +435,11 @@ export function filterStepsByPosition(
     if ((step.connection || (step as Connection)).connector) {
       return (step.connection || (step as Connection)).connector!.actions.some(
         (action: ConnectorAction) => {
-          return action.pattern === 'To' || action.pattern === 'Pipe';
+          return (
+            action.pattern === 'To' ||
+            action.pattern === 'Pipe' ||
+            action.pattern === 'PollEnrich'
+          );
         }
       );
     }


### PR DESCRIPTION
This adds support for Connector Actions with `PollEnrich` pattern placed
other than at first step of the Integration Flow by using Poll Enrich
EIP.

To utilize this support, Connector Action needs to declare the `pattern`
as `PollEnrich` and the connector's Camel component needs to support
`PollingConsumer`.

To support before/after consumers for poll enrich, we're not using the
`pollEnrich` Route DSL, but we're adding `PollEnricher` processor
directly to the route via `process` Route DSL method. This allows us
to add a pipeline of `before-PollEnricher-after` processors.

User interface now allows actions with the `PollEnrich` pattern in all
but the first step.

(cherry picked from commit 0b068adf3b5e65c99936518edf6983faa2f3106f)

```
# Conflicts:
#	app/integration/runtime/pom.xml
#	app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
#	app/pom.xml
```