### PR TITLE
fix: wagon TTL setting is a JVM property

### DIFF
--- a/app/.mvn/jvm.config
+++ b/app/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xmx1024m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication
+-Xmx1024m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication -Dmaven.wagon.httpconnectionManager.ttlSeconds=180

--- a/app/.mvn/maven.config
+++ b/app/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dmaven.artifact.threads=8 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dfailsafe.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dmaven.wagon.httpconnectionManager.ttlSeconds=180
+-Dmaven.artifact.threads=8 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt -Dfailsafe.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt


### PR DESCRIPTION
It appears that the setting is not a Maven but a JVM property.
Go figure.