### PR TITLE
fix(build): make sure pull request code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,6 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -89,6 +94,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -109,6 +119,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -131,6 +146,11 @@ jobs:
       IMAGES_DIR: syndesis_images
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -179,6 +199,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
With `pull_request_target` the target branch is checked out, so an
additional `actions/checkout` is needed to checkout the pull request.
So we have been building the code from the target branch `1.12.x` and
not from the pull request. This should fix that by the addition of a
`actions/checkout` when the event is `pull_request_target` that uses the
git id of the pull request.