### PR TITLE
fix: pass header parameters in API client

### DIFF
--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -142,10 +142,21 @@
       <classifier>annotations</classifier>
     </dependency>
 
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-data-models</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/HeaderParametersCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/HeaderParametersCustomizer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.combined.visitors.CombinedAllNodeVisitor;
+import io.apicurio.datamodels.core.factories.TraverserFactory;
+import io.apicurio.datamodels.core.models.Document;
+import io.apicurio.datamodels.core.models.common.Operation;
+import io.apicurio.datamodels.core.models.common.Parameter;
+import io.apicurio.datamodels.core.visitors.ITraverser;
+import io.apicurio.datamodels.core.visitors.TraverserDirection;
+import io.apicurio.datamodels.openapi.v2.models.Oas20Parameter;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Parameter;
+import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+import io.syndesis.integration.component.proxy.Processors;
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * Makes sure that header parameters are allowed, i.e. passed from Camel to the
+ * API service. We only pass headers that we explicitly allow, to make sure that
+ * we do not pass sensitive headers or headers that might interfere with the API
+ * service (i.e. setting `Connection: close` or `Content-Length` with
+ * inappropriate content length).
+ */
+public class HeaderParametersCustomizer implements ComponentProxyCustomizer {
+
+    public static class AllowHeaders implements Processor {
+
+        private final Set<String> headerParameters;
+
+        public AllowHeaders(final Set<String> headerParameters) {
+            this.headerParameters = headerParameters;
+        }
+
+        @Override
+        public void process(final Exchange exchange) throws Exception {
+            SyndesisHeaderStrategy.allow(exchange, headerParameters);
+        }
+    }
+
+    private static final class OperationHeaderParameterCollector extends CombinedAllNodeVisitor {
+
+        private String currentOperation;
+
+        private final Set<String> operationHeaderParameters = new HashSet<>();
+
+        private final String operationId;
+
+        public OperationHeaderParameterCollector(final String operationId) {
+            this.operationId = operationId;
+        }
+
+        @Override
+        public void visitOperation(final Operation node) {
+            currentOperation = node.operationId;
+        }
+
+        @Override
+        public void visitParameter(final Parameter node) {
+            if (!operationId.equals(currentOperation)) {
+                return;
+            }
+
+            final String in;
+            if (node instanceof Oas20Parameter) {
+                final Oas20Parameter oas20Parameter = (Oas20Parameter) node;
+                in = oas20Parameter.in;
+            } else if (node instanceof Oas30Parameter) {
+                final Oas30Parameter oas30Parameter = (Oas30Parameter) node;
+                in = oas30Parameter.in;
+            } else {
+                throw new IllegalArgumentException("Given parameter type is not OpenAPI 2.x or 3.x" + node.getClass().getName());
+            }
+
+            if ("header".equals(in)) {
+                operationHeaderParameters.add(node.name);
+            }
+        }
+    }
+
+    @Override
+    public void customize(final ComponentProxyComponent component, final Map<String, Object> options) {
+        // set by SpecificationResourceCustomizer
+        final String specification = (String) options.get("specification");
+
+        final String operationId = (String) options.get("operationId");
+
+        final Set<String> headerParameters = findHeaderParametersFor(specification, operationId);
+
+        Processors.addBeforeProducer(component, new AllowHeaders(headerParameters));
+    }
+
+    static Set<String> findHeaderParametersFor(final String specification, final String operationId) {
+        final Document document = Library.readDocumentFromJSONString(specification);
+
+        final OperationHeaderParameterCollector headerParameterCollector = new OperationHeaderParameterCollector(operationId);
+        final ITraverser traverser = TraverserFactory.create(document, headerParameterCollector, TraverserDirection.down);
+
+        traverser.traverse(document);
+
+        return headerParameterCollector.operationHeaderParameters;
+    }
+
+}

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/RequestHeaderSetter.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/RequestHeaderSetter.java
@@ -43,10 +43,10 @@ final class RequestHeaderSetter implements Processor {
         final Map<String, Object> headers = in.getHeaders();
         headers.putAll(httpHeaders);
 
-        SyndesisHeaderStrategy.whitelist(exchange, httpHeaders.keySet());
+        SyndesisHeaderStrategy.allow(exchange, httpHeaders.keySet());
     }
 
-    private static String determineContentTypeOf(final DataShape outputDataShape) {
+    static String determineContentTypeOf(final DataShape outputDataShape) {
         if (outputDataShape == null) {
             return DEFAULT_CONTENT_TYPE;
         }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
@@ -109,8 +109,8 @@ public final class SpecificationResourceCustomizer implements ComponentProxyCust
     private static Optional<String> getNameFromDefinition(String securityDefinitionSelectedByUser) {
         if (securityDefinitionSelectedByUser != null && securityDefinitionSelectedByUser.indexOf(':') > 0) {
             return Optional.of(securityDefinitionSelectedByUser.substring(securityDefinitionSelectedByUser.indexOf(':') + 1).trim());
-        } else {
-            return Optional.empty();
         }
+
+        return Optional.empty();
     }
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeader.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeader.java
@@ -29,7 +29,7 @@ public class SetHttpHeader extends SetHeader {
     public void process(final Exchange exchange) throws Exception {
         super.process(exchange);
 
-        SyndesisHeaderStrategy.whitelist(exchange, headerName);
+        SyndesisHeaderStrategy.allow(exchange, headerName);
     }
 
 }

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessor.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/auth/oauth/OAuthRefreshTokenProcessor.java
@@ -82,7 +82,7 @@ class OAuthRefreshTokenProcessor implements Processor {
         final Message in = exchange.getIn();
         in.setHeader("Authorization", "Bearer " + state.getAccessToken());
 
-        SyndesisHeaderStrategy.whitelist(exchange, "Authorization");
+        SyndesisHeaderStrategy.allow(exchange, "Authorization");
     }
 
     CloseableHttpClient createHttpClient() {

--- a/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
+++ b/app/connector/rest-swagger/src/main/resources/META-INF/syndesis/connector/rest-swagger.json
@@ -5,6 +5,7 @@
     "componentName": "connector-rest-swagger-http4"
   },
   "connectorCustomizers": [
+    "io.syndesis.connector.rest.swagger.HeaderParametersCustomizer",
     "io.syndesis.connector.rest.swagger.SpecificationResourceCustomizer",
     "io.syndesis.connector.rest.swagger.AuthenticationCustomizer",
     "io.syndesis.connector.rest.swagger.RequestCustomizer",

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
@@ -212,6 +212,7 @@ public class DescriptorTest {
                 .order(2)
                 .build())
             .putConfiguredProperty("componentName", "connector-rest-swagger-http4")
+            .addConnectorCustomizer(HeaderParametersCustomizer.class.getName())
             .addConnectorCustomizer(SpecificationResourceCustomizer.class.getName())
             .addConnectorCustomizer(AuthenticationCustomizer.class.getName())
             .addConnectorCustomizer(RequestCustomizer.class.getName())

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/HeaderParametersCustomizerTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/HeaderParametersCustomizerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger;
+
+import java.util.Set;
+
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.openapi.models.OasDocument;
+import io.apicurio.datamodels.openapi.models.OasOperation;
+import io.apicurio.datamodels.openapi.models.OasParameter;
+import io.apicurio.datamodels.openapi.models.OasPathItem;
+import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
+import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeaderParametersCustomizerTest {
+
+    OasDocument createTestDocument(final OasDocument doc) {
+        doc.paths = doc.createPaths();
+
+        final OasPathItem slash = doc.paths.createPathItem("/");
+        doc.paths.addPathItem("slash", slash);
+
+        final OasOperation get = slash.createOperation("get");
+        get.operationId = "get";
+        slash.setOperation(get);
+
+        final OasParameter p1 = get.createParameter();
+        p1.name = "p1";
+        get.addParameter(p1);
+
+        final OasParameter h1 = get.createParameter();
+        h1.name = "h1";
+        h1.in = "header";
+        get.addParameter(h1);
+
+        final OasOperation post = slash.createOperation("post");
+        post.operationId = "post";
+        slash.setOperation(post);
+
+        final OasParameter h2 = post.createParameter();
+        h2.name = "h2";
+        h2.in = "header";
+        post.addParameter(h2);
+
+        final OasParameter h3 = post.createParameter();
+        h3.name = "h3";
+        h3.in = "header";
+        post.addParameter(h3);
+
+        return doc;
+    }
+
+    Set<String> findHeaderParametersIn(final OasDocument doc, final String operationId) {
+        final String json = Library.writeDocumentToJSONString(doc);
+
+        return HeaderParametersCustomizer.findHeaderParametersFor(json, operationId);
+    }
+
+    @Test
+    void shouldFindHeaderParametersInOperationFromOpenApi2() {
+        assertThat(findHeaderParametersIn(createTestDocument(new Oas20Document()), "get")).containsOnly("h1");
+        assertThat(findHeaderParametersIn(createTestDocument(new Oas20Document()), "post")).containsOnly("h2", "h3");
+    }
+
+    @Test
+    void shouldFindHeaderParametersInOperationFromOpenApi3() {
+        assertThat(findHeaderParametersIn(createTestDocument(new Oas30Document()), "get")).containsOnly("h1");
+        assertThat(findHeaderParametersIn(createTestDocument(new Oas30Document()), "post")).containsOnly("h2", "h3");
+    }
+
+    @Test
+    void shouldNotFindAnyHeaderParametersInEmptyDocument() {
+        final Oas20Document doc = new Oas20Document();
+        final String json = Library.writeDocumentToJSONString(doc);
+
+        assertThat(HeaderParametersCustomizer.findHeaderParametersFor(json, "")).isEmpty();
+    }
+}

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RequestHeaderSetterTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/RequestHeaderSetterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.rest.swagger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.integration.runtime.util.SyndesisHeaderStrategy;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestHeaderSetterTest {
+
+    @ParameterizedTest
+    @EnumSource(DataShapeKinds.class)
+    void shouldDetermineContentType(final DataShapeKinds kind) {
+        final DataShape shape = new DataShape.Builder()
+            .kind(kind)
+            .build();
+
+        assertThat(RequestHeaderSetter.determineContentTypeOf(shape)).satisfiesAnyOf(
+            c -> assertThat(c).isEqualTo("application/json"),
+            c -> assertThat(c).isEqualTo("text/xml"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "JSON_INSTANCE,        XML_INSTANCE,  application/json, text/xml",
+        "JSON_SCHEMA,          JSON_SCHEMA,   application/json, application/json",
+        "XML_INSTANCE,         XML_SCHEMA,    text/xml,         text/xml",
+        "XML_SCHEMA,           NONE,          text/xml,         application/json",
+        "XML_SCHEMA_INSPECTED, JSON_INSTANCE, text/xml,         application/json"
+    })
+    void shouldPassStandardHeaders(final DataShapeKinds requestContentType, final DataShapeKinds responseContentType, final String expectedRequestContentType,
+        final String expectedResponseContenType) throws Exception {
+        final DataShape inShape = new DataShape.Builder()
+            .kind(requestContentType)
+            .build();
+
+        final DataShape outShape = new DataShape.Builder()
+            .kind(responseContentType)
+            .build();
+
+        final RequestHeaderSetter requestHeaderSetter = new RequestHeaderSetter(inShape, outShape);
+
+        final Exchange exchange = mock(Exchange.class);
+        final HashSet<Object> allowed = new HashSet<>();
+        when(exchange.getProperty(SyndesisHeaderStrategy.ALLOWED_HEADERS, Collection.class)).thenReturn(allowed);
+
+        final Message message = mock(Message.class);
+        when(exchange.getIn()).thenReturn(message);
+        final HashMap<String, Object> headers = new HashMap<>();
+        when(message.getHeaders()).thenReturn(headers);
+
+        requestHeaderSetter.process(exchange);
+
+        assertThat(headers).contains(
+            entry("Content-Type", expectedRequestContentType),
+            entry("Accept", expectedResponseContenType));
+
+        assertThat(allowed).contains("Content-Type", "Accept");
+    }
+
+}

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetAuthorizationHeaderTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetAuthorizationHeaderTest.java
@@ -32,7 +32,7 @@ public class SetAuthorizationHeaderTest {
         new SetAuthorizationHeader("value").process(exchange);
 
         assertThat(exchange.getIn().getHeader("Authorization")).isEqualTo("value");
-        assertThat(SyndesisHeaderStrategy.isWhitelisted(exchange, "Authorization")).isTrue();
+        assertThat(SyndesisHeaderStrategy.isAllowed(exchange, "Authorization")).isTrue();
     }
 
 }

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeaderTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/auth/SetHttpHeaderTest.java
@@ -32,7 +32,7 @@ public class SetHttpHeaderTest {
         new SetHttpHeader("name", "value").process(exchange);
 
         assertThat(exchange.getIn().getHeader("name")).isEqualTo("value");
-        assertThat(SyndesisHeaderStrategy.isWhitelisted(exchange, "name")).isTrue();
+        assertThat(SyndesisHeaderStrategy.isAllowed(exchange, "name")).isTrue();
     }
 
 }

--- a/app/connector/rest-swagger/src/test/resources/petstore.json
+++ b/app/connector/rest-swagger/src/test/resources/petstore.json
@@ -41,6 +41,32 @@
     "http"
   ],
   "paths": {
+    "/status": {
+      "get": {
+        "operationId": "status",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "component",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        }
+      }
+    },
     "/pet": {
       "post": {
         "tags": [

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/SyndesisHeaderStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/util/SyndesisHeaderStrategy.java
@@ -25,27 +25,27 @@ public final class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
 
     public static final SyndesisHeaderStrategy INSTANCE = new SyndesisHeaderStrategy();
 
-    public static final String WHITELISTED_HEADERS = "syndesis-whitelisted-headers";
+    public static final String ALLOWED_HEADERS = "syndesis-allowed-headers";
 
     /**
      * Filters headers passed on from Camel message to (possibly) external
-     * service by configured filters and the whitelist. The whitelist needs to
+     * service by configured filters and the allow list. The allow list needs to
      * be a {@link Collection} of {@link String}s under the
-     * {@link SyndesisHeaderStrategy#WHITELISTED_HEADERS} name.
+     * {@link SyndesisHeaderStrategy#ALLOWED_HEADERS} name.
      */
     @Override
     public boolean applyFilterToCamelHeaders(final String headerName, final Object headerValue, final Exchange exchange) {
-        if (isWhitelisted(exchange, headerName)) {
+        if (isAllowed(exchange, headerName)) {
             return false; // allow the header
         }
 
         return super.applyFilterToCamelHeaders(headerName, headerValue, exchange);
     }
 
-    public static boolean isWhitelisted(final Exchange exchange, String headerName) {
-        final Collection<String> whitelisted = whitelisted(exchange);
+    public static boolean isAllowed(final Exchange exchange, String headerName) {
+        final Collection<String> allowed = allowList(exchange);
 
-        return whitelisted != null && whitelisted.contains(headerName);
+        return allowed != null && allowed.contains(headerName);
     }
 
     @Override
@@ -59,33 +59,33 @@ public final class SyndesisHeaderStrategy extends HttpHeaderFilterStrategy {
         setInFilterPattern("^(?!Content-Type).*$");
     }
 
-    public static void whitelist(final Exchange exchange, final Collection<String> headerNames) {
+    public static void allow(final Exchange exchange, final Collection<String> headerNames) {
         for (final String headerName : headerNames) {
-            whitelist(exchange, headerName);
+            allow(exchange, headerName);
         }
     }
 
-    public static void whitelist(final Exchange exchange, final String headerName) {
-        final Collection<String> existing = whitelisted(exchange);
+    public static void allow(final Exchange exchange, final String headerName) {
+        final Collection<String> existing = allowList(exchange);
 
-        Collection<String> whitelisted = existing;
+        Collection<String> allowed = existing;
         if (existing == null) {
-            whitelisted = new HashSet<>();
+            allowed = new HashSet<>();
         }
 
         try {
-            whitelisted.add(headerName);
+            allowed.add(headerName);
         } catch (final UnsupportedOperationException ignored) {
             // handle unmodifiable collections
-            whitelisted = new HashSet<>(existing);
-            whitelisted.add(headerName);
+            allowed = new HashSet<>(existing);
+            allowed.add(headerName);
         }
 
-        exchange.setProperty(WHITELISTED_HEADERS, whitelisted);
+        exchange.setProperty(ALLOWED_HEADERS, allowed);
     }
 
     @SuppressWarnings("unchecked")
-    private static Collection<String> whitelisted(final Exchange exchange) {
-        return exchange.getProperty(WHITELISTED_HEADERS, Collection.class);
+    private static Collection<String> allowList(final Exchange exchange) {
+        return exchange.getProperty(ALLOWED_HEADERS, Collection.class);
     }
 }

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/BaseOpenApiGeneratorExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/BaseOpenApiGeneratorExampleTest.java
@@ -81,7 +81,7 @@ public abstract class BaseOpenApiGeneratorExampleTest {
         assertThat(generated.getProperties().keySet()).as("Expecting the same properties to be generated")
             .containsOnlyElementsOf(expected.getProperties().keySet());
         assertThat(generated.getProperties()).containsAllEntriesOf(expected.getProperties());
-        assertThat(generated).isEqualToIgnoringGivenFields(expected, "id", "icon", "properties", "configuredProperties", "actions");
+        assertThat(generated).isEqualToIgnoringGivenFields(expected, "id", "icon", "properties", "configuredProperties", "actions", "connectorCustomizers");
         assertThat(generated.getIcon()).startsWith("data:image");
         assertThat(generated.getActions()).hasSameSizeAs(expected.getActions());
 


### PR DESCRIPTION
We filter Camel message headers that we pass on to 3rd party HTTP APIs,
this is to prevent problematic headers to be passed on. We need to block
headers containing sensitive information, or headers that are not
appropriate for the HTTP request. For this reason we use a custom header
filter strategy that contains a list of allowed headers.

Till now we passed only `Content-Type` and `Accept` headers, and did not
pass the headers specified as parameters of an OpenAPI operation.

This changes so for each operation we gather the headers that are given
as parameters and instruct the custom header filter strategy to allow
passing them on to the 3rd party HTTP API.

Fixes #9397