### PR TITLE
feature(e2e-job): Don't execute on docs or ui changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,35 @@ name: Integration Tests 1.x branch
 on: pull_request
 
 jobs:
+  # JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      docs: ${{ steps.filter.outputs.docs }}
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        # Added all possible filters even if we just use app
+        filters: |
+          app:
+            - 'app/**'
+          docs:
+            - 'doc/**'
+          ui:
+            - 'app/ui-react/**'
+            - 'package.json'
+            - 'yarn.lock'
+            - 'node_modules/**'
+
+
   integration-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -3,8 +3,36 @@ name: On PR
 on: 
   pull_request
 
-jobs:
+jobs:  
+  # JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      docs: ${{ steps.filter.outputs.docs }}
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        # Added all possible filters even if we just use app and ui
+        filters: |
+          app:
+            - 'app/**'
+          docs:
+            - 'doc/**'
+          ui:
+            - 'app/ui-react/**'
+            - 'package.json'
+            - 'yarn.lock'
+            - 'node_modules/**'
+            
+
   full-pr-build:
+    needs: changes
+    if: ${{ needs.changes.outputs.app == 'true' || needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     env:
       IMAGES_DIR: syndesis_images


### PR DESCRIPTION
In theory the integration tests should be skipped (and seen as success) on this PR.

But on other PR it should run.