### PR TITLE
fix: make sure messages are captured in pollenrich

### DIFF
--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerPollEnrichIT.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/ConnectorStepHandlerPollEnrichIT.java
@@ -30,6 +30,7 @@ import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import io.syndesis.integration.runtime.capture.OutMessageCaptureProcessor;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -174,6 +175,7 @@ public class ConnectorStepHandlerPollEnrichIT {
                     .putConfiguredProperty("period", "1000")
                     .build(),
                 new Step.Builder()
+                    .id("expected")
                     .stepKind(StepKind.endpoint)
                     .action(FTP_ACTION_FETCH)
                     .connection(
@@ -205,6 +207,7 @@ public class ConnectorStepHandlerPollEnrichIT {
             MockEndpoint.assertWait(2, TimeUnit.SECONDS, result);
 
             result.expectedBodiesReceived("Hi there");
+            result.allMessages().exchangeProperty(OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP).convertTo(String.class).contains("expected");
 
             MockEndpoint.assertIsSatisfied(context);
 
@@ -245,6 +248,7 @@ public class ConnectorStepHandlerPollEnrichIT {
                     .putConfiguredProperty("CamelFileName", "dynamic.txt")
                     .build(),
                 new Step.Builder()
+                    .id("expected")
                     .stepKind(StepKind.endpoint)
                     .action(FTP_ACTION_FETCH_DYNAMIC)
                     .connection(
@@ -276,6 +280,7 @@ public class ConnectorStepHandlerPollEnrichIT {
             MockEndpoint.assertWait(2, TimeUnit.SECONDS, result);
 
             result.expectedBodiesReceived("Hi dynamic");
+            result.allMessages().exchangeProperty(OutMessageCaptureProcessor.CAPTURED_OUT_MESSAGES_MAP).convertTo(String.class).contains("expected");
 
             MockEndpoint.assertIsSatisfied(context);
 


### PR DESCRIPTION
The default aggregation strategy in `PollEnricher` does not persist the
headers needed by Syndesis to perform output message capture. Seems that
aggregation tries to copy data from the `Exchange` created in the
`PollEnrich` but it ends up just copying everything from that `Exchange`
while discarding any values from the previous `Exchange`. We need the
actions that utilize `PollEnrich` to maintain message capture so that
the data is available for mapping. This should also maintain the
activity tracking.