### PR TITLE
fix: handling of YAML to JSON conversion

### DIFF
--- a/app/connector/rest-swagger/pom.xml
+++ b/app/connector/rest-swagger/pom.xml
@@ -201,6 +201,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
@@ -20,19 +20,22 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 import io.syndesis.integration.component.proxy.ComponentProxyCustomizer;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 public final class SpecificationResourceCustomizer implements ComponentProxyCustomizer {
 
@@ -62,55 +65,71 @@ public final class SpecificationResourceCustomizer implements ComponentProxyCust
     }
 
     /**
-     * Scan the specification and leave only the security method picked by user, if any present.
-     * The change is required to avoid exposure of security configuration (such as apikey) through other channels not requested by user,
-     * for example, query parameters when the user only wants to provide api key through http headers.
-     *
-     * @param specification                    the swagger/openapi original specification
-     * @param securityDefinitionSelectedByUser the securityDefinition picked by the user
-     * @return the updated swagger/openapi specification or the original specification
-     */
-    private static String updateSecuritySpecification(final String specification, final String securityDefinitionSelectedByUser) throws IOException {
-        final Optional<String> securityDefinitionName = getNameFromDefinition(securityDefinitionSelectedByUser);
-        if (securityDefinitionName.isPresent()) {
-            JsonNode rootNode = OBJECT_MAPPER.readTree(specification);
-            List<JsonNode> securities = rootNode.findValues("security");
-            if (!securities.isEmpty()) {
-                LOG.info("Updating specification to accept only {} user selected security method", securityDefinitionName.get());
-                for (JsonNode endpointSecurity : securities) {
-                    if (endpointSecurity.isArray()) {
-                        ArrayNode securityArray = (ArrayNode) endpointSecurity;
-                        for (int i = 0; i < securityArray.size(); i++) {
-                            String securityName = securityArray.get(i).fieldNames().next();
-                            if (!securityDefinitionName.get().equals(securityName)) {
-                                securityArray.remove(i);
-                            }
-                        }
-                    } else {
-                        // Security section must be an array
-                        throw new IllegalArgumentException("Swagger/OpenAPI specification requires endpoint security to be an array of elements!");
-                    }
-                }
-                return OBJECT_MAPPER.writeValueAsString(rootNode);
-            }
-        }
-
-        // no changes
-        LOG.debug("Specification was provided with no security method");
-        return specification;
-    }
-
-    /**
      * Get the name from the security definition or an empty value
      *
-     * @param securityDefinitionSelectedByUser with format type:name (ie, apiKey: api-key-security)
+     * @param securityDefinitionSelectedByUser with format type:name (ie,
+     *            apiKey: api-key-security)
      * @return the name of the definition or an empty value
      */
-    private static Optional<String> getNameFromDefinition(String securityDefinitionSelectedByUser) {
+    private static Optional<String> getNameFromDefinition(final String securityDefinitionSelectedByUser) {
         if (securityDefinitionSelectedByUser != null && securityDefinitionSelectedByUser.indexOf(':') > 0) {
             return Optional.of(securityDefinitionSelectedByUser.substring(securityDefinitionSelectedByUser.indexOf(':') + 1).trim());
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Scan the specification and leave only the security method picked by user,
+     * if any present. The change is required to avoid exposure of security
+     * configuration (such as apikey) through other channels not requested by
+     * user, for example, query parameters when the user only wants to provide
+     * api key through http headers.
+     *
+     * @param specification the swagger/openapi original specification
+     * @param securityDefinitionSelectedByUser the securityDefinition picked by
+     *            the user
+     * @return the updated swagger/openapi specification or the original
+     *         specification
+     */
+    private static String updateSecuritySpecification(final String specification, final String securityDefinitionSelectedByUser) throws IOException {
+        final Optional<String> securityDefinitionName = getNameFromDefinition(securityDefinitionSelectedByUser);
+        if (!securityDefinitionName.isPresent()) {
+            // no changes
+            LOG.debug("Specification was provided with no security method");
+            return specification;
+        }
+
+        final JsonNode rootNode = OBJECT_MAPPER.readTree(specification);
+        final List<JsonNode> securities = rootNode.findValues("security");
+        if (securities.isEmpty()) {
+            // no changes
+            LOG.debug("Specification was provided with no security method");
+            return specification;
+        }
+
+        LOG.info("Updating specification to accept only {} user selected security method", securityDefinitionName.get());
+        for (final JsonNode endpointSecurity : securities) {
+            if (endpointSecurity.isArray()) {
+                final ArrayNode securityArray = (ArrayNode) endpointSecurity;
+                for (int i = 0; i < securityArray.size(); i++) {
+                    final JsonNode securityDefinition = securityArray.get(i);
+                    final Iterator<String> fields = securityDefinition.fieldNames();
+                    if (!fields.hasNext()) {
+                        continue;
+                    }
+
+                    final String securityName = fields.next();
+                    if (!securityDefinitionName.get().equals(securityName)) {
+                        securityArray.remove(i);
+                    }
+                }
+            } else {
+                // Security section must be an array
+                throw new IllegalArgumentException("Swagger/OpenAPI specification requires endpoint security to be an array of elements!");
+            }
+        }
+
+        return OBJECT_MAPPER.writeValueAsString(rootNode);
     }
 }

--- a/app/connector/rest-swagger/src/test/resources/twitter-api.yaml
+++ b/app/connector/rest-swagger/src/test/resources/twitter-api.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.2
+info:
+  title: Tweeter API - GET
+  description: some description
+  version: 0.1.9
+servers:
+  - url: https://api.twitter.com
+    description: Optional server description, e.g. Main (production) server
+paths:
+  /labs/2/users/{id}:
+    get:
+      summary: Get types.
+      parameters:
+        - name: id
+          in: path
+          description: User ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: A list of types.
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/User'
+        '500':
+          description: Error
+components:
+  schemas:
+    User:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        username:
+          type: string
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+security:
+- ApiKeyAuth: []


### PR DESCRIPTION
We keep all OpenAPI documents as JSON, so when folk upload an OpenAPI
document in YAML format, we convert it to JSON. This conversion used
Jackson `ObjectMaper` configured to drop _empty_ values. So if a
document with empty array for a value would be uploaded the resulting
JSON would not contain the object field containing that value.

This represents a problem when handling OpenAPI documents as some fields
may hold empty arrays, could be due to the OpenAPI generation quirks.

So for example a YAML document:

```yaml
security:
- ApiKeyAuth: []
```

Would be converted to a JSON document:

```json
{
  "security": [{}]
}
```

Loosing the `ApiKeyAuth` field in the process.

This addresses this by configuring a separate `ObjectMapper` for value
conversion and introducing additional robustness in OpenAPI document
handling.

Fixes #9411