### PR TITLE
Use latest release to download syndesis-operator, excluding 2.x

### DIFF
--- a/tools/bin/commands/crc
+++ b/tools/bin/commands/crc
@@ -81,6 +81,10 @@ crc::run() {
 
     if [ $(hasflag --install) ]; then
 
+        # syndesis-operator install --help prints the version in the --tag description
+        operator_version=$($OPERATOR_BINARY install --help|grep '\-\-tag'|cut -d "\"" -f 2)
+        echo "Syndesis version: ${operator_version}"
+
         # Switch to the proper context
         local profile=$(readopt --profile)
         if [ -n "${profile}" ]; then

--- a/tools/bin/commands/install
+++ b/tools/bin/commands/install
@@ -48,6 +48,10 @@ install::run() {
     fi
     download_operator_binary || print_error_and_exit "unable to download the operator binary, exit"
 
+    # syndesis-operator install --help prints the version in the --tag description
+    operator_version=$($OPERATOR_BINARY install --help|grep '\-\-tag'|cut -d "\"" -f 2)
+    echo "Syndesis version: ${operator_version}"
+
     local prep_only="false"
     if [[ $(hasflag -s --setup) ]]; then
         echo "Installing Syndesis CRD"

--- a/tools/bin/commands/minishift
+++ b/tools/bin/commands/minishift
@@ -92,6 +92,10 @@ minishift::run() {
 
     if [ $(hasflag --install) ]; then
 
+        # syndesis-operator install --help prints the version in the --tag description
+        operator_version=$($OPERATOR_BINARY install --help|grep '\-\-tag'|cut -d "\"" -f 2)
+        echo "Syndesis version: ${operator_version}"
+
         # Switch to the proper context
         local profile=$(readopt --profile)
         if [ -n "${profile}" ]; then

--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -89,18 +89,17 @@ download_operator_binary() {
     esac
 
     if [[ "${pattern}" != "unknown" ]]; then
-        release_uri="https://api.github.com/repos/syndesisio/syndesis/releases?per_page=1"
+        release_uri="https://api.github.com/repos/syndesisio/syndesis/releases?per_page=4"
         release_tag="$(readopt --tag)"
 
         if [[ -n "$release_tag" ]]; then
             release_uri="https://api.github.com/repos/syndesisio/syndesis/releases/tags/${release_tag}"
         fi
 
+        asset_name="${OPERATOR}-${pattern}"
         url=$(curl -s $release_uri \
-            | grep browser_download_url \
-            | grep ${OPERATOR} \
-            | grep ${pattern} \
-            | cut -d '"' -f 4)
+            | jq -r '.[]| select(.tag_name |startswith("2.")|not)| .assets[] | select(.name |startswith("'"${asset_name}"'"))| .browser_download_url' \
+            | head -1)
 
         #
         # Check curl returns a valid url
@@ -122,7 +121,8 @@ download_operator_binary() {
         fi
 
         if $(check_operator_binary); then
-            echo "operator binary successfully downloaded"
+            _version=$(echo ${url}| cut -d "/" -f 8)
+            echo "syndesis-operator ${_version} binary successfully downloaded"
             return 0
         else
             echo "operator binary download failed. Please try manually downloading from ${url} into $(dirname ${OPERATOR_BINARY})"


### PR DESCRIPTION
When instaling syndesis with syndesis script, prints the syndesis
version, so the user can check if the correct version is used.

Excludes releases from 2.x branch when installing with syndesis script.