### PR TITLE
chore: Upgrade to Citrus 3.0.0-M3

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -146,7 +146,7 @@
     <powermock.version>2.0.7</powermock.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <docker-java.version>3.2.7</docker-java.version>
-    <citrus.version>3.0.0-M1</citrus.version>
+    <citrus.version>3.0.0-M3</citrus.version>
     <mockito.version>3.3.3</mockito.version>
 
     <greenmail.version>1.5.14</greenmail.version>
@@ -3387,19 +3387,16 @@
           </exclusion>
         </exclusions>
       </dependency>
-
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>jdbc</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
-
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${testcontainers.version}</version>
       </dependency>
-
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>mariadb</artifactId>
@@ -3412,38 +3409,13 @@
         <version>${docker-java.version}</version>
       </dependency>
 
-      <!-- Citrus -->
       <dependency>
-        <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-core</artifactId>
-        <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.consol.citrus</groupId>
-            <artifactId>citrus-validation-xml</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-api</artifactId>
+        <version>3.2.7</version>
       </dependency>
+
+      <!-- Citrus -->
       <dependency>
         <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-endpoint-catalog</artifactId>
@@ -3456,27 +3428,8 @@
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-java-dsl</artifactId>
-        <version>${citrus.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-api</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
@@ -3485,14 +3438,13 @@
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-spring</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-validation-hamcrest</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
@@ -3500,79 +3452,30 @@
         <version>${citrus.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-groovy</artifactId>
+        <version>${citrus.version}</version>
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-jms</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.jms</groupId>
-            <artifactId>com.springsource.javax.jms</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-http</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-ftp</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.icegreen</groupId>
@@ -3595,28 +3498,8 @@
         <version>${citrus.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -3624,16 +3507,6 @@
         <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-ws</artifactId>
         <version>${citrus.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -67,22 +67,22 @@
     <!-- Citrus -->
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -97,17 +97,17 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-groovy</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-validation-hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-http</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-java-dsl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -225,6 +225,10 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.github.docker-java</groupId>
@@ -304,8 +308,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.jms</groupId>
-      <artifactId>javax.jms-api</artifactId>
+      <groupId>jakarta.jms</groupId>
+      <artifactId>jakarta.jms-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/SyndesisIntegrationTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/SyndesisIntegrationTestSupport.java
@@ -18,7 +18,7 @@ package io.syndesis.test.itest;
 
 import javax.sql.DataSource;
 
-import com.consol.citrus.junit.JUnit4CitrusSupport;
+import com.consol.citrus.junit.spring.JUnit4CitrusSpringSupport;
 import io.syndesis.test.container.db.SyndesisDbContainer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Christoph Deppisch
  */
 @ContextConfiguration(classes = SyndesisIntegrationTestSupport.EndpointConfig.class)
-public abstract class SyndesisIntegrationTestSupport extends JUnit4CitrusSupport {
+public abstract class SyndesisIntegrationTestSupport extends JUnit4CitrusSpringSupport {
 
     private static final SyndesisDbContainer syndesisDb;
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -84,12 +84,14 @@ public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
     @CitrusTest
     public void testHttpToAMQ(@CitrusResource TestCaseRunner runner) {
         runner.given(send().endpoint(todoJms)
-                .payload("{\"id\": \"1\", \"name\":\"Learn some #golang\", \"done\": 1}"));
+                .message()
+                .body("{\"id\": \"1\", \"name\":\"Learn some #golang\", \"done\": 1}"));
 
         runner.when(http().server(todoApiServer)
                 .receive()
                 .post()
-                .payload("{\"id\": \"1\", \"task\":\"Learn some #golang\", \"completed\": 1}"));
+                .message()
+                .body("{\"id\": \"1\", \"task\":\"Learn some #golang\", \"completed\": 1}"));
 
         runner.then(http().server(todoApiServer)
                 .send()

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -90,11 +90,13 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
                 .send()
                 .response(HttpStatus.OK)
-                .payload("[{\"id\": \"1\", \"task\":\"Learn to play drums\", \"completed\": 0}," +
+                .message()
+                .body("[{\"id\": \"1\", \"task\":\"Learn to play drums\", \"completed\": 0}," +
                           "{\"id\": \"2\", \"task\":\"Learn to play guitar\", \"completed\": 1}]"));
 
         runner.then(receive().endpoint(todoJms)
-                        .payload("[{\"id\": \"1\", \"name\":\"Learn to play drums\", \"done\": 0}," +
+                        .message()
+                        .body("[{\"id\": \"1\", \"name\":\"Learn to play drums\", \"done\": 0}," +
                                   "{\"id\": \"2\", \"name\":\"Learn to play guitar\", \"done\": 1}]"));
     }
 
@@ -108,10 +110,12 @@ public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
                 .send()
                 .response(HttpStatus.OK)
-                .payload("[]"));
+                .message()
+                .body("[]"));
 
         runner.then(receive().endpoint(todoJms)
-                        .payload("[]"));
+                        .message()
+                        .body("[]"));
     }
 
     @Configuration

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2ApiKeyInHeader_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2ApiKeyInHeader_IT.java
@@ -84,13 +84,15 @@ public class TodoApiV2ApiKeyInHeader_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
             .receive()
             .get("/api")
+            .message()
             .header("keyName", "secret"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
+            .body("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
     }
 
     @Configuration

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2ApiKeyInQuery_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2ApiKeyInQuery_IT.java
@@ -89,8 +89,9 @@ public class TodoApiV2ApiKeyInQuery_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
+            .body("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
     }
 
     @Configuration

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2BasicAuth_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoApiV2BasicAuth_IT.java
@@ -84,13 +84,15 @@ public class TodoApiV2BasicAuth_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
             .receive()
             .get("/api")
+            .message()
             .header("Authorization", "Basic citrus:encodeBase64('syndesis:secret')"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
+            .body("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
     }
 
     @Configuration

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector_IT.java
@@ -88,28 +88,32 @@ public class TodoOpenApiV2Connector_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
             .receive()
             .post("/api")
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"task\":\"${task}\", \"completed\": 0}"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.CREATED)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("Update task"));
 
         runner.when(http().server(todoApiServer)
             .receive()
             .put("/api/${id}")
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"citrus:upperCase(${task})\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"citrus:upperCase(${task})\", \"completed\": 0}"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("Fetch task by id"));
 
@@ -120,8 +124,9 @@ public class TodoOpenApiV2Connector_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("List all tasks"));
 
@@ -132,8 +137,9 @@ public class TodoOpenApiV2Connector_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
+            .body("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
 
         runner.run(echo("Delete task by id"));
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector_IT.java
@@ -88,28 +88,32 @@ public class TodoOpenApiV3Connector_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
             .receive()
             .post("/api")
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"task\":\"${task}\", \"completed\": 0}"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.CREATED)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("Update task"));
 
         runner.when(http().server(todoApiServer)
             .receive()
             .put("/api/${id}")
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"citrus:upperCase(${task})\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"citrus:upperCase(${task})\", \"completed\": 0}"));
 
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("Fetch task by id"));
 
@@ -120,8 +124,9 @@ public class TodoOpenApiV3Connector_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
+            .body("{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}"));
 
         runner.run(echo("List all tasks"));
 
@@ -132,8 +137,9 @@ public class TodoOpenApiV3Connector_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
             .send()
             .response(HttpStatus.OK)
+            .message()
             .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-            .payload("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
+            .body("[{\"id\": ${id}, \"task\":\"${task}\", \"completed\": 0}]"));
 
         runner.run(echo("Delete task by id"));
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
@@ -89,8 +89,9 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
+                .message()
                 .contentType(VND_OAI_OPENAPI_JSON)
-                .payload(new ClassPathResource("todo-api.json", TodoApi_IT.class)));
+                .body(new ClassPathResource("todo-api.json", TodoApi_IT.class)));
     }
 
     @Test
@@ -108,7 +109,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("{\"name\":\"Walk the dog\",\"done\":0}"));
+                .message()
+                .body("{\"name\":\"Walk the dog\",\"done\":0}"));
     }
 
     @Test
@@ -128,7 +130,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[{\"name\":\"Wash the dog\",\"done\":0}," +
+                .message()
+                .body("[{\"name\":\"Wash the dog\",\"done\":0}," +
                             "{\"name\":\"Feed the dog\",\"done\":0}," +
                             "{\"name\":\"Play with the dog\",\"done\":0}]"));
     }
@@ -152,7 +155,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[{\"name\":\"Wash the dog\",\"done\":0}," +
+                .message()
+                .body("[{\"name\":\"Wash the dog\",\"done\":0}," +
                             "{\"name\":\"Feed the dog\",\"done\":0}," +
                             "{\"name\":\"Play with the dog\",\"done\":0}]"));
     }
@@ -176,7 +180,8 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[{\"name\":\"Play piano\",\"done\":1}," +
+                .message()
+                .body("[{\"name\":\"Play piano\",\"done\":1}," +
                             "{\"name\":\"Play guitar\",\"done\":1}]"));
     }
 
@@ -192,7 +197,6 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
@@ -90,8 +90,9 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoListApiClient)
                 .receive()
                 .response(HttpStatus.OK)
+                .message()
                 .contentType(VND_OAI_OPENAPI_JSON)
-                .payload(new ClassPathResource("todolist-api.json", TodoApi_IT.class)));
+                .body(new ClassPathResource("todolist-api.json", TodoApi_IT.class)));
     }
 
     @Test
@@ -102,7 +103,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
         runner.given(http().client(todoListApiClient)
                 .send()
                 .post("/todos")
-                .payload("[{\"name\":\"Wash the cat\",\"done\":0}," +
+                .message()
+                .body("[{\"name\":\"Wash the cat\",\"done\":0}," +
                             "{\"name\":\"Feed the cat\",\"done\":0}," +
                             "{\"name\":\"Play with the cat\",\"done\":0}]"));
 
@@ -133,7 +135,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoListApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[{\"id\":\"@ignore@\",\"name\":\"Wash the dog\",\"done\":0}," +
+                .message()
+                .body("[{\"id\":\"@ignore@\",\"name\":\"Wash the dog\",\"done\":0}," +
                             "{\"id\":\"@ignore@\",\"name\":\"Feed the dog\",\"done\":0}," +
                             "{\"id\":\"@ignore@\",\"name\":\"Play with the dog\",\"done\":0}]"));
     }
@@ -150,7 +153,8 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoListApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[]"));
+                .message()
+                .body("[]"));
     }
 
     @Configuration
@@ -165,7 +169,6 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
@@ -96,8 +96,9 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
+                .message()
                 .contentType(VND_OAI_OPENAPI_JSON)
-                .payload(new ClassPathResource("todo-openapi-v3.json", TodoOpenApiV3_IT.class)));
+                .body(new ClassPathResource("todo-openapi-v3.json", TodoOpenApiV3_IT.class)));
     }
 
     @Test
@@ -117,7 +118,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("{\"id\":${id},\"task\":\"Walk the dog\",\"completed\":0}"));
+                .message()
+                .body("{\"id\":${id},\"task\":\"Walk the dog\",\"completed\":0}"));
     }
 
     @Test
@@ -149,12 +151,14 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(todoApiClient)
             .send()
             .put("/api/${id}")
-            .payload("{\"id\":${id},\"task\":\"WALK THE DOG\",\"completed\":1}"));
+            .message()
+            .body("{\"id\":${id},\"task\":\"WALK THE DOG\",\"completed\":1}"));
 
         runner.then(http().client(todoApiClient)
             .receive()
             .response(HttpStatus.OK)
-            .payload("{\"id\":${id},\"task\":\"WALK THE DOG\",\"completed\":1}"));
+            .message()
+            .body("{\"id\":${id},\"task\":\"WALK THE DOG\",\"completed\":1}"));
 
         runner.then(query(sampleDb)
             .statement("select task, completed from todo where id=${id}")
@@ -202,7 +206,8 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().client(todoApiClient)
                 .receive()
                 .response(HttpStatus.OK)
-                .payload("[" +
+                .message()
+                .body("[" +
                         "{\"id\":\"@ignore@\",\"task\":\"Wash the dog\",\"completed\":0}," +
                         "{\"id\":\"@ignore@\",\"task\":\"Feed the dog\",\"completed\":0}," +
                         "{\"id\":\"@ignore@\",\"task\":\"Play with the dog\",\"completed\":0}" +
@@ -221,7 +226,6 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
@@ -75,7 +75,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("John", "Red Hat")));
+                .message()
+                .body(contact("John", "Red Hat")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -92,7 +93,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("Bill", "Microsoft")));
+                .message()
+                .body(contact("Bill", "Microsoft")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -109,7 +111,8 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("Joanna", "Red Hat")));
+                .message()
+                .body(contact("Joanna", "Red Hat")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -140,7 +143,6 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
@@ -130,7 +130,6 @@ public abstract class FtpTestSupport extends SyndesisIntegrationTestSupport {
 
     protected void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
@@ -91,7 +91,8 @@ public class WebHookToFtp_IT extends FtpTestSupport {
                 .send()
                 .post()
                 .fork(true)
-                .payload("{\"first_name\":\"${first_name}\",\"company\":\"${company}\",\"mail\":\"${email}\"}"));
+                .message()
+                .body("{\"first_name\":\"${first_name}\",\"company\":\"${company}\",\"mail\":\"${email}\"}"));
 
         runner.then(receive()
                 .endpoint(ftpTestServer)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
@@ -93,14 +93,16 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
                 .send()
                 .response(HttpStatus.OK)
-                .payload("[{\"id\": \"1\", \"task\":\"Learn to play drums\", \"completed\": 0}," +
+                .message()
+                .body("[{\"id\": \"1\", \"task\":\"Learn to play drums\", \"completed\": 0}," +
                           "{\"id\": \"2\", \"task\":\"Learn to play guitar\", \"completed\": 0}," +
                           "{\"id\": \"3\", \"task\":\"Important: Learn to play piano\", \"completed\": 0}]"));
 
         runner.then(http().server(todoApiServer)
                 .receive()
                 .put()
-                .payload("{\"id\": \"1\", \"task\":\"Important: Learn to play drums\", \"completed\": 0}"));
+                .message()
+                .body("{\"id\": \"1\", \"task\":\"Important: Learn to play drums\", \"completed\": 0}"));
 
         runner.when(http().server(todoApiServer)
                 .send()
@@ -109,7 +111,8 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(todoApiServer)
                 .receive()
                 .put()
-                .payload("{\"id\": \"2\", \"task\":\"Important: Learn to play guitar\", \"completed\": 0}"));
+                .message()
+                .body("{\"id\": \"2\", \"task\":\"Important: Learn to play guitar\", \"completed\": 0}"));
 
         runner.when(http().server(todoApiServer)
                 .send()
@@ -129,7 +132,8 @@ public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(todoApiServer)
                 .send()
                 .response(HttpStatus.OK)
-                .payload("[]"));
+                .message()
+                .body("[]"));
 
         runner.then(receiveTimeout(todoApiServer)
                 .timeout(1000L));

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
@@ -100,7 +100,8 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
                 .send()
                 .post()
                 .fork(true)
-                .payload(getWebhookPayload()));
+                .message()
+                .body(getWebhookPayload()));
 
         String mailBody = FileUtils.readToString(new ClassPathResource("mail.txt", SendMail_IT.class));
         runner.when(receive().endpoint(mailServer)
@@ -135,9 +136,11 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
                 .send()
                 .post()
                 .fork(true)
-                .payload(getWebhookPayload()));
+                .message()
+                .body(getWebhookPayload()));
 
         runner.when(receive().endpoint(mailServer)
+                        .message()
                         .header(CitrusMailMessageHeaders.MAIL_FROM, "people-team@syndesis.org")
                         .header(CitrusMailMessageHeaders.MAIL_TO, "${email}")
                         .header(CitrusMailMessageHeaders.MAIL_SUBJECT, "Welcome!"));
@@ -184,7 +187,6 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
@@ -70,7 +70,8 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
         runner.given(http().client(webHookClient)
                 .send()
                 .post()
-                .payload("{\"task\":\"My new task!\"}"));
+                .message()
+                .body("{\"task\":\"My new task!\"}"));
 
         runner.when(http().client(webHookClient)
                 .receive()
@@ -93,7 +94,6 @@ public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from todo"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -64,7 +64,8 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
         runner.when(http().server(googleSheetsApiServer)
                         .receive()
                         .put()
-                        .payload("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Jackson\",\"Red Hat\"]]}"));
+                        .message()
+                        .body("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Jackson\",\"Red Hat\"]]}"));
 
         runner.then(http().server(googleSheetsApiServer)
                         .send()
@@ -73,7 +74,8 @@ public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
         runner.then(http().server(googleSheetsApiServer)
                 .receive()
                 .put()
-                .payload("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joanne\",\"Jackson\",\"Red Hat\"]]}"));
+                .message()
+                .body("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joanne\",\"Jackson\",\"Red Hat\"]]}"));
 
         runner.then(http().server(googleSheetsApiServer)
                 .send()

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -64,7 +64,8 @@ public class DBToSheets_IT extends GoogleSheetsTestSupport {
         runner.when(http().server(googleSheetsApiServer)
                         .receive()
                         .put()
-                        .payload("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Jackson\",\"Red Hat\"],[\"Joanne\",\"Jackson\",\"Red Hat\"]]}"));
+                        .message()
+                        .body("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Jackson\",\"Red Hat\"],[\"Joanne\",\"Jackson\",\"Red Hat\"]]}"));
 
         runner.then(http().server(googleSheetsApiServer)
                         .send()

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
@@ -79,7 +79,6 @@ public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
                     .endpoint(googleSheetsApiServer));
 
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from contact"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -65,7 +65,8 @@ public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
         runner.when(http().server(googleSheetsApiServer)
                         .receive()
                         .post()
-                        .payload("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Red Hat\"],[\"Joanne\",\"Red Hat\"]]}"));
+                        .message()
+                        .body("{\"majorDimension\":\"ROWS\",\"values\":[[\"Joe\",\"Red Hat\"],[\"Joanne\",\"Red Hat\"]]}"));
 
         runner.then(http().server(googleSheetsApiServer)
                         .send()

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
@@ -59,8 +59,9 @@ public class SheetsToSheets_IT extends GoogleSheetsTestSupport {
             runner.then(http().server(googleSheetsApiServer)
                     .send()
                     .response(HttpStatus.OK)
+                    .message()
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .payload("{" +
+                    .body("{" +
                                 "\"spreadsheetId\": \"testSheetId\"," +
                                 "\"valueRanges\": [" +
                                     "{" +
@@ -74,7 +75,8 @@ public class SheetsToSheets_IT extends GoogleSheetsTestSupport {
             runner.when(http().server(googleSheetsApiServer)
                     .receive()
                     .put("/v4/spreadsheets/testSheetId/values/Copy!A:E")
-                    .payload("{\"majorDimension\":\"ROWS\",\"values\":[[\"a1\", \"b1\", \"c1\", \"d1\", \"e1\"]]}"));
+                    .message()
+                    .body("{\"majorDimension\":\"ROWS\",\"values\":[[\"a1\", \"b1\", \"c1\", \"d1\", \"e1\"]]}"));
 
             runner.then(http().server(googleSheetsApiServer)
                     .send()

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -87,8 +87,9 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().server(httpTestServer)
                 .receive()
                 .put()
+                .message()
                 .selector(Collections.singletonMap("jsonPath:$.contact", "@startsWith(Joanne)@"))
-                .payload("{\"contact\":\"Joanne Jackson Red Hat\"}"));
+                .body("{\"contact\":\"Joanne Jackson Red Hat\"}"));
 
         runner.then(http().server(httpTestServer)
                 .send()
@@ -97,8 +98,9 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
         runner.then(http().server(httpTestServer)
                 .receive()
                 .put()
+                .message()
                 .selector(Collections.singletonMap("jsonPath:$.contact", "@startsWith(Joe)@"))
-                .payload("{\"contact\":\"Joe Jackson Red Hat\"}"));
+                .body("{\"contact\":\"Joe Jackson Red Hat\"}"));
 
         runner.then(http().server(httpTestServer)
                 .send()
@@ -120,7 +122,6 @@ public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from contact"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
@@ -76,7 +76,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contacts( "Red Hat", "John", "Johnny")));
+                .message()
+                .body(contacts( "Red Hat", "John", "Johnny")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -93,7 +94,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contacts("Microsoft", "Bill", "Johnny")));
+                .message()
+                .body(contacts("Microsoft", "Bill", "Johnny")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -110,7 +112,8 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contacts( "Red Hat", "Unknown")));
+                .message()
+                .body(contacts( "Red Hat", "Unknown")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -147,7 +150,6 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from contact"));
     }
 }

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
@@ -87,7 +87,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("John", "Red Hat")));
+                .message()
+                .body(contact("John", "Red Hat")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -104,7 +105,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("Bill", "Microsoft")));
+                .message()
+                .body(contact("Bill", "Microsoft")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -121,7 +123,8 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
         runner.when(http().client(webHookClient)
                 .send()
                 .post()
-                .payload(contact("Unknown", "Red Hat")));
+                .message()
+                .body(contact("Unknown", "Red Hat")));
 
         runner.then(http().client(webHookClient)
                 .receive()
@@ -152,7 +155,6 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
 
     private void cleanupDatabase(TestCaseRunner runner) {
         runner.given(sql(sampleDb)
-            .dataSource(sampleDb)
             .statement("delete from contact"));
     }
 }

--- a/app/test/test-support/pom.xml
+++ b/app/test/test-support/pom.xml
@@ -121,6 +121,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>

--- a/app/test/test-support/src/main/java/io/syndesis/test/model/IntegrationRuntime.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/model/IntegrationRuntime.java
@@ -31,14 +31,14 @@ public class IntegrationRuntime {
     public static final IntegrationRuntime SPRING_BOOT = new IntegrationRuntime("spring-boot",
             "spring-boot:run",
         "syndesis/syndesis-s2i",
-            Wait.forLogMessage(".*Started Application.*\\s", 1),
+            Wait.forLogMessage("^.*Started Application.*\\n$", 1),
             SpringBootProjectBuilder::new);
 
 
     public static final IntegrationRuntime CAMEL_K = new IntegrationRuntime("camel-k",
             "process-resources exec:java",
         "syndesis/syndesis-s2i-camelk",
-            Wait.forLogMessage(".*Apache Camel .* started.*\\s", 1),
+            Wait.forLogMessage("^.*Apache Camel .* started.*\\n$", 1),
             CamelKProjectBuilder::new);
 
     private final String id;


### PR DESCRIPTION
- Fixes javax vs jakarta exclusions in Citrus
- Use new Citrus Java DSL
- Make use of new Citrus modularity