### PR TITLE
fix(server): commit information in version API

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1390,7 +1390,7 @@
         <inherited>false</inherited>
         <executions>
           <execution>
-            <id>set-git-properties</id>
+            <id>basepom.default</id>
             <configuration>
               <injectAllReactorProjects>true</injectAllReactorProjects>
               <offline>true</offline>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1455,6 +1455,26 @@
             </bannedDependencies>
           </rules>
         </configuration>
+        <executions>
+          <execution>
+            <id>enforce-git-info</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <fail>true</fail>
+              <rules>
+                <requireProperty>
+                  <property>git.commit.id</property>
+                  <message>The `git.commit.id` property was not set</message>
+                  <regex>[0-9a-f]+</regex>
+                  <regexMessage>`git.commit.id` property must be a git commit id</regexMessage>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/VersionITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/VersionITCase.java
@@ -39,7 +39,7 @@ public class VersionITCase extends BaseITCase {
         final ResponseEntity<Map<String, String>> detailed = http(HttpMethod.GET, "/api/v1/version", null, MAP_OF_STRINGS,
             tokenRule.validToken(), headers, HttpStatus.OK);
 
-        assertThat(detailed.getBody()).isNotEmpty();
+        assertThat(detailed.getBody()).containsKeys("version", "commit-id");
     }
 
     @Test


### PR DESCRIPTION
Seems that recent refactoring had a side effect of removing the
`git.commit.id` property set by the `git-commit-id-plugin`. This refines
the configuration and adds a check in the integration test to make sure
the commit information is present in the future.

Ref. https://issues.redhat.com/browse/ENTESB-16130