### PR TITLE
fix(ui) entesb-16038 - unable to delete middle integration step

### DIFF
--- a/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
+++ b/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
@@ -1,6 +1,19 @@
-import { DataShape, Step } from '@syndesis/models';
+import {
+  Connection,
+  DataShape,
+  Flow,
+  Integration,
+  Step,
+} from '@syndesis/models';
+import produce from 'immer';
 import { DataShapeKinds } from '../../constants';
-import { hasDataShape } from '../integrationFunctions';
+import {
+  getFlow,
+  hasDataShape,
+  isIntegrationApiProvider,
+  isPrimaryFlow,
+  removeStepFromFlow,
+} from '../integrationFunctions';
 
 describe('integration functions', () => {
   test.each`
@@ -46,5 +59,134 @@ describe('integration functions', () => {
     } as Step;
 
     expect(hasDataShape(step, true)).toBe(false);
+  });
+
+  it(`should return a specified flow from an integration`, () => {
+    const connections: Connection[] = [];
+
+    const flows: Flow[] = [
+      {
+        connections,
+        id: '123456',
+        name: 'hello!',
+      },
+      {
+        connections,
+        id: '123457',
+        name: 'goodbye!',
+      },
+    ];
+
+    const integration: Integration = {
+      flows,
+      name: 'Tiny Integration',
+    };
+
+    expect(getFlow(integration, '123457')).toBe(flows[1]);
+  });
+
+  it(`should determine if the provided flow is primary`, () => {
+    const primFlow: Flow = {
+      name: 'Some super duper primary flow..',
+      type: 'PRIMARY',
+    };
+    const nonPrimFlow: Flow = {
+      name: 'An alternate flow',
+      type: 'ALTERNATE',
+    };
+
+    expect(isPrimaryFlow(primFlow)).toBeTruthy();
+    expect(isPrimaryFlow(nonPrimFlow)).toBeFalsy();
+
+    nonPrimFlow.type = 'API_PROVIDER';
+
+    expect(nonPrimFlow.type).toBe('API_PROVIDER');
+    /**
+     * isPrimaryFlow checks for BOTH Primary + API Provider types
+     */
+    expect(isPrimaryFlow(nonPrimFlow)).toBeTruthy();
+  });
+
+  it(`should determine if the provided integration is an API provider integration`, () => {
+    /**
+     * The way this is determined is by including `API_PROVIDER`
+     * as a tag within the integration
+     */
+    const integration: Integration = {
+      flows: [],
+      name: 'Tiny Integration',
+      tags: ['api-provider'],
+    };
+
+    expect(isIntegrationApiProvider(integration)).toBeTruthy();
+  });
+
+  it(`should remove banana step from the provided integration`, async () => {
+    const customPosition = 1;
+    const fetchStepDescriptors = jest.fn().mockImplementation(() => {
+      return steps;
+    });
+
+    const removeStep = async (
+      integration: Integration,
+      flowId: string,
+      position: number
+    ) => {
+      return produce(integration, () => {
+        return removeStepFromFlow(
+          integration,
+          flowId,
+          position,
+          fetchStepDescriptors
+        );
+      });
+    };
+
+    /**
+     * If step is first or last position,
+     * the step should be deleted and user
+     * redirected to the step select
+     * page for that position.
+     */
+
+    const steps: Step[] = [
+      {
+        connection: { name: 'peach' },
+        id: '1234567',
+      },
+      {
+        connection: { name: 'banana' },
+        id: '1234567',
+      },
+      {
+        connection: { name: 'apple' },
+        id: '1234567',
+      },
+      {
+        connection: { name: 'mango' },
+        id: '1234567',
+      },
+    ];
+
+    const flows: Flow[] = [
+      {
+        id: '-MW_06XdNSe0O_IutbEY',
+        name: 'My Fun Flow',
+        steps,
+      },
+    ];
+
+    const customIntegration: Integration = {
+      flows,
+      name: 'Tiny Integration',
+    };
+
+    const newInt = await removeStep(
+      customIntegration,
+      '-MW_06XdNSe0O_IutbEY',
+      customPosition
+    );
+
+    expect(newInt!.flows![0].steps).toHaveLength(3);
   });
 });

--- a/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
+++ b/app/ui-react/packages/api/src/helpers/__test__/integrationFunctions.spec.ts
@@ -5,10 +5,11 @@ import {
   Integration,
   Step,
 } from '@syndesis/models';
-import produce from 'immer';
+import produce, { isDraft } from 'immer';
 import { DataShapeKinds } from '../../constants';
 import {
   getFlow,
+  getSteps,
   hasDataShape,
   isIntegrationApiProvider,
   isPrimaryFlow,
@@ -121,34 +122,7 @@ describe('integration functions', () => {
     expect(isIntegrationApiProvider(integration)).toBeTruthy();
   });
 
-  it(`should remove banana step from the provided integration`, async () => {
-    const customPosition = 1;
-    const fetchStepDescriptors = jest.fn().mockImplementation(() => {
-      return steps;
-    });
-
-    const removeStep = async (
-      integration: Integration,
-      flowId: string,
-      position: number
-    ) => {
-      return produce(integration, () => {
-        return removeStepFromFlow(
-          integration,
-          flowId,
-          position,
-          fetchStepDescriptors
-        );
-      });
-    };
-
-    /**
-     * If step is first or last position,
-     * the step should be deleted and user
-     * redirected to the step select
-     * page for that position.
-     */
-
+  it(`getSteps should return steps from given integration object`, () => {
     const steps: Step[] = [
       {
         connection: { name: 'peach' },
@@ -160,10 +134,6 @@ describe('integration functions', () => {
       },
       {
         connection: { name: 'apple' },
-        id: '1234567',
-      },
-      {
-        connection: { name: 'mango' },
         id: '1234567',
       },
     ];
@@ -181,12 +151,58 @@ describe('integration functions', () => {
       name: 'Tiny Integration',
     };
 
-    const newInt = await removeStep(
-      customIntegration,
-      '-MW_06XdNSe0O_IutbEY',
-      customPosition
-    );
+    const someSteps = getSteps(customIntegration, flows[0].id!);
+    // Expect original length to be the same
+    expect(someSteps).toHaveLength(3);
+    expect(customIntegration.flows![0].steps).toHaveLength(3);
+  });
 
-    expect(newInt!.flows![0].steps).toHaveLength(3);
+  it(`removeStepFromFlow should remove a step from a defined flow`, async () => {
+    const customSteps: Step[] = [
+      {
+        connection: { name: 'peach' },
+        id: '1234567',
+      },
+      {
+        connection: { name: 'banana' },
+        id: '1234567',
+      },
+      {
+        connection: { name: 'mango' },
+        id: '1234567',
+      },
+    ];
+
+    const customFlowId = '-MW_06XdNSe0O_IutbEY';
+
+    const customFlows: Flow[] = [
+      {
+        id: customFlowId,
+        name: 'My Fun Flow',
+        steps: customSteps,
+      },
+    ];
+
+    const customIntegration: Integration = {
+      flows: customFlows,
+      name: 'Tiny Integration',
+    };
+
+    const fetchStepDescriptors = jest.fn().mockImplementation(() => {
+      return customIntegration.flows![0].steps;
+    });
+
+    const newInt = await produce(customIntegration, () => {
+      return removeStepFromFlow(
+        customIntegration,
+        customFlowId,
+        1,
+        fetchStepDescriptors
+      );
+    });
+
+    expect(customIntegration.flows![0].steps).toHaveLength(2);
+    expect(newInt.flows![0].steps).toHaveLength(2);
+    expect(isDraft(newInt)).toBeFalsy();
   });
 });

--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -302,7 +302,8 @@ export function isActionShapeless(descriptor: ActionDescriptor) {
   return (
     inputDataShape &&
     outputDataShape &&
-    inputDataShape.kind && outputDataShape.kind &&
+    inputDataShape.kind &&
+    outputDataShape.kind &&
     (toDataShapeKinds(inputDataShape.kind) === DataShapeKinds.ANY ||
       toDataShapeKinds(outputDataShape.kind) === DataShapeKinds.ANY)
   );
@@ -572,14 +573,14 @@ export function setDescriptorOnAction(
       descriptor.inputDataShape.kind &&
       toDataShapeKinds(descriptor.inputDataShape.kind) !==
         DataShapeKinds.NONE &&
-        !descriptor.inputDataShape.specification);
+      !descriptor.inputDataShape.specification);
   const preserveOutput =
     isUserDefinedDataShape(oldOutputDataShape) ||
     (descriptor.outputDataShape &&
       descriptor.outputDataShape.kind &&
       toDataShapeKinds(descriptor.outputDataShape.kind) !==
         DataShapeKinds.NONE &&
-        !descriptor.outputDataShape.specification);
+      !descriptor.outputDataShape.specification);
   return {
     ...action,
     descriptor: {

--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -9,7 +9,7 @@ import {
 } from '@syndesis/models';
 import { key } from '@syndesis/utils';
 import { saveAs } from 'file-saver';
-import produce, { setAutoFreeze } from 'immer';
+import produce, { freeze, setAutoFreeze } from 'immer';
 import * as React from 'react';
 import { ApiContext } from './ApiContext';
 import { callFetch } from './callFetch';
@@ -459,14 +459,16 @@ export const useIntegrationHelpers = () => {
     flowId: string,
     position: number
   ) => {
-    return produce(integration, () => {
-      return removeStepFromFlow(
-        integration,
-        flowId,
-        position,
-        fetchStepDescriptors
-      );
-    });
+    return freeze(
+      produce(integration, () => {
+        return removeStepFromFlow(
+          integration,
+          flowId,
+          position,
+          fetchStepDescriptors
+        );
+      })
+    );
   };
 
   return {

--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -9,7 +9,7 @@ import {
 } from '@syndesis/models';
 import { key } from '@syndesis/utils';
 import { saveAs } from 'file-saver';
-import produce from 'immer';
+import produce, { setAutoFreeze } from 'immer';
 import * as React from 'react';
 import { ApiContext } from './ApiContext';
 import { callFetch } from './callFetch';
@@ -29,6 +29,8 @@ import {
   setStepInFlow,
   throwStandardError,
 } from './helpers';
+
+setAutoFreeze(false);
 
 export const useIntegrationHelpers = () => {
   const apiContext = React.useContext(ApiContext);

--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -30,10 +30,9 @@ import {
   throwStandardError,
 } from './helpers';
 
-setAutoFreeze(false);
-
 export const useIntegrationHelpers = () => {
   const apiContext = React.useContext(ApiContext);
+  setAutoFreeze(false);
 
   const fetchStepDescriptors = async (steps: Step[]): Promise<Step[]> => {
     const response = await callFetch({


### PR DESCRIPTION
fixes [entesb-16038](https://issues.redhat.com/browse/ENTESB-16038)

Immer [automatically freezes](https://immerjs.github.io/immer/freezing) any state trees modified using `produce`, which is typically what we'd want. However, "If auto freezing is enabled, recipes are not entirely side-effect free: Any plain object or array that ends up in the produced result, will be frozen, even when these objects were not frozen before the start of the producer!" Also: " Immer freezes everything recursively, for large data objects that won't be changed in the future this might be over-kill, in that case it can be more efficient to shallowly pre-freeze data using the freeze utility."

Specific to this issue, we are modifying the `steps` array prior to the integration being saved for the first time, and disabling auto freezing resolves this issue. To avoid causing future bugs, I've also pre-frozen the newly created `integration` object, which does a shallow freeze and allows `steps` to behave as a draft. Additional unit tests have been added, though as usual can be improved upon.

Note: Auto-freezing is normally disabled in production by Immer, and disabling it would only disable it in development mode.