### PR TITLE
fix(server): integration deployment test fix

### DIFF
--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationDeploymentITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationDeploymentITCase.java
@@ -85,7 +85,7 @@ public class IntegrationDeploymentITCase extends BaseITCase {
 
     @Test
     public void shouldDirectlyManipulateDeploymentTargetState() {
-        final ResponseEntity<IntegrationDeployment> version1 = put("/api/v1/integrations/test-id/deployments", null,
+        put("/api/v1/integrations/test-id/deployments", null,
             IntegrationDeployment.class, tokenRule.validToken(), HttpStatus.OK);
 
         post("/api/v1/integrations/test-id/deployments/1/targetState",
@@ -96,9 +96,8 @@ public class IntegrationDeploymentITCase extends BaseITCase {
             final ResponseEntity<IntegrationDeployment> fetched = get("/api/v1/integrations/test-id/deployments/1",
                 IntegrationDeployment.class);
 
-            assertThat(fetched.getBody()).isNotNull()
-                .isEqualTo(version1.getBody().withCurrentState(IntegrationDeploymentState.Unpublished)
-                    .withTargetState(IntegrationDeploymentState.Unpublished));
+            assertThat(fetched.getBody()).isNotNull().extracting(IntegrationDeployment::getTargetState)
+                .isEqualTo(IntegrationDeploymentState.Unpublished);
         });
     }
 }


### PR DESCRIPTION
With the change in #9492 the value of the current state of the
integration deployment no longer flops, so this integration test needs
to be updated to take that into account.