### PR TITLE
chore: endpoint parameters in component proxy

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
@@ -63,6 +63,12 @@ public interface WithConfigurationProperties {
     }
 
     @JsonIgnore
+    default boolean isProxyEndpointProperty(final String propertyName) {
+        final ConfigurationProperty property = getProperties().get(propertyName);
+        return property != null && "proxyParameter".equals(property.getKind());
+    }
+
+    @JsonIgnore
     default boolean isSecret(Entry<String, String> e) {
         return this.isSecret(e.getKey());
     }

--- a/app/common/model/src/test/java/io/syndesis/common/model/WithConfigurationPropertiesTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/WithConfigurationPropertiesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.common.model;
+
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WithConfigurationPropertiesTest {
+
+    @Test
+    public void shouldDetectProxyEndpointParameters() {
+        assertThat(new ConnectorAction.Builder().build().isProxyEndpointProperty("nonexistant")).isFalse();
+
+        assertThat(new ConnectorAction.Builder()
+            .descriptor(new ConnectorDescriptor.Builder().build())
+            .build()
+            .isProxyEndpointProperty("nonexistant")).isFalse();
+
+        assertThat(new ConnectorAction.Builder()
+            .descriptor(new ConnectorDescriptor.Builder()
+                .withActionDefinitionStep("step", "description", s -> s.putProperty("key", new ConfigurationProperty.Builder().build()))
+                .build())
+            .build()
+            .isProxyEndpointProperty("key")).isFalse();
+
+        assertThat(new ConnectorAction.Builder()
+            .descriptor(new ConnectorDescriptor.Builder()
+                .withActionDefinitionStep("step", "description", s -> s.putProperty("key", new ConfigurationProperty.Builder()
+                    .kind("proxyParameter")
+                    .build()))
+                .build())
+            .build()
+            .isProxyEndpointProperty("key")).isTrue();
+    }
+}

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
@@ -161,9 +161,6 @@ public class ComponentProxyComponent extends DefaultComponent {
         // in DefaultConnectorComponent.validateParameters()
         parameters.clear();
 
-        // remove temporary options
-        this.remainingOptions.clear();
-
         return answer;
     }
 
@@ -403,7 +400,7 @@ public class ComponentProxyComponent extends DefaultComponent {
         }
 
         // add extra options from remaining (context-path)
-        if (remaining != null) {
+        if (ObjectHelper.isNotEmpty(remaining)) {
             String targetUri = componentScheme + ":" + remaining;
             final Map<String, String> extra;
             try {

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyEndpoint.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyEndpoint.java
@@ -73,7 +73,7 @@ public class ComponentProxyEndpoint extends DefaultEndpoint implements DelegateE
     @Override
     public PollingConsumer createPollingConsumer() throws Exception {
         final PollingConsumer consumer = endpoint.createPollingConsumer();
-        configureConsumer(consumer);
+        configurePollingConsumer(consumer);
 
         return consumer;
     }

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/Processors.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/Processors.java
@@ -17,8 +17,9 @@ package io.syndesis.integration.component.proxy;
 
 import java.util.Collection;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Processor;
-import org.apache.camel.model.language.ConstantExpression;
+import org.apache.camel.model.language.SimpleExpression;
 import org.apache.camel.processor.Pipeline;
 import org.apache.camel.processor.PollEnricher;
 
@@ -89,9 +90,11 @@ public final class Processors {
     }
 
     public static Processor pollEnricher(final String endpointUri, final ComponentProxyComponent proxyComponent) {
-        final PollEnricher pollEnricher = new PollEnricher(new ConstantExpression(endpointUri), -1);
+        final PollEnricher pollEnricher = new PollEnricher(new SimpleExpression(endpointUri), 0);
+        final CamelContext camelContext = proxyComponent.getCamelContext();
+        pollEnricher.setCamelContext(camelContext);
         pollEnricher.setDefaultAggregationStrategy();
 
-        return Pipeline.newInstance(proxyComponent.getCamelContext(), proxyComponent.getBeforeConsumer(), pollEnricher, proxyComponent.getAfterConsumer());
+        return Pipeline.newInstance(camelContext, proxyComponent.getBeforeConsumer(), pollEnricher, proxyComponent.getAfterConsumer());
     }
 }

--- a/app/integration/runtime/pom.xml
+++ b/app/integration/runtime/pom.xml
@@ -149,6 +149,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-ftp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-olingo4</artifactId>
       <scope>test</scope>
     </dependency>

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandler.java
@@ -148,30 +148,32 @@ public class ConnectorStepHandler implements IntegrationStepHandler, Integration
         }
         context.addComponent(component.getComponentId(), component);
 
-        final String endpointUri = createProxyComponentUri(flowIndex, stepIndex, scheme, step); 
+        final String endpointUri = createProxyComponentUri(flowIndex, stepIndex, scheme, step);
 
-        final ProcessorDefinition<?> definition;
-        if (route == null) {
-            // we're at step 0
-            definition = builder.from(endpointUri);
-        } else {
-            // route exists we passed step 0
-            final Pattern pattern = action.getPattern().orElse(Pattern.To);
-            switch (pattern) {
-            case To:
-            case Pipe:
-            case From: // sql-start connector uses From
-                definition = route.to(endpointUri);
-                break;
-            case PollEnrich:
-                definition = route.process(pollEnricher(endpointUri, component));
-                break;
-            default:
-                throw new UnsupportedOperationException("'" + pattern + "' pattern not supported");
-            }
-        }
+        final ProcessorDefinition<?> definition = createRouteElement(route, builder, action, component, endpointUri);
 
         return Optional.ofNullable(definition);
+    }
+
+    static ProcessorDefinition<?> createRouteElement(final ProcessorDefinition<?> route, final IntegrationRouteBuilder builder, final ConnectorAction action,
+        final ComponentProxyComponent component, final String endpointUri) {
+        if (route == null) {
+            // we're at step 0
+            return builder.from(endpointUri);
+        }
+
+        // route exists we passed step 0
+        final Pattern pattern = action.getPattern().orElse(Pattern.To);
+        switch (pattern) {
+        case To:
+        case Pipe:
+        case From: // sql-start connector uses From
+            return route.to(endpointUri);
+        case PollEnrich:
+            return route.process(pollEnricher(endpointUri, component));
+        default:
+            throw new UnsupportedOperationException("'" + pattern + "' pattern not supported");
+        }
     }
 
     static String createProxyComponentUri(final String flowIndex, final String stepIndex, final String scheme, final Step step) {


### PR DESCRIPTION
When using Pool Enrich EIP, Consumer that's being pooled operates on a
Exchange created from scratch, so we can't pass data from the Exchange
used in the Route flow preceding Poll Enrich. The only option is to
pass data via endpoint parameters. The endpoint that's accessible from
the route is Component Proxy endpoint, and as implemented did not
support any endpoint parameters.

So to pass data from the running exchange into the Poll Enriched
Consumer via endpoint parameters, Component Proxy needed to support
endpoint parameters, i.e. when generating Component Proxy Endpoint we
need to separate parameters that will be passed on the Component Proxy
Endpoint vs parameters that will be passed to the delegate Endpoint
directly. For this `kind` property of the Action now supports value
`"proxyParameter"` in addition to `"path"` and `"parameter"` used to
pass parameters to the delegated Endpoint. When `kind` is set to
`"proxyParameter"` that parameter is passed via the Component Proxy
endpoint, e.g. `component-F-S:?param=value`, instead of setting
parameter on the delegated Endpoint.

With this in Poll Enrich EIP we now can use dynamic endpoints, with the
first use case in the FTP connector when the `fileName` property is
passed via `CamelFileName` header to the FTP Polling Consumer within the
Poll Enrichment EIP.