### PR TITLE
fix: backport for #8722 present on 2.x and 1.11.x

### DIFF
--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/ComponentProperties.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/ComponentProperties.java
@@ -29,6 +29,8 @@ public final class ComponentProperties {
     public static final String PASSWORD = "password";
     public static final String ADD_TIMESTAMP = "addTimestamp";
 
+    public static final String EXCEPTION_MESSAGE_CAUSE_ENABLED = "exceptionMessageCauseEnabled";
+
     private ComponentProperties() {
         // singleton
     }

--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/SoapCxfProxyComponent.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/SoapCxfProxyComponent.java
@@ -15,18 +15,35 @@
  */
 package io.syndesis.connector.soap.cxf;
 
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
+import org.apache.camel.Producer;
 import org.apache.camel.component.cxf.CxfEndpoint;
 import org.apache.camel.component.cxf.CxfEndpointConfigurer;
+import org.apache.camel.processor.CatchProcessor;
+import org.apache.camel.processor.Pipeline;
+import org.apache.camel.processor.TryProcessor;
+import org.apache.cxf.binding.soap.Soap11;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapVersion;
+import org.apache.cxf.binding.soap.SoapVersionFactory;
 
+import io.syndesis.connector.soap.cxf.payload.Soap11FaultSoapPayloadConverter;
+import io.syndesis.connector.soap.cxf.payload.Soap12FaultSoapPayloadConverter;
 import io.syndesis.integration.component.proxy.ComponentDefinition;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
+import io.syndesis.integration.component.proxy.ComponentProxyEndpoint;
+import io.syndesis.integration.component.proxy.ComponentProxyProducer;
 
 public final class SoapCxfProxyComponent extends ComponentProxyComponent {
 
     private CxfEndpointConfigurer endpointConfigurer;
+    private boolean exceptionMessageCauseEnabled;
+    private SoapVersion soapVersion;
 
     public SoapCxfProxyComponent(final String componentId, final String componentScheme) {
         super(componentId, componentScheme);
@@ -37,8 +54,62 @@ public final class SoapCxfProxyComponent extends ComponentProxyComponent {
     }
 
     @Override
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
+        return super.createEndpoint(uri, remaining, parameters);
+    }
+
+    @Override
     protected void configureDelegateEndpoint(ComponentDefinition definition, Endpoint endpoint, Map<String, Object> options) {
         super.configureDelegateEndpoint(definition, endpoint, options);
-        ((CxfEndpoint)endpoint).setCxfEndpointConfigurer(endpointConfigurer);
+        ((CxfEndpoint)((ComponentProxyEndpoint)endpoint).getEndpoint()).setCxfEndpointConfigurer(endpointConfigurer);
+    }
+
+    @Override
+    protected void enrichOptions(Map<String, Object> options) {
+        // read and remove soap version property
+        this.soapVersion = Soap11.getInstance();
+        final Object value = options.remove(ComponentProperties.SOAP_VERSION);
+        if (value != null) {
+            final double versionNumber = Double.parseDouble(value.toString());
+            final Iterator<SoapVersion> versions = SoapVersionFactory.getInstance().getVersions();
+
+            while (versions.hasNext()) {
+                final SoapVersion version = versions.next();
+                if (version.getVersion() == versionNumber) {
+                    soapVersion = version;
+                    break;
+                }
+            }
+        }
+
+        // read and remove exceptionMessageCauseEnabled
+        final Object causeEnabled = options.remove(ComponentProperties.EXCEPTION_MESSAGE_CAUSE_ENABLED);
+        if (causeEnabled != null) {
+            exceptionMessageCauseEnabled = Boolean.TRUE.equals(Boolean.parseBoolean(causeEnabled.toString()));
+        }
+    }
+
+    @Override
+    protected Endpoint createDelegateEndpoint(ComponentDefinition definition, String scheme,
+                                              Map<String, String> options) {
+
+        final Endpoint delegateEndpoint = super.createDelegateEndpoint(definition, scheme, options);
+
+        // wrap the delegate in a proxy that decorates the CXF producer
+        final boolean isSoap11 = Soap11.getInstance().equals(soapVersion);
+        return new ComponentProxyEndpoint(delegateEndpoint.getEndpointUri(), this, delegateEndpoint) {
+
+            @Override
+            public Producer createProducer() throws Exception {
+                final CamelContext context = getCamelContext();
+
+                // replace with a try-catch pipeline to handle SOAP faults
+                return new ComponentProxyProducer(this, Pipeline.newInstance(context,
+                    new TryProcessor(super.createProducer(),
+                        Collections.singletonList(new CatchProcessor(Collections.singletonList(SoapFault.class),
+                            (isSoap11 ? new Soap11FaultSoapPayloadConverter(exceptionMessageCauseEnabled) :
+                                new Soap12FaultSoapPayloadConverter(exceptionMessageCauseEnabled)), null, null)), null)));
+            }
+        };
     }
 }

--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/AbstractFaultSoapPayloadConverter.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/AbstractFaultSoapPayloadConverter.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.soap.cxf.payload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.InvalidPayloadException;
+import org.apache.camel.Message;
+import org.apache.camel.RuntimeCamelException;
+import org.apache.camel.component.cxf.CxfPayload;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.SoapVersion;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public abstract class AbstractFaultSoapPayloadConverter extends ResponseSoapPayloadConverter {
+
+    private final boolean exceptionMessageCauseEnabled;
+
+    protected AbstractFaultSoapPayloadConverter(boolean exceptionMessageCauseEnabled) {
+        this.exceptionMessageCauseEnabled = exceptionMessageCauseEnabled;
+    }
+
+    @Override
+    public void process(Exchange exchange) {
+        final Exception exception = (Exception) exchange.getProperty(Exchange.EXCEPTION_CAUGHT);
+        if (exception instanceof SoapFault) {
+
+            SoapFault soapFault = (SoapFault) exception;
+            final Message in = exchange.getIn();
+
+            // get SOAP QNames from CxfPayload headers
+            final SoapMessage soapMessage = in.getHeader("CamelCxfMessage", SoapMessage.class);
+            final SoapVersion soapVersion = soapMessage.getVersion();
+
+            try {
+
+                // get CxfPayload body
+                final CxfPayload<?> cxfPayload = in.getMandatoryBody(CxfPayload.class);
+
+                final OutputStream outputStream = newOutputStream(in, cxfPayload);
+                final XMLStreamWriter writer = newXmlStreamWriter(outputStream);
+
+                handleFault(writer, soapFault, soapVersion);
+                writer.writeEndDocument();
+
+                final InputStream inputStream = getInputStream(outputStream, writer);
+
+                // set the input stream as the Camel message body
+                in.setBody(inputStream);
+
+            } catch (InvalidPayloadException | XMLStreamException | IOException e) {
+                throw new RuntimeCamelException("Error parsing CXF Payload: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    protected abstract void handleFault(XMLStreamWriter writer, SoapFault soapFault, SoapVersion soapVersion);
+
+    protected static String getFaultCodePrefix(XMLStreamWriter writer, QName faultCode) throws XMLStreamException {
+        String codeNs = faultCode.getNamespaceURI();
+        String prefix = null;
+        if (codeNs.length() > 0) {
+            prefix = faultCode.getPrefix();
+            if (!StringUtils.isEmpty(prefix)) {
+                String boundNS = writer.getNamespaceContext().getNamespaceURI(prefix);
+                if (StringUtils.isEmpty(boundNS)) {
+                    writer.writeNamespace(prefix, codeNs);
+                } else if (!codeNs.equals(boundNS)) {
+                    prefix = null;
+                }
+            }
+            if (StringUtils.isEmpty(prefix)) {
+                prefix = StaxUtils.getUniquePrefix(writer, codeNs, true);
+            }
+        }
+        return prefix;
+    }
+
+    protected String getFaultMessage(SoapFault fault) {
+        if (fault.getMessage() != null) {
+            if (exceptionMessageCauseEnabled && fault.getCause() != null
+                && fault.getCause().getMessage() != null && !fault.getMessage().equals(fault.getCause().getMessage())) {
+                return fault.getMessage() + " Caused by: " + fault.getCause().getMessage();
+            }
+            return fault.getMessage();
+        } else if (exceptionMessageCauseEnabled && fault.getCause() != null) {
+            if (fault.getCause().getMessage() != null) {
+                return fault.getCause().getMessage();
+            }
+            return fault.getCause().toString();
+        } else {
+            return "Fault occurred while processing.";
+        }
+    }
+
+    protected void prepareStackTrace(String soapNamespace, SoapFault fault) {
+        if (exceptionMessageCauseEnabled && fault.getCause() != null) {
+            StringBuilder sb = new StringBuilder();
+            Throwable throwable = fault.getCause();
+            sb.append("Caused by: ")
+                .append(throwable.getClass().getCanonicalName())
+                .append(": ")
+                .append(throwable.getMessage())
+                .append('\n')
+                .append(org.apache.cxf.message.Message.EXCEPTION_CAUSE_SUFFIX);
+            while (throwable != null) {
+                for (StackTraceElement ste : throwable.getStackTrace()) {
+                    sb.append(ste.getClassName())
+                        .append('!')
+                        .append(ste.getMethodName())
+                        .append('!')
+                        .append(ste.getFileName())
+                        .append('!')
+                        .append(ste.getLineNumber())
+                        .append(org.apache.cxf.message.Message.EXCEPTION_CAUSE_SUFFIX);
+                }
+                throwable = throwable.getCause();
+                if (throwable != null) {
+                    sb.append("Caused by: ")
+                        .append(throwable.getClass().getCanonicalName())
+                        .append(" : ")
+                        .append(throwable.getMessage())
+                        .append(org.apache.cxf.message.Message.EXCEPTION_CAUSE_SUFFIX);
+                }
+            }
+            Element detail = fault.getDetail();
+            if (detail == null) {
+                Document doc = DOMUtils.getEmptyDocument();
+                Element stackTrace = doc.createElementNS(
+                    Fault.STACKTRACE_NAMESPACE, Fault.STACKTRACE);
+                stackTrace.setTextContent(sb.toString());
+                detail = doc.createElementNS(
+                    soapNamespace, "detail");
+                fault.setDetail(detail);
+                detail.appendChild(stackTrace);
+            } else {
+                Element stackTrace =
+                    detail.getOwnerDocument().createElementNS(Fault.STACKTRACE_NAMESPACE,
+                        Fault.STACKTRACE);
+                stackTrace.setTextContent(sb.toString());
+                detail.appendChild(stackTrace);
+            }
+        }
+    }
+
+}

--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/Soap11FaultSoapPayloadConverter.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/Soap11FaultSoapPayloadConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.soap.cxf.payload;
+
+import java.util.Map;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.apache.camel.RuntimeCamelException;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapVersion;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class Soap11FaultSoapPayloadConverter extends AbstractFaultSoapPayloadConverter {
+
+    public Soap11FaultSoapPayloadConverter(boolean exceptionMessageCauseEnabled) {
+        super(exceptionMessageCauseEnabled);
+    }
+
+    @Override
+    protected void handleFault(XMLStreamWriter writer, SoapFault fault, SoapVersion soapVersion) {
+        try {
+            Map<String, String> namespaces = fault.getNamespaces();
+            for (Map.Entry<String, String> e : namespaces.entrySet()) {
+                writer.writeNamespace(e.getKey(), e.getValue());
+            }
+
+            final String soapNamespace = soapVersion.getNamespace();
+            writer.writeStartElement(SOAP_PREFIX, "Fault", soapNamespace);
+
+            writer.writeStartElement("faultcode");
+
+            String codeString = fault.getCodeString(getFaultCodePrefix(writer, fault.getFaultCode()), SOAP_PREFIX);
+
+            writer.writeCharacters(codeString);
+            writer.writeEndElement();
+
+            writer.writeStartElement("faultstring");
+            String lang = fault.getLang();
+            if (!StringUtils.isEmpty(lang)) {
+                writer.writeAttribute("xml", "http://www.w3.org/XML/1998/namespace", "lang", lang);
+            }
+            writer.writeCharacters(getFaultMessage(fault));
+            writer.writeEndElement();
+            prepareStackTrace(soapNamespace, fault);
+
+            if (fault.getRole() != null) {
+                writer.writeStartElement("faultactor");
+                writer.writeCharacters(fault.getRole());
+                writer.writeEndElement();
+            }
+
+            if (fault.hasDetails()) {
+                Element detail = fault.getDetail();
+                writer.writeStartElement("detail");
+
+                Node node = detail.getFirstChild();
+                while (node != null) {
+                    StaxUtils.writeNode(node, writer, true);
+                    node = node.getNextSibling();
+                }
+
+                // Details
+                writer.writeEndElement();
+            }
+
+            // Fault
+            writer.writeEndElement();
+        } catch (Exception xe) {
+            throw new RuntimeCamelException("XML write exception: " + xe.getMessage(), xe);
+        }
+    }
+}

--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/Soap12FaultSoapPayloadConverter.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/Soap12FaultSoapPayloadConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.soap.cxf.payload;
+
+import java.util.Locale;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.apache.camel.RuntimeCamelException;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.binding.soap.SoapVersion;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.staxutils.StaxUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+public class Soap12FaultSoapPayloadConverter extends AbstractFaultSoapPayloadConverter {
+
+    public Soap12FaultSoapPayloadConverter(boolean exceptionMessageCauseEnabled) {
+        super(exceptionMessageCauseEnabled);
+    }
+
+    @Override
+    protected void handleFault(XMLStreamWriter writer, SoapFault soapFault, SoapVersion soapVersion) {
+        try {
+            Map<String, String> namespaces = soapFault.getNamespaces();
+            for (Map.Entry<String, String> e : namespaces.entrySet()) {
+                writer.writeNamespace(e.getKey(), e.getValue());
+            }
+
+            String ns = soapVersion.getNamespace();
+            writer.writeStartElement(SOAP_PREFIX, "Fault", ns);
+
+            writer.writeStartElement(SOAP_PREFIX, "Code", ns);
+            writer.writeStartElement(SOAP_PREFIX, "Value", ns);
+
+            writer.writeCharacters(soapFault.getCodeString(getFaultCodePrefix(writer, soapFault.getFaultCode()), SOAP_PREFIX));
+            writer.writeEndElement();
+
+            if (soapFault.getSubCodes() != null) {
+                int fscCount = 0;
+                for (QName fsc : soapFault.getSubCodes()) {
+                    writer.writeStartElement(SOAP_PREFIX, "Subcode", ns);
+                    writer.writeStartElement(SOAP_PREFIX, "Value", ns);
+                    writer.writeCharacters(getCodeString(getFaultCodePrefix(writer, fsc), SOAP_PREFIX, fsc));
+                    writer.writeEndElement();
+                    fscCount++;
+                }
+                while (fscCount > 0) {
+                    writer.writeEndElement();
+                    fscCount--;
+                }
+            }
+            writer.writeEndElement();
+
+            writer.writeStartElement(SOAP_PREFIX, "Reason", ns);
+            writer.writeStartElement(SOAP_PREFIX, "Text", ns);
+            String lang = soapFault.getLang();
+            if (StringUtils.isEmpty(lang)) {
+                lang = getLangCode();
+            }
+            writer.writeAttribute("xml", "http://www.w3.org/XML/1998/namespace", "lang", lang);
+            writer.writeCharacters(getFaultMessage(soapFault));
+            writer.writeEndElement();
+            writer.writeEndElement();
+
+            if (soapFault.getRole() != null) {
+                writer.writeStartElement(SOAP_PREFIX, "Role", ns);
+                writer.writeCharacters(soapFault.getRole());
+                writer.writeEndElement();
+            }
+
+            prepareStackTrace(ns, soapFault);
+
+            if (soapFault.hasDetails()) {
+                Element detail = soapFault.getDetail();
+                writer.writeStartElement(SOAP_PREFIX, "Detail", ns);
+
+                Node node = detail.getFirstChild();
+                while (node != null) {
+                    StaxUtils.writeNode(node, writer, true);
+                    node = node.getNextSibling();
+                }
+
+                // Details
+                writer.writeEndElement();
+            }
+
+            // Fault
+            writer.writeEndElement();
+        } catch (Exception xe) {
+            throw new RuntimeCamelException("XML Write Exception: " + xe.getMessage(), xe);
+        }
+    }
+
+    private static String getLangCode() {
+        String code = Locale.getDefault().getLanguage();
+        if (StringUtils.isEmpty(code)) {
+            return "en";
+        }
+        return code;
+    }
+
+    private static String getCodeString(String prefix, String defaultPrefix, QName code) {
+        String codePrefix;
+        if (StringUtils.isEmpty(prefix)) {
+            codePrefix = code.getPrefix();
+            if (StringUtils.isEmpty(codePrefix)) {
+                codePrefix = defaultPrefix;
+            }
+        } else {
+            codePrefix = prefix;
+        }
+
+        return codePrefix + ":" + code.getLocalPart();
+    }
+}

--- a/app/connector/soap/src/test/java/io/syndesis/connector/soap/cxf/BasicAuthIntegrationTest.java
+++ b/app/connector/soap/src/test/java/io/syndesis/connector/soap/cxf/BasicAuthIntegrationTest.java
@@ -40,11 +40,15 @@ public class BasicAuthIntegrationTest extends IntegrationTestBase {
 
     @Override
     protected String requestEnvelopePattern(String body) {
-        return  ("<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">"  +
+        return  ("<soap:Envelope xmlns:soap=\"" + getSoapNamespace() + "\">" +
                     "<soap:Body>" +
                         body +
                     "</soap:Body>" +
                 "</soap:Envelope>").replaceAll("/", "\\\\/").replaceAll("([^\\\\])\\.", "$1\\\\.");
+    }
+
+    protected String getSoapVersion() {
+        return "1.1";
     }
 
     @Override
@@ -52,7 +56,7 @@ public class BasicAuthIntegrationTest extends IntegrationTestBase {
         connection = new Connection.Builder()
             .putConfiguredProperty(ADDRESS, "http://localhost:" + wiremock.port())
             .putConfiguredProperty(SPECIFICATION, readSpecification())
-            .putConfiguredProperty(SOAP_VERSION, "1.1")
+            .putConfiguredProperty(SOAP_VERSION, getSoapVersion())
             .putConfiguredProperty(AUTHENTICATION_TYPE, AuthenticationType.BASIC.getValue())
             .putConfiguredProperty(USERNAME, TEST_USER)
             .putConfiguredProperty(PASSWORD, TEST_PASSWORD)

--- a/app/connector/soap/src/test/java/io/syndesis/connector/soap/cxf/SoapFaultIntegrationTest.java
+++ b/app/connector/soap/src/test/java/io/syndesis/connector/soap/cxf/SoapFaultIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.soap.cxf;
+
+public class SoapFaultIntegrationTest extends BasicAuthIntegrationTest {
+
+    private static final String ERROR_PAYLOAD =
+        "<soap:Fault>" +
+            "<faultcode>soap:Server</faultcode>" +
+            "<faultstring>Internal Server Error</faultstring>" +
+            "<detail>" +
+                "<ns1:sayHiError xmlns:ns1=\"http://camel.apache.org/cxf/wsrm\">" +
+                    "<error xmlns=\"http://camel.apache.org/cxf/wsrm/\">Hello Error!!!</error>" +
+                "</ns1:sayHiError>" +
+            "</detail>" +
+        "</soap:Fault>";
+
+    @Override
+    protected String getResponsePayload() {
+        return ERROR_PAYLOAD;
+    }
+}

--- a/app/connector/soap/src/test/resources/HelloWorld.wsdl
+++ b/app/connector/soap/src/test/resources/HelloWorld.wsdl
@@ -30,8 +30,14 @@
           <xs:element minOccurs="0" name="return" type="xs:string"/>
         </xs:sequence>
       </xs:complexType>
+      <xs:complexType name="sayHiError">
+          <xs:sequence>
+              <xs:element minOccurs="0" name="error" type="xs:string"/>
+          </xs:sequence>
+      </xs:complexType>
       <xs:element name="sayHi" nillable="true" type="sayHi"/>
       <xs:element name="sayHiResponse" nillable="true" type="sayHiResponse"/>
+      <xs:element name="sayHiError" nillable="true" type="sayHiError"/>
     </xs:schema>
   </wsdl:types>
   <wsdl:message name="sayHi">
@@ -42,12 +48,18 @@
     <wsdl:part element="tns:sayHiResponse" name="parameters">
     </wsdl:part>
   </wsdl:message>
+  <wsdl:message name="sayHiError">
+      <wsdl:part element="tns:sayHiError" name="parameters">
+      </wsdl:part>
+  </wsdl:message>
   <wsdl:portType name="HelloWorld">
     <wsdl:operation name="sayHi">
       <wsdl:input message="tns:sayHi" name="sayHi">
       </wsdl:input>
       <wsdl:output message="tns:sayHiResponse" name="sayHiResponse">
       </wsdl:output>
+      <wsdl:fault message="tns:sayHiError" name="sayHiError">
+      </wsdl:fault>
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="HelloWorldServiceSoapBinding" type="tns:HelloWorld">
@@ -60,6 +72,9 @@
       <wsdl:output name="sayHiResponse">
         <soap:body use="literal"/>
       </wsdl:output>
+      <wsdl:fault name="sayHiError">
+        <soap:body use="literal"/>
+      </wsdl:fault>
     </wsdl:operation>
   </wsdl:binding>
   <wsdl:service name="HelloWorldService">


### PR DESCRIPTION
Fixes #8722, handle SOAP faults copying them to out message in SOAP
connector

(cherry picked from commit aae6428bd9670cd157b91dd47b27a5135a62645a)

```
# Conflicts:
#	app/connector/soap/pom.xml
#	app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/SoapCxfProxyComponent.java
#	app/connector/soap/src/test/java/io/syndesis/connector/soap/cxf/IntegrationTestBase.java
```