### PR TITLE
fix: git authentication and setup in daily release

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -38,7 +38,7 @@ jobs:
           QUAYIO_PASSWORD: ${{ secrets.QUAYIO_PASSWORD }}
           SYNDESISCI_TOKEN: ${{ secrets.SYNDESISCI_TOKEN }}
         run: |
-          git config --user user.email admin@syndesis.io
-          git config --user user.name 'Syndesis CI'
-          git config --user "http.https://github.com.extraheader=Authorization: basic ${SYNDESISCI_TOKEN}"
+          git config user.email admin@syndesis.io
+          git config user.name 'Syndesis CI'
+          git config "http.https://github.com.extraheader=Authorization: basic ${SYNDESISCI_TOKEN}"
           tools/bin/syndesis release --snapshot-release --git-remote origin --docker-user "${DOCKER_USER}" --docker-password "${DOCKER_PASSWORD}" --quayio-user "${QUAYIO_USER}" --quayio-password "${QUAYIO_PASSWORD}"


### PR DESCRIPTION
Remove `--user`, the intent was `--local`, but that's the default
anyways.