### PR TITLE
fix(build): network issues on GitHub Actions

### DIFF
--- a/app/.mvn/maven.config
+++ b/app/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dmaven.artifact.threads=8 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dfailsafe.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt
+-Dmaven.artifact.threads=8 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dfailsafe.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dmaven.wagon.httpconnectionManager.ttlSeconds=180


### PR DESCRIPTION
Seems that Azure has resets any network connection that are idle for 4
minutes[1]. This sets the wagon connection pool TTL[2] to 3 minutes to
bypass that issue.

[1] https://azure.microsoft.com/en-us/blog/new-configurable-idle-timeout-for-azure-load-balancer/
[2] https://issues.apache.org/jira/browse/WAGON-545