### PR TITLE
ENTESB-15225: Adds affinity and toleration values on install

### DIFF
--- a/install/operator/pkg/syndesis/action/install_test.go
+++ b/install/operator/pkg/syndesis/action/install_test.go
@@ -1,0 +1,195 @@
+package action_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1beta2"
+	"github.com/syndesisio/syndesis/install/operator/pkg/generator"
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/action"
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/clienttools"
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
+	syntesting "github.com/syndesisio/syndesis/install/operator/pkg/syndesis/testing"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func renderResource(t *testing.T, ctx context.Context, clientTools *clienttools.ClientTools, syndesis *v1beta2.Syndesis, resourcePath string) []unstructured.Unstructured {
+	configuration, err := configuration.GetProperties(ctx, "../../../build/conf/config-test.yaml", clientTools, syndesis)
+	require.NoError(t, err)
+
+	resources, err := generator.Render(resourcePath, configuration)
+	require.NoError(t, err)
+	assert.True(t, len(resources) > 0)
+	return resources
+}
+
+func TestPreProcessForAffinityTolerationsNotDeploymentConfig(t *testing.T) {
+	syndesis := &v1beta2.Syndesis{
+		Spec: v1beta2.SyndesisSpec{
+			InfraScheduling: v1beta2.SchedulingSpec{
+				Affinity:    &v1.Affinity{},
+				Tolerations: []v1.Toleration{},
+			},
+		},
+	}
+
+	clientTools := syntesting.FakeClientTools()
+	rtClient, err := clientTools.RuntimeClient()
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	resources := renderResource(t, ctx, clientTools, syndesis, "./infrastructure/02-syndesis-secrets.yml.tmpl")
+
+	copy := (&resources[0]).DeepCopy()
+	err = action.PreProcessForAffinityTolerations(ctx, rtClient, syndesis, &resources[0])
+	require.NoError(t, err)
+	assert.Equal(t, *copy, resources[0])
+}
+
+func TestPreProcessForAffinityTolerationsNoInfraScheduling(t *testing.T) {
+	syndesis := &v1beta2.Syndesis{
+		Spec: v1beta2.SyndesisSpec{},
+	}
+
+	clientTools := syntesting.FakeClientTools()
+	rtClient, err := clientTools.RuntimeClient()
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	resources := renderResource(t, ctx, clientTools, syndesis, "./infrastructure/04-syndesis-server.yml.tmpl")
+
+	copy := (&resources[1]).DeepCopy()
+	err = action.PreProcessForAffinityTolerations(ctx, rtClient, syndesis, &resources[1])
+	require.NoError(t, err)
+	assert.Equal(t, *copy, resources[1])
+}
+
+func TestPreProcessForAffinityTolerations(t *testing.T) {
+	syndesis := &v1beta2.Syndesis{
+		Spec: v1beta2.SyndesisSpec{
+			InfraScheduling: v1beta2.SchedulingSpec{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "failure-domain.beta.kubernetes.io/zone",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west-1c"},
+										},
+										{
+											Key:      "failure-domain.beta.kubernetes.io/region",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west-1"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Tolerations: []v1.Toleration{
+					{
+						Key:      "tol_333",
+						Operator: v1.TolerationOpEqual,
+						Effect:   v1.TaintEffectNoSchedule,
+					},
+					{
+						Key:      "key3333",
+						Operator: v1.TolerationOpEqual,
+						Value:    "value2",
+						Effect:   v1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+	}
+
+	clientTools := syntesting.FakeClientTools()
+	rtClient, err := clientTools.RuntimeClient()
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	resources := renderResource(t, ctx, clientTools, syndesis, "./infrastructure/04-syndesis-server.yml.tmpl")
+	copy := (&resources[1]).DeepCopy()
+	err = action.PreProcessForAffinityTolerations(ctx, rtClient, syndesis, &resources[1])
+	require.NoError(t, err)
+	assert.NotEqual(t, *copy, resources[1])
+
+	affinity, found, err := unstructured.NestedFieldNoCopy(resources[1].UnstructuredContent(), "spec", "template", "spec", "affinity")
+	assert.True(t, found)
+	assert.NotNil(t, affinity)
+
+	toleration, found, err := unstructured.NestedFieldNoCopy(resources[1].UnstructuredContent(), "spec", "template", "spec", "tolerations")
+	assert.True(t, found)
+	assert.NotNil(t, toleration)
+}
+
+func TestPreProcessJaegerCR(t *testing.T) {
+	syndesis := &v1beta2.Syndesis{
+		Spec: v1beta2.SyndesisSpec{
+			InfraScheduling: v1beta2.SchedulingSpec{
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "failure-domain.beta.kubernetes.io/zone",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west-1c"},
+										},
+										{
+											Key:      "failure-domain.beta.kubernetes.io/region",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"us-west-1"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Tolerations: []v1.Toleration{
+					{
+						Key:      "tol_333",
+						Operator: v1.TolerationOpEqual,
+						Effect:   v1.TaintEffectNoSchedule,
+					},
+					{
+						Key:      "key3333",
+						Operator: v1.TolerationOpEqual,
+						Value:    "value2",
+						Effect:   v1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+	}
+
+	clientTools := syntesting.FakeClientTools()
+	rtClient, err := clientTools.RuntimeClient()
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	resources := renderResource(t, ctx, clientTools, syndesis, "./addons/jaeger/syndesis-jaeger.yml.tmpl")
+	copy := (&resources[0]).DeepCopy()
+
+	err = action.PreProcessForAffinityTolerations(ctx, rtClient, syndesis, &resources[0])
+	require.NoError(t, err)
+	assert.NotEqual(t, *copy, resources[0])
+
+	affinity, found, err := unstructured.NestedFieldNoCopy(resources[0].UnstructuredContent(), "spec", "affinity")
+	assert.True(t, found)
+	assert.NotNil(t, affinity)
+
+	toleration, found, err := unstructured.NestedFieldNoCopy(resources[0].UnstructuredContent(), "spec", "tolerations")
+	assert.True(t, found)
+	assert.NotNil(t, toleration)
+}


### PR DESCRIPTION
* During install phase, adds the affinity and toleration values to the
  infrastructure deployment configs
 * Not been possible previously due to not having the deployment configs
   readily to hand as typed objects

* install.go
 * Processes each resource on install and determines if they're a DC
 * If so, adds in the content from the Syndesis resource as blocks
 * Should the syntax in the Syndesis resource be incorrect then there will
   be errors in the operator log

* install_test.go
 * Tests for the PreProcessDeploymentConfig function