### PR TITLE
Test performance improvements

### DIFF
--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/noop/NoopIntegrationController.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/noop/NoopIntegrationController.java
@@ -15,20 +15,11 @@
  */
 package io.syndesis.server.controller.integration.noop;
 
-import io.syndesis.common.util.EventBus;
-import io.syndesis.server.controller.ControllersConfigurationProperties;
-import io.syndesis.server.controller.StateChangeHandlerProvider;
-import io.syndesis.server.controller.integration.online.IntegrationController;
-import io.syndesis.server.dao.manager.DataManager;
-import io.syndesis.server.openshift.OpenShiftService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 @Service
 @ConditionalOnProperty(value = "controllers.integration", havingValue = "noop")
-public class NoopIntegrationController extends IntegrationController {
-
-    public NoopIntegrationController(OpenShiftService openShiftService, DataManager dataManager, EventBus eventBus, StateChangeHandlerProvider handlerFactory, ControllersConfigurationProperties properties) {
-        super(openShiftService, dataManager, eventBus, handlerFactory, properties);
-    }
+public class NoopIntegrationController {
+    // do nothing
 }

--- a/app/server/runtime/src/test/resources/bootstrap-test.yml
+++ b/app/server/runtime/src/test/resources/bootstrap-test.yml
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring:
+  cloud:
+    kubernetes:
+      config:
+        enabled: false
+      reload:
+        enabled: false


### PR DESCRIPTION
refactor: disable auto reconfiguration in tests (69d4ecc)

This disables Spring Cloud auto configuration/reconfiguration in tests.

refactor: empty noop implementation (81a76df)

The `NoopIntegrationController` would run exactly the same as the
default (S2I) `IntegrationController`, this makes the implementation be
a noop, as the name applies.

