### PR TITLE
fix(ui): [backport] ENTESB-15738 - validation for API connector security

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorSecurityForm.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorSecurityForm.tsx
@@ -47,6 +47,10 @@ export const ApiConnectorCreatorSecurityForm: React.FunctionComponent<IApiConnec
   });
   const [values, setValues] = React.useState(defaultValues);
 
+  React.useEffect(() => {
+    setErrors(validateSecurity(values));
+  }, []);
+
   const handleSubmit = (event: { preventDefault: () => void }) => {
     if (event) {
       event.preventDefault();

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/securityValidation.ts
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/securityValidation.ts
@@ -10,6 +10,7 @@ export default function validateSecurity(values: ICreateConnectorPropsUi) {
 
   if (
     values.authenticationType === 'basic' ||
+    values.authenticationType === 'basic:username_password' ||
     values.authenticationType === 'ws-security-ut'
   ) {
     if (values.passwordType !== 'PasswordNone') {


### PR DESCRIPTION
fixes [ENTESB-15738](https://issues.redhat.com/browse/ENTESB-15738), issue with validation for API connector security and allowing users to proceed when basic required fields are empty.

backport of https://github.com/syndesisio/syndesis/pull/9399