### PR TITLE
chore: don't fail fast on release matrix build

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - branch: 1.12.x


### PR DESCRIPTION
Let's not abort all builds in release if one branch of the release build
fails.