### PR TITLE
fix(c/odata): listen on localhost in the tests

### DIFF
--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/server/ODataTestServer.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/server/ODataTestServer.java
@@ -240,6 +240,7 @@ public class ODataTestServer extends Server implements ODataConstants {
         }
 
         httpConnector = new ServerConnector(this);
+        httpConnector.setHost("localhost");
         httpConnector.setPort(httpPort); // Finds next available port if still 0
         this.addConnector(httpConnector);
 
@@ -254,6 +255,7 @@ public class ODataTestServer extends Server implements ODataConstants {
             final SslContextFactory sslContextFactory = new SslContextFactory();
             sslContextFactory.setSslContext(sslContext);
             httpsConnector = new ServerConnector(this, sslContextFactory, new HttpConnectionFactory(httpConfiguration));
+            httpsConnector.setHost("localhost");
             httpsConnector.setPort(httpsPort); // Finds next available port if still 0
             this.addConnector(httpsConnector);
         }

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
@@ -278,6 +278,7 @@ public class ODataTestServer extends Server implements ODataConstants {
         }
 
         httpConnector = new ServerConnector(this);
+        httpConnector.setHost("localhost");
         httpConnector.setPort(httpPort); // Finds next available port if still 0
         this.addConnector(httpConnector);
 
@@ -292,6 +293,7 @@ public class ODataTestServer extends Server implements ODataConstants {
             final SslContextFactory sslContextFactory = new SslContextFactory();
             sslContextFactory.setSslContext(sslContext);
             httpsConnector = new ServerConnector(this, sslContextFactory, new HttpConnectionFactory(httpConfiguration));
+            httpsConnector.setHost("localhost");
             httpsConnector.setPort(httpsPort); // Finds next available port if still 0
             this.addConnector(httpsConnector);
         }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationDeploymentITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationDeploymentITCase.java
@@ -85,7 +85,7 @@ public class IntegrationDeploymentITCase extends BaseITCase {
 
     @Test
     public void shouldDirectlyManipulateDeploymentTargetState() {
-        final ResponseEntity<IntegrationDeployment> version1 = put("/api/v1/integrations/test-id/deployments", null,
+        put("/api/v1/integrations/test-id/deployments", null,
             IntegrationDeployment.class, tokenRule.validToken(), HttpStatus.OK);
 
         post("/api/v1/integrations/test-id/deployments/1/targetState",
@@ -96,9 +96,8 @@ public class IntegrationDeploymentITCase extends BaseITCase {
             final ResponseEntity<IntegrationDeployment> fetched = get("/api/v1/integrations/test-id/deployments/1",
                 IntegrationDeployment.class);
 
-            assertThat(fetched.getBody()).isNotNull()
-                .isEqualTo(version1.getBody().withCurrentState(IntegrationDeploymentState.Unpublished)
-                    .withTargetState(IntegrationDeploymentState.Unpublished));
+            assertThat(fetched.getBody()).isNotNull().extracting(IntegrationDeployment::getTargetState)
+                .isEqualTo(IntegrationDeploymentState.Unpublished);
         });
     }
 }


### PR DESCRIPTION
`ODataTestServer` wasn't configured to listen on `localhost`, which
leads to timeouts in the test. This is getting a bit tiresome.