### PR TITLE
Revert "chore(deps-dev): bump guava from 27.0.1-jre to 29.0-jre in /app"

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2886,7 +2886,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>29.0-jre</version>
+        <version>27.0.1-jre</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Reverts syndesisio/syndesis#9463

Upgrading Guava requires upgrading errorprone to 2.3.4 or newer due to missing `DoNotMock` annotation, upgrading to 2.3.4 leads to NullPointerExceptions in errorprone (https://github.com/google/error-prone/issues/1447), upgrading to 2.4.0 that has the fix for that leads to:

```
Fatal error compiling: CompilerException: InvocationTargetException: com/google/errorprone/ErrorProneCompiler: com.google.errorprone.ErrorProneCompiler
```

It seems that there is no quick fix for this, let's migrate to newer Guava and errorprone in a new pull request.