### PR TITLE
chore: tweak parameters for out of cluster dev env

### DIFF
--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -489,7 +489,6 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
-          <jvmArguments>-server -Xms256m -Xmx512m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000</jvmArguments>
           <layout>ZIP</layout>
         </configuration>
         <executions>
@@ -498,6 +497,17 @@
               <goal>repackage</goal>
               <goal>build-info</goal>
             </goals>
+          </execution>
+          <execution>
+            <?m2e ignore ?>
+            <id>default-cli</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase />
+            <configuration>
+              <jvmArguments>-server -Xms256m -Xmx512m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999 -Dserver.port=9090 -Dmanagement.server.port=9091 -DLOADER_HOME=target</jvmArguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -182,7 +182,7 @@
             </goals>
             <phase />
             <configuration>
-              <jvmArguments>-Dencrypt.key=supersecret -Dcontrollers.dblogging.enabled=false -Dopenshift.enabled=false -Dmetrics.kind=noop -Dfeatures.monitoring.enabled=false</jvmArguments>
+              <jvmArguments>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8888 -Dcontrollers.dblogging.enabled=false -Dencrypt.key=supersecret -Dfeatures.monitoring.enabled=false -Dmeta.service=localhost:9090 -Dmetrics.kind=noop -Dopenshift.enabled=false -Dmetrics.kind=noop -Dspring.cloud.kubernetes.enabled=false</jvmArguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Updates parameters when running server or meta via `spring-boot:run` to
include Java debug wire protocol agent and disable latest additions that
require OpenShift cluster to run.