### PR TITLE
ENTESB-16286 Fix load procedures and functions in connector-sql

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbMetaDataHelper.java
@@ -57,9 +57,19 @@ public final class DbMetaDataHelper {
         return db.fetchProcedureColumns(meta, catalog, schema, procedureName);
     }
 
+    public ResultSet fetchFunctionColumns(final String catalog,
+        final String schema, final String procedureName) throws SQLException {
+        return db.fetchFunctionColumns(meta, catalog, schema, procedureName);
+    }
+
     public ResultSet fetchProcedures(final String catalog,
         final String schemaPattern, final String procedurePattern) throws SQLException {
         return db.fetchProcedures(meta, catalog, schemaPattern, procedurePattern);
+    }
+
+    public ResultSet fetchFunctions(final String catalog,
+        final String schemaPattern, final String functionPattern) throws SQLException {
+        return db.fetchFunctions(meta, catalog, schemaPattern, functionPattern);
     }
 
     Set<String> fetchTables(final String catalog,

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/Db.java
@@ -25,8 +25,12 @@ public interface Db {
     String adaptPattern(String pattern);
     ResultSet fetchProcedureColumns(DatabaseMetaData meta, String catalog,
         String schema, String procedureName) throws SQLException;
+    ResultSet fetchFunctionColumns(DatabaseMetaData meta, String catalog,
+        String schema, String functionName) throws SQLException;
     ResultSet fetchProcedures(DatabaseMetaData meta, String catalog,
         String schemaPattern, String procedurePattern) throws SQLException;
+    ResultSet fetchFunctions(DatabaseMetaData meta, String catalog,
+        String schemaPattern, String functionPattern) throws SQLException;
     String getAutoIncrementGrammar();
     String getName();
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/db/DbStandard.java
@@ -41,12 +41,30 @@ public class DbStandard implements Db {
     }
 
     @Override
+    public ResultSet fetchFunctionColumns(final DatabaseMetaData meta, final String catalog, final String schema, final String functionName) throws SQLException {
+        return meta.getFunctionColumns(
+                catalog,
+                adaptPattern(schema),
+                adaptPattern(functionName),
+                adaptPattern(null));
+    }
+
+    @Override
     public ResultSet fetchProcedures(final DatabaseMetaData meta, final String catalog, final String schemaPattern, final String procedurePattern)
             throws SQLException {
         return meta.getProcedures(
                 catalog,
                 adaptPattern(schemaPattern),
                 adaptPattern(procedurePattern));
+    }
+
+    @Override
+    public ResultSet fetchFunctions(final DatabaseMetaData meta, final String catalog, final String schemaPattern, final String functionPattern)
+        throws SQLException {
+        return meta.getFunctions(
+            catalog,
+            adaptPattern(schemaPattern),
+            adaptPattern(functionPattern));
     }
 
     @Override

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtension.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtension.java
@@ -32,9 +32,8 @@ public class SqlStoredConnectorMetaDataExtension extends AbstractMetaDataExtensi
 
     @Override
     public Optional<MetaData> meta(final Map<String, Object> properties) {
-        final Map<String, StoredProcedureMetadata> list = SqlSupport.getStoredProcedures(properties);
+        final Map<String, StoredProcedureMetadata> list = SqlSupport.getProceduresAndFunctions(properties);
         final MetaData metaData = new DefaultMetaData(null, null, list);
-
         return Optional.of(metaData);
     }
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
@@ -31,6 +31,14 @@ public final class SampleStoredProcedures {
             "LANGUAGE JAVA " +
             "EXTERNAL NAME 'io.syndesis.connector.sql.stored.SampleStoredProcedures.demo_out'";
 
+    public static final String DERBY_FUNCTION_DEMO_OUT_SQL =
+        "CREATE FUNCTION DEMO_OUT_DEGREES " +
+            "( RADIANS DOUBLE ) " +
+            "RETURNS DOUBLE " +
+            "PARAMETER STYLE JAVA " +
+            "NO SQL LANGUAGE JAVA " +
+            "EXTERNAL NAME 'java.lang.Math.toDegrees'";
+
     /**
      * SQL to create the DEMO_ADD procedure in Oracle
      */

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtensionTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredConnectorMetaDataExtensionTest.java
@@ -53,8 +53,8 @@ public class SqlStoredConnectorMetaDataExtensionTest {
         when(result.getInt("DATA_TYPE")).thenReturn(JDBCType.INTEGER.getVendorTypeNumber(),
             JDBCType.INTEGER.getVendorTypeNumber(), JDBCType.INTEGER.getVendorTypeNumber());
 
-        final StoredProcedureMetadata metadata = SqlSupport.getStoredProcedureMetadata(connection, "catalog", "schema",
-            "procedureName");
+        final StoredProcedureMetadata metadata = SqlSupport.getFunctionOrProcedureMetadata(connection, "catalog", "schema",
+            "procedureName", SqlSupport.TYPE.STORED_PROCEDURE);
 
         final StoredProcedureColumn columnA = new StoredProcedureColumn();
         columnA.setJdbcType(JDBCType.INTEGER);
@@ -100,8 +100,8 @@ public class SqlStoredConnectorMetaDataExtensionTest {
         when(result.getInt("COLUMN_TYPE")).thenReturn(ColumnMode.IN.ordinal());
         when(result.getInt("DATA_TYPE")).thenReturn(JDBCType.INTEGER.getVendorTypeNumber());
 
-        final StoredProcedureMetadata metadata = SqlSupport.getStoredProcedureMetadata(connection, "catalog", "schema",
-            "procedureName");
+        final StoredProcedureMetadata metadata = SqlSupport.getFunctionOrProcedureMetadata(connection, "catalog", "schema",
+            "procedureName", SqlSupport.TYPE.STORED_PROCEDURE);
 
         final StoredProcedureColumn columnA = new StoredProcedureColumn();
         columnA.setJdbcType(JDBCType.INTEGER);

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredProcedureTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredProcedureTest.java
@@ -30,10 +30,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.syndesis.connector.sql.stored.SampleStoredProcedures.DERBY_FUNCTION_DEMO_OUT_SQL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SqlTest.class)
-@Setup(SampleStoredProcedures.DERBY_DEMO_ADD_SQL)
+@Setup({SampleStoredProcedures.DERBY_DEMO_ADD_SQL, DERBY_FUNCTION_DEMO_OUT_SQL})
 @Teardown("DROP PROCEDURE DEMO_ADD")
 public class SqlStoredProcedureTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStoredProcedureTest.class);
@@ -45,10 +46,12 @@ public class SqlStoredProcedureTest {
         parameters.put("password", info.password);
         parameters.put("url", info.url);
 
-        Map<String, StoredProcedureMetadata> storedProcedures = SqlSupport.getStoredProcedures(parameters);
+        Map<String, StoredProcedureMetadata> storedProcedures = SqlSupport.getProceduresAndFunctions(parameters);
         assertThat(storedProcedures.isEmpty()).isFalse();
+        assertThat(storedProcedures.size()).isEqualTo(2);
         // Find 'demo_add'
         assertThat(storedProcedures.keySet().contains("DEMO_ADD")).isTrue();
+        assertThat(storedProcedures.keySet().contains("DEMO_OUT_DEGREES")).isTrue();
 
         for (String storedProcedureName : storedProcedures.keySet()) {
             StoredProcedureMetadata md = storedProcedures.get(storedProcedureName);


### PR DESCRIPTION
PostgreSQL 11 started to support procedures, before 11, the jdbc metadata getProcedures returned a list of functions.
Then after PostgreSQL 11, the getProcedures() method, only returns procedures and getFunctions() returns only functions.
To populate the procedures dropdown in UI, syndesis used to call only getProcedures(), which will not return the functions.
The fix is to use both getProcedures/getFunctions to maintain the same
behavior as before.

Syndesis doesn't show PostgreSQL demo data procedures
https://issues.redhat.com/browse/ENTESB-16286