### PR TITLE
chore(sql): polish UUID support in PostgreSQL

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlSupport.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.syndesis.connector.sql.common.DbMetaDataHelper;
+import io.syndesis.connector.sql.common.JDBCTypeHelper;
 import io.syndesis.connector.sql.common.stored.ColumnMode;
 import io.syndesis.connector.sql.common.stored.StoredProcedureColumn;
 import io.syndesis.connector.sql.common.stored.StoredProcedureMetadata;
@@ -59,7 +60,9 @@ public final class SqlSupport {
                         final StoredProcedureColumn column = new StoredProcedureColumn();
                         column.setName(columnSet.getString("COLUMN_NAME"));
                         column.setMode(mode);
-                        column.setJdbcType(JDBCType.valueOf(columnSet.getInt("DATA_TYPE")));
+
+                        final JDBCType jdbcType = JDBCTypeHelper.determineJDBCType(columnSet);
+                        column.setJdbcType(jdbcType);
                         columnList.add(column);
                     }
                 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JDBCTypeHelper.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JDBCTypeHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public final class JDBCTypeHelper {
+
+    private JDBCTypeHelper() {
+        // utility class
+    }
+
+    public static JDBCType determineJDBCType(final ResultSet columnResultSet) throws SQLException {
+        final int columnType = columnResultSet.getInt("DATA_TYPE");
+        final String columnTypeName = columnResultSet.getString("TYPE_NAME");
+
+        return determineJDBCType(columnType, columnTypeName);
+    }
+
+    public static JDBCType determineJDBCType(final ResultSetMetaData metaData, final int column) throws SQLException {
+        final int columnType = metaData.getColumnType(column);
+        final String columnTypeName = metaData.getColumnTypeName(column);
+
+        return determineJDBCType(columnType, columnTypeName);
+    }
+
+    private static JDBCType determineJDBCType(final int columnType, final String columnTypeName) {
+        if (columnType == Types.OTHER) {
+            return determineOtherJDBCType(columnTypeName);
+        }
+
+        return JDBCType.valueOf(columnType);
+    }
+
+    private static JDBCType determineOtherJDBCType(final String typeName) {
+        if ("uuid".equalsIgnoreCase(typeName)) {
+            // treat UUID column type as VARCHAR
+            return JDBCType.VARCHAR;
+        }
+
+        return JDBCType.OTHER;
+    }
+
+}


### PR DESCRIPTION
Adds support for UUID column type in input parameters (SELECT
statements), and in stored procedures.