### PR TITLE
fix(credential): support type:name syntax

### DIFF
--- a/app/server/credential/src/main/java/io/syndesis/server/credential/CredentialProviderRegistry.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/CredentialProviderRegistry.java
@@ -77,9 +77,11 @@ final class CredentialProviderRegistry implements CredentialProviderLocator {
         }
     }
 
-    private static String determineProviderFrom(final Connector connector) {
+    static String determineProviderFrom(final Connector connector) {
         final Optional<String> authentication = connector.propertyTaggedWith(Credentials.AUTHENTICATION_TYPE_TAG);
 
-        return authentication.orElse(connector.getId().get());
+        return authentication
+            .map(a -> a.replaceFirst(":.*", ""))
+            .orElseGet(() -> connector.getId().get());
     }
 }

--- a/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialProviderRegistryTest.java
+++ b/app/server/credential/src/test/java/io/syndesis/server/credential/CredentialProviderRegistryTest.java
@@ -56,4 +56,26 @@ public class CredentialProviderRegistryTest {
             assertThat(p.getProperties().getAppSecret()).isEqualTo("a-client-secret");
         });
     }
+
+    @Test
+    public void shouldSupportDescriptiveAuthenticationTypes() {
+        // authentication types from OpenAPI are generated in the form of
+        // `type:id`, this is to distinguish different security constraints
+        // of the same type, alas with different IDs
+        final Connector connector = new Connector.Builder()
+            .putProperty("authType", new ConfigurationProperty.Builder()
+                .addTag(Credentials.AUTHENTICATION_TYPE_TAG)
+                .build())
+            .build();
+
+        assertThat(CredentialProviderRegistry.determineProviderFrom(withAuthenticationType(connector, "oauth2"))).isEqualTo("oauth2");
+        assertThat(CredentialProviderRegistry.determineProviderFrom(withAuthenticationType(connector, "oauth2:"))).isEqualTo("oauth2");
+        assertThat(CredentialProviderRegistry.determineProviderFrom(withAuthenticationType(connector, "oauth2:id"))).isEqualTo("oauth2");
+    }
+
+    private static Connector withAuthenticationType(final Connector connector, String type) {
+        return connector.builder()
+            .putOrRemoveConfiguredPropertyTaggedWith(Credentials.AUTHENTICATION_TYPE_TAG, type)
+            .build();
+    }
 }


### PR DESCRIPTION
With #5669 we introduced `type:name` syntax for authentication type. We
needed to follow up on that in #5858, and yet again here with the
credentials support.

When credential provider is to be selected the `type` is what the
provider is keyed against, we need to filter out the `:name` part so
that the correct credential provider can be looked up.