### PR TITLE
chore(dep): Error Prone, Guava and Immutables bump

### DIFF
--- a/app/common/model/pom.xml
+++ b/app/common/model/pom.xml
@@ -77,11 +77,22 @@
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
 
+    <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+    </dependency>
+
     <!-- === Test ============================================================================ -->
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/DataShape.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/DataShape.java
@@ -69,7 +69,6 @@ public interface DataShape extends Serializable, WithName, WithMetadata {
 
     /**
      * Holds the variants available for this data shape.
-     *
      * A variant could be the single element inspection of collection
      */
     @Value.Default

--- a/app/common/model/src/main/java/io/syndesis/common/model/DataShapeKinds.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/DataShapeKinds.java
@@ -18,8 +18,6 @@ package io.syndesis.common.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-/**
- */
 public enum DataShapeKinds {
     ANY("any"),
     JAVA("java"),

--- a/app/common/model/src/main/java/io/syndesis/common/model/DataShapeMetaData.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/DataShapeMetaData.java
@@ -16,9 +16,6 @@
 
 package io.syndesis.common.model;
 
-/**
- * @author Christoph Deppisch
- */
 public final class DataShapeMetaData {
 
     public static final String VARIANT = "variant";
@@ -30,10 +27,7 @@ public final class DataShapeMetaData {
     public static final String SHOULD_COMPRESS = "compression";
     public static final String IS_COMPRESSED = "compressed";
 
-    /**
-     * Prevent instantiation of utility class.
-     */
     private DataShapeMetaData() {
-        super();
+      // Prevent instantiation of utility class.
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/InputDataShapeAware.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/InputDataShapeAware.java
@@ -30,7 +30,6 @@ public interface InputDataShapeAware {
     /**
      * Assign the given dataShape to the target object if it implements
      * InputDataShapeAware interface.
-     *
      * @param target the potential InputDataShapeAware target.
      * @param dataShape the data shape.
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
@@ -29,7 +29,6 @@ import org.immutables.value.Value;
 /**
  * Holds the result of a list, including the total count of elements. This is used by the client for working out paging
  * when viewing a large list.
- *
  * @param <T> The type of the elements in the returned list.
  */
 @Value.Immutable
@@ -38,13 +37,13 @@ import org.immutables.value.Value;
 public interface ListResult<T> extends Iterable<T> {
 
     /**
-     *
+     * Total.
      * @return The total count of entities available.
      */
     int getTotalCount();
 
     /**
-     *
+     * Items on this page.
      * @return The filtered list of items. Depending on operations, this will contain at most getTotalCount elements.
      */
     @Value.Default

--- a/app/common/model/src/main/java/io/syndesis/common/model/ModelData.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/ModelData.java
@@ -26,7 +26,6 @@ import io.syndesis.common.util.json.JsonUtils;
 
 /**
  * Used to read the deployment.json file from the client GUI project
- *
  */
 public class ModelData<T extends WithId<T>> implements ToJson {
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/OutputDataShapeAware.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/OutputDataShapeAware.java
@@ -30,7 +30,6 @@ public interface OutputDataShapeAware {
     /**
      * Assign the given dataShape to the target object if it implements
      * InputDataShapeAware interface.
-     *
      * @param target the potential InputDataShapeAware target.
      * @param dataShape the data shape.
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/TagFinder.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/TagFinder.java
@@ -21,7 +21,6 @@ import java.util.TreeSet;
 /**
  * Finds the unique set of tags set on Syndesis entities WithTags, which are
  * Connections and Integrations.
- *
  */
 public class TagFinder {
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/WithConfigurationProperties.java
@@ -16,7 +16,6 @@
 package io.syndesis.common.model;
 
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -34,22 +33,22 @@ public interface WithConfigurationProperties {
     Map<String, ConfigurationProperty> getProperties();
 
     @JsonIgnore
-    default boolean isEndpointProperty(Entry<String, String> e) {
+    default boolean isEndpointProperty(Map.Entry<String, String> e) {
         return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && !this.getProperties().get(e.getKey()).componentProperty();
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isEndpointProperty() {
+    default Predicate<Map.Entry<String, String>> isEndpointProperty() {
         return this::isEndpointProperty;
     }
 
     @JsonIgnore
-    default boolean isComponentProperty(Entry<String, String> e) {
+    default boolean isComponentProperty(Map.Entry<String, String> e) {
         return this.getProperties() != null && this.getProperties().containsKey(e.getKey()) && this.getProperties().get(e.getKey()).componentProperty();
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isComponentProperty() {
+    default Predicate<Map.Entry<String, String>> isComponentProperty() {
         return this::isComponentProperty;
     }
 
@@ -69,42 +68,42 @@ public interface WithConfigurationProperties {
     }
 
     @JsonIgnore
-    default boolean isSecret(Entry<String, String> e) {
+    default boolean isSecret(Map.Entry<String, String> e) {
         return this.isSecret(e.getKey());
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isSecret() {
+    default Predicate<Map.Entry<String, String>> isSecret() {
         return e -> this.isSecret(e.getKey());
     }
 
     @JsonIgnore
-    default boolean isSecretEndpointProperty(Entry<String, String> e) {
+    default boolean isSecretEndpointProperty(Map.Entry<String, String> e) {
         return this.isEndpointProperty(e) && this.isSecret(e);
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isSecretEndpointProperty() {
+    default Predicate<Map.Entry<String, String>> isSecretEndpointProperty() {
         return this::isSecretEndpointProperty;
     }
 
     @JsonIgnore
-    default boolean isSecretComponentProperty(Entry<String, String> e) {
+    default boolean isSecretComponentProperty(Map.Entry<String, String> e) {
         return this.isComponentProperty(e) && this.isSecret(e);
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isSecretComponentProperty() {
+    default Predicate<Map.Entry<String, String>> isSecretComponentProperty() {
         return this::isSecretComponentProperty;
     }
 
     @JsonIgnore
-    default boolean isSecretOrComponentProperty(Entry<String, String> e) {
+    default boolean isSecretOrComponentProperty(Map.Entry<String, String> e) {
         return this.isComponentProperty(e) || this.isSecret(e);
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isSecretOrComponentProperty() {
+    default Predicate<Map.Entry<String, String>> isSecretOrComponentProperty() {
         return this::isSecretOrComponentProperty;
     }
 
@@ -118,48 +117,47 @@ public interface WithConfigurationProperties {
     }
 
     @JsonIgnore
-    default boolean isRaw(Entry<String, String> e) {
+    default boolean isRaw(Map.Entry<String, String> e) {
         return this.isRaw(e.getKey());
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isRaw() {
+    default Predicate<Map.Entry<String, String>> isRaw() {
         return e -> this.isRaw(e.getKey());
     }
 
     @JsonIgnore
-    default boolean isRawEndpointProperty(Entry<String, String> e) {
+    default boolean isRawEndpointProperty(Map.Entry<String, String> e) {
         return this.isEndpointProperty(e) && this.isRaw(e);
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isRawEndpointProperty() {
+    default Predicate<Map.Entry<String, String>> isRawEndpointProperty() {
         return this::isRawEndpointProperty;
     }
 
     @JsonIgnore
-    default boolean isRawComponentProperty(Entry<String, String> e) {
+    default boolean isRawComponentProperty(Map.Entry<String, String> e) {
         return this.isComponentProperty(e) && this.isRaw(e);
     }
 
     @JsonIgnore
-    default Predicate<Entry<String, String>> isRawComponentProperty() {
+    default Predicate<Map.Entry<String, String>> isRawComponentProperty() {
         return this::isRawComponentProperty;
     }
 
 
     /**
      * Filters the specified properties, using the specified {@link Predicate} and value converter {@link Function}.
-     *
      * @param properties        The configuration.
      * @param predicate         The {@link Predicate}.
      * @param keyConverter    The {@link Function} to apply to keys.
      * @param valueConverter    The {@link Function} to apply to values.
      * @return                  A map with the properties that match the {@link Predicate}, and converted values.
      */
-    default Map<String, String> filterProperties(Map<String, String> properties, Predicate<Entry<String, String>> predicate,
-                                                 Function<Entry<String, String>, String> keyConverter,
-                                                 Function<Entry<String, String>, String> valueConverter) {
+    default Map<String, String> filterProperties(Map<String, String> properties, Predicate<Map.Entry<String, String>> predicate,
+                                                 Function<Map.Entry<String, String>, String> keyConverter,
+                                                 Function<Map.Entry<String, String>, String> valueConverter) {
         return properties.entrySet()
             .stream()
             .filter(predicate)
@@ -168,13 +166,12 @@ public interface WithConfigurationProperties {
 
     /**
      * Filters the specified properties, using the specified {@link Predicate} and value converter {@link Function}.
-     *
      * @param properties        The configuration.
      * @param predicate         The {@link Predicate}.
 
      * @return                  A map with the properties that match the {@link Predicate}, and converted values.
      */
-    default Map<String, String> filterProperties(Map<String, String> properties, Predicate<Entry<String, String>> predicate) {
+    default Map<String, String> filterProperties(Map<String, String> properties, Predicate<Map.Entry<String, String>> predicate) {
         return filterProperties(properties, predicate, Map.Entry::getKey, Map.Entry::getValue);
     }
 
@@ -200,7 +197,7 @@ public interface WithConfigurationProperties {
      * @return                  A map with just the sensitive data.
      */
     default Map<String, String> filterSecrets(Map<String, String> properties) {
-        return filterSecrets(properties, Entry::getValue);
+        return filterSecrets(properties, Map.Entry::getValue);
     }
 
     /**
@@ -209,27 +206,25 @@ public interface WithConfigurationProperties {
      * @param valueConverter    A {@link Function} that is applies to each {@link Entry} of the configuration.
      * @return                  A map with just the sensitive data.
      */
-    default Map<String, String> filterSecrets(Map<String, String> properties, Function<Entry<String, String>, String> valueConverter) {
+    default Map<String, String> filterSecrets(Map<String, String> properties, Function<Map.Entry<String, String>, String> valueConverter) {
         return properties.entrySet()
             .stream()
             .filter(isSecret())
-            .collect(Collectors.toMap(Entry::getKey, valueConverter::apply));
+            .collect(Collectors.toMap(Map.Entry::getKey, valueConverter));
     }
 
     /**
      * Returns first property entry tagged with the given tag.
-     *
      * @param tag               The looked after tag
      * @return                  First property tagged with the supplied tag, if any
      */
-    default Optional<Entry<String, ConfigurationProperty>> propertyEntryTaggedWith(final String tag) {
+    default Optional<Map.Entry<String, ConfigurationProperty>> propertyEntryTaggedWith(final String tag) {
         return getProperties().entrySet().stream().filter(entry -> entry.getValue().getTags().contains(tag))
             .findFirst();
     }
 
     /**
      * Returns first property tagged with the given tag.
-     *
      * @param properties        The properties
      * @param tag               The looked after tag
      * @return                  First property tagged with the supplied tag, if any

--- a/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/Action.java
@@ -18,7 +18,6 @@ package io.syndesis.common.model.action;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -102,7 +101,7 @@ public interface Action extends WithResourceId, WithKind, WithName, WithTags, Wi
         return descriptor != null
             ? descriptor.getPropertyDefinitionSteps().stream()
                 .flatMap(step -> step.getProperties().entrySet().stream())
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
             : Collections.emptyMap();
     }
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectionBase.java
@@ -41,7 +41,6 @@ public interface ConnectionBase
 
     /**
      * Actual options how this connection is configured
-     *
      * @return list of options
      */
     Map<String, String> getOptions();

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/Connector.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/Connector.java
@@ -48,9 +48,6 @@ import org.immutables.value.Value;
 public interface Connector extends WithId<Connector>, WithIdVersioned<Connector>, WithVersion.AutoUpdatable, WithActions<ConnectorAction>, WithTags, WithName, WithProperties, WithDependencies, WithMetadata, ToJson, Serializable {
 
     class Builder extends ImmutableConnector.Builder implements WithPropertiesBuilder<Builder> {
-        public Builder putOrRemoveConfiguredPropertyTaggedWith(final String tag, final String value) {
-            return putOrRemoveConfiguredPropertyTaggedWith(this, tag, value);
-        }
     }
 
     default Builder builder() {
@@ -92,8 +89,7 @@ public interface Connector extends WithId<Connector>, WithIdVersioned<Connector>
      * Provides a summary of the connector's actions
      * <p>
      * Note:
-     * Excluded from {@link #hashCode()} and {@link #equals(Object)}
-     *
+     * Excluded from {@link Connector#hashCode()} and {@link Connector#equals(Object)}
      * @return the summary of the connector's actions
      */
     @Value.Auxiliary
@@ -103,8 +99,7 @@ public interface Connector extends WithId<Connector>, WithIdVersioned<Connector>
      * Provide number of connections using this connector
      * <p>
      * Note:
-     * Excluded from {@link #hashCode()} and {@link #equals(Object)}
-     *
+     * Excluded from {@link Connector#hashCode()} and {@link Connector#equals(Object)}
      * @return count of integrations
      */
     @Value.Auxiliary

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorGroup.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConnectorGroup.java
@@ -25,9 +25,6 @@ import org.immutables.value.Value;
 
 /**
  * ConnectorGroups are labels in Camel.
- *
- * @author kstam
- *
  */
 @Value.Immutable
 @JsonDeserialize(builder = ConnectorGroup.Builder.class)

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/WithPropertiesBuilder.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/WithPropertiesBuilder.java
@@ -27,7 +27,6 @@ public interface WithPropertiesBuilder<T extends WithPropertiesBuilder<T>> {
     /**
      * Either sets or removes the property depending on if the given value is
      * {@code null}.
-     *
      * @param properties The properties
      * @param key Property key
      * @param value The value to set the property to, if null property will be
@@ -44,23 +43,21 @@ public interface WithPropertiesBuilder<T extends WithPropertiesBuilder<T>> {
 
     /**
      * Sets property tagged with the given tag to the supplied value
-     *
-     * @param properties The properties
      * @param tag The looked after tag
      * @param value The value to set the property to
      * @return The previous value of the property, if any
      */
-    default T putOrRemoveConfiguredPropertyTaggedWith(final WithPropertiesBuilder<T> builder, final String tag,
+    default T putOrRemoveConfiguredPropertyTaggedWith(final String tag,
         final String value) {
-        final WithProperties withProperties = builder.build();
+        final WithProperties withProperties = build();
         final Map<String, String> configuredProperties = withProperties.getConfiguredProperties();
 
         final Map<String, String> mutableCopy = new HashMap<>(configuredProperties);
 
         withProperties.propertyEntryTaggedWith(tag)
-            .map(entry -> putOrRemoveProperty(mutableCopy, entry.getKey(), value));
+            .ifPresent(entry -> putOrRemoveProperty(mutableCopy, entry.getKey(), value));
 
-        return builder.configuredProperties(mutableCopy);
+        return configuredProperties(mutableCopy);
     }
 
     T configuredProperties(Map<String, ? extends String> properties);

--- a/app/common/model/src/main/java/io/syndesis/common/model/expression/RuleBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/expression/RuleBase.java
@@ -16,9 +16,6 @@
 
 package io.syndesis.common.model.expression;
 
-/**
- * @author Christoph Deppisch
- */
 public interface RuleBase {
 
     /**

--- a/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
@@ -15,38 +15,92 @@
  */
 package io.syndesis.common.model.filter;
 
+import java.io.IOException;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.immutables.value.Value;
 
-import java.io.Serializable;
-
-@Value.Immutable
-@JsonDeserialize(builder = Op.Builder.class)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonDeserialize(using = Op.Deserializer.class)
 @SuppressWarnings("PMD.ShortClassName")
-public interface Op extends Serializable {
+@Schema(implementation = Op.Schema.class)
+public enum Op {
 
-    Op EQUALS = new Op.Builder().label("equals").operator("==").build();
-    Op EQUALS_IGNORE_CASE = new Op.Builder().label("equals (ignores case)").operator("=~").build();
-    Op NOT_EQUALS = new Op.Builder().label("not equals").operator("!=").build();
+    CONTAINS("contains", "contains"),
+    CONTAINS_IGNORE_CASE("contains (ignore case)", "~~"),
+    EQUALS("equals", "=="),
+    EQUALS_IGNORE_CASE("equals (ignores case)", "=~"),
+    GREATER_THAN("greater than", ">"),
+    GREATER_THAN_OR_EQUALS("greater than or equal to", ">="),
+    IN("in", "in"),
+    LESS_THAN("less than", "<"),
+    LESS_THAN_OR_EQUALS("less than or equal to", "<="),
+    MATCHES("matches", "regex"),
+    NOT_CONTAINS("not contains", "not contains"),
+    NOT_EQUALS("not equals", "!="),
+    NOT_IN("not in", "not in"),
+    NOT_MATCHES("not matches", "not regex");
 
-    Op LESS_THAN = new Op.Builder().label("less than").operator("<").build();
-    Op LESS_THAN_OR_EQUALS = new Op.Builder().label("less than or equal to").operator("<=").build();
-    Op GREATER_THAN = new Op.Builder().label("greater than").operator(">").build();
-    Op GREATER_THAN_OR_EQUALS = new Op.Builder().label("greater than or equal to").operator(">=").build();
+    @JsonProperty(index = 0)
+    private final String label;
 
-    Op CONTAINS = new Op.Builder().label("contains").operator("contains").build();
-    Op CONTAINS_IGNORE_CASE = new Op.Builder().label("contains (ignore case)").operator("~~").build();
-    Op NOT_CONTAINS = new Op.Builder().label("not contains").operator("not contains").build();
-    Op MATCHES = new Op.Builder().label("matches").operator("regex").build();
-    Op NOT_MATCHES = new Op.Builder().label("not matches").operator("not regex").build();
-    Op IN = new Op.Builder().label("in").operator("in").build();
-    Op NOT_IN = new Op.Builder().label("not in").operator("not in").build();
+    @JsonProperty(index = 1)
+    private final String operator;
 
-    String getLabel();
+    @SuppressWarnings("UnusedVariable")
+    @io.swagger.v3.oas.annotations.media.Schema(name = "Op")
+    static final class Schema {
+        @JsonProperty(index = 0)
+        private String label;
 
-    String getOperator();
+        @JsonProperty(index = 1)
+        private String operator;
 
-    class Builder extends ImmutableOp.Builder {
-        // make ImmutableOp.Builder which is package private accessible
+        private Schema() {
+            // used solely to describe the API for OpenAPI document generation
+        }
+    }
+
+    public static final class Deserializer extends JsonDeserializer<Op> {
+
+        @Override
+        public Op deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            final JsonNode node = ctxt.readTree(p);
+            final JsonNode operator = node.get("operator");
+            if (operator == null) {
+                return null;
+            }
+
+            final String opOperator = operator.textValue();
+
+            for (final Op op : Op.values()) {
+                if (op.operator.equals(opOperator)) {
+                    return op;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    Op(final String label, final String operator) {
+        this.label = label;
+        this.operator = operator;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getOperator() {
+        return operator;
     }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/filter/Op.java
@@ -42,14 +42,6 @@ public interface Op extends Serializable {
     Op IN = new Op.Builder().label("in").operator("in").build();
     Op NOT_IN = new Op.Builder().label("not in").operator("not in").build();
 
-    Op[] DEFAULT_OPTS = new Op[] {
-        EQUALS, EQUALS_IGNORE_CASE, NOT_EQUALS,
-        LESS_THAN, LESS_THAN_OR_EQUALS, GREATER_THAN, GREATER_THAN_OR_EQUALS,
-        CONTAINS, CONTAINS_IGNORE_CASE, NOT_CONTAINS,
-        MATCHES, NOT_MATCHES,
-        IN, NOT_IN
-    };
-
     String getLabel();
 
     String getOperator();

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/ContinuousDeliveryEnvironment.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/ContinuousDeliveryEnvironment.java
@@ -55,31 +55,26 @@ public interface ContinuousDeliveryEnvironment extends Serializable {
 
     /**
      * Associated {@link io.syndesis.common.model.environment.Environment}.
-     * @return
      */
     String getEnvironmentId();
 
     /**
      * Tag ID updated by release tag service. Used to compare tagged 'version' in destination environment.
-     * @return
      */
     String getReleaseTag();
 
     /**
      * Time when last tagged. Used to test whether integration should be updated.
-     * @return
      */
     Date getLastTaggedAt();
 
     /**
      * Time when last exported. If taggedAt is newer, then integration should be exported.
-     * @return
      */
     Optional<Date> getLastExportedAt();
 
     /**
      * Time when last imported.
-     * @return
      */
     Optional<Date> getLastImportedAt();
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/FlowMetadata.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/FlowMetadata.java
@@ -16,9 +16,6 @@
 
 package io.syndesis.common.model.integration;
 
-/**
- * @author Christoph Deppisch
- */
 public enum FlowMetadata {
     EXCERPT("excerpt");
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/IntegrationBase.java
@@ -105,8 +105,6 @@ public interface IntegrationBase
      * Map of target environment ids and continuous delivery states. Names are
      * created/deleted on the fly in the UI (since it's just a string). Managed
      * by release tag service and used by CD export and import service.
-     *
-     * @return
      */
     @Value.Default
     default Map<String, ContinuousDeliveryEnvironment> getContinuousDeliveryState() {

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/Step.java
@@ -26,7 +26,6 @@ import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.DataShapeMetaData;
 import io.syndesis.common.model.Dependency;
-import io.syndesis.common.model.Dependency.Type;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.WithConfiguredProperties;
 import io.syndesis.common.model.WithDependencies;
@@ -126,11 +125,11 @@ public interface Step extends WithId<Step>, WithConfiguredProperties, WithDepend
     @JsonIgnore
     default Set<String> getExtensionIds() {
         final Set<String> collected = getDependencies().stream()
-            .filter(d -> d.getType() == Type.EXTENSION)
+            .filter(d -> d.getType() == Dependency.Type.EXTENSION)
             .map(Dependency::getId)
             .collect(Collectors.toSet());
 
-        getExtension().map(Extension::getExtensionId).map(collected::add);
+        getExtension().map(Extension::getExtensionId).ifPresent(collected::add);
 
         return collected;
     }

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/MustacheTemplatePreProcessor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/MustacheTemplatePreProcessor.java
@@ -135,13 +135,11 @@ class MustacheTemplatePreProcessor extends AbstractTemplatePreProcessor<Mustache
 
         /*
          * Mustache endpoint has a conflict with ProcessorDefinition.
-         *
          * Once returned, the route (ProcessorDefinition) is resolved. This resolution
          * looks for any properties delimited by {{ and }}, which is the default syntax
          * for mustache properties. Thus, resolution of the mustache properties is
          * incorrectly attempted and fails since these properties are meant for mustache
          * and not camel.
-         *
          * Changing the mustache delimiter patterns avoids this problem and allows the
          * properties to be resolved later by mustache.
          */

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/TemplateStepLanguage.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/TemplateStepLanguage.java
@@ -137,7 +137,6 @@ public class TemplateStepLanguage {
 
     /**
      * Update the integration by visiting its {@link Flow}s and their {@link Step}s
-     *
      * @param integration the integration
      * @return the update integration
      */
@@ -158,7 +157,6 @@ public class TemplateStepLanguage {
 
     /**
      * Update the flow by visiting its {@link Step}s
-     *
      * @param flow the flow
      * @return the newly updated flow
      */
@@ -178,7 +176,6 @@ public class TemplateStepLanguage {
 
     /**
      * Update the template step {@link Step} with required dependencies
-     *
      * @param step the template step
      * @return the new step
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/TemplateStepPreProcessor.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/integration/step/template/TemplateStepPreProcessor.java
@@ -25,28 +25,24 @@ public interface TemplateStepPreProcessor<C extends ProcessingContext> {
      * Takes a template and conducts checks to ensure it is compatible
      * with the processing endpoint, eg. ensure 'body' prefix is present on each of
      * the symbols.
-     *
-     * @param template
-     * @return pre-processed template
      * @throws exception if processing fails
      */
     String preProcess(String template) throws TemplateProcessingException;
 
     /**
      * Parameters required for the endpoint
-     *
-     * @return
      */
     Map<String, Object> getUriParams();
 
     /**
+     * Syntaxes for the template language.
      * @return the syntax for the language's symbol, eg. '{{...}}' or '${...}'
      * Note: returns an array since languages can have more than one
      */
     List<SymbolSyntax> getSymbolSyntaxes();
 
     /**
-     * @param symbol
+     * Determines if the given symbol is recognised by this pre-processor.
      * @return whether the given symbol is recognised by this pre-processor
      */
     boolean isMySymbol(String symbol);

--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationDeploymentMetrics.java
@@ -30,23 +30,28 @@ public interface IntegrationDeploymentMetrics extends Serializable {
 
     String getVersion();
     /**
+     * Number of successful messages.
      * @return Number of successful messages
      */
     Long getMessages();
     /**
+     * Number of messages that resulted in error.
      * @return Number of messages that resulted in error
      */
     Long getErrors();
     /**
+     * Most recent start time of the integration.
      * @return most recent (re-) start Date of the integration, empty if no live pods
      * are found for this integration, which would mean that the integration is currently down.
      */
     Optional<Instant> getStart();
     /**
+     * Last message timestamp.
      * @return the TimeStamp of when the last message for processed
      */
     Optional<Instant> getLastProcessed();
     /**
+     * Uptime.
      * @return the duration this deployment is up and running.
      */
     Long getUptimeDuration();

--- a/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/metrics/IntegrationMetricsSummary.java
@@ -38,6 +38,7 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
     }
 
     /**
+     * Accumulated error messages.
      * @return Number of messages that resulted in error
      */
     Long getErrors();
@@ -50,11 +51,13 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
     }
 
     /**
+     * Last processed timestamp.
      * @return the TimeStamp of when the last message for processed
      */
     Optional<Instant> getLastProcessed();
 
     /**
+     * Number of successful messages
      * @return Number of successful messages
      */
     Long getMessages();
@@ -62,6 +65,7 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
     String getMetricsProvider();
 
     /**
+     * Most recent start time of the integration.
      * @return most recent (re-) start Date of the integration, empty if no live
      *         pods are found for this integration, which would mean that the
      *         integration is currently down.
@@ -69,6 +73,7 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
     Optional<Instant> getStart();
 
     /**
+     * Overview of top integrations.
      * @return Map of top 'N' (configured in metrics service, default 5)
      *         integrations by total messages. Only valid when retrieving total
      *         metrics summary.
@@ -76,6 +81,7 @@ public interface IntegrationMetricsSummary extends WithId<IntegrationMetricsSumm
     Optional<Map<String, Long>> getTopIntegrations();
 
     /**
+     * Uptime.
      * @return the duration this application is up and running.
      */
     Long getUptimeDuration();

--- a/app/common/model/src/main/java/io/syndesis/common/model/monitoring/IntegrationDeploymentStateDetails.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/monitoring/IntegrationDeploymentStateDetails.java
@@ -70,7 +70,6 @@ public interface IntegrationDeploymentStateDetails extends WithId<IntegrationDep
 
     /**
      * Type of log link being returned, i.e. whether events url or logs url should be displayed.
-     * @return
      */
     Optional<LinkType> getLinkType();
 

--- a/app/common/model/src/main/java/io/syndesis/common/model/support/Equivalencer.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/support/Equivalencer.java
@@ -208,7 +208,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link Step} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -267,7 +266,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link Extension} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -326,7 +324,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param one a {@link Integration} to compare with
      * @param another a {@link Integration} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
@@ -381,7 +378,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link Integration} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -430,7 +426,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link Connection} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -486,9 +481,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
-     * @param parentContext
-     * @param one
      * @param another a {@link Connector} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -549,7 +541,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link Action} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -605,7 +596,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link StepAction} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -656,7 +646,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link ConnectorAction} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -707,7 +696,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link StepDescriptor} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */
@@ -754,7 +742,6 @@ public class Equivalencer implements StringConstants {
      * Method can result in 2 instances being equivalent even though some
      * properties are different. Thus, this should only be used in appropriate
      * situations.
-     *
      * @param another a {@link ConnectorDescriptor} to compare with
      * @return true if this is equivalent to {code}another{code}, false otherwise
      */

--- a/app/common/model/src/main/java/io/syndesis/common/model/validation/TargetWithDomain.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/validation/TargetWithDomain.java
@@ -23,8 +23,6 @@ import io.syndesis.common.model.WithId;
 /**
  * An object paired with a search domain allowing then to be passed
  * around as single objects.
- *
- * @param <T>
  */
 public abstract class TargetWithDomain<T extends WithId<T>> implements WithId<T> {
 

--- a/app/common/model/src/test/java/io/syndesis/common/model/DataShapeBuilderTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/DataShapeBuilderTest.java
@@ -26,9 +26,6 @@ import io.syndesis.common.util.IOStreams;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class DataShapeBuilderTest {
 
     private static final String SPECIFICATION = "some uncompressed data";

--- a/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
@@ -27,24 +27,24 @@ public class OpTest {
 
     @Test
     public void allOperationsShouldBeKnownCamelSimpleOperations() {
-        assertThat(Stream.of(Op.DEFAULT_OPTS)
+        assertThat(Stream.of(Op.values())
             .map(Op::getOperator))
                 .allSatisfy(BinaryOperatorType::asOperator);
     }
 
     @Test
     public void allOperationsShouldHaveDistinctBinaryOperator() {
-        assertThat(Stream.of(Op.DEFAULT_OPTS)
+        assertThat(Stream.of(Op.values())
             .map(Op::getOperator)
             .collect(Collectors.toSet()))
-                .hasSameSizeAs(Op.DEFAULT_OPTS);
+                .hasSameSizeAs(Op.values());
     }
 
     @Test
     public void allOperationsShouldHaveDistinctLabels() {
-        assertThat(Stream.of(Op.DEFAULT_OPTS)
+        assertThat(Stream.of(Op.values())
             .map(Op::getLabel)
             .collect(Collectors.toSet()))
-                .hasSameSizeAs(Op.DEFAULT_OPTS);
+                .hasSameSizeAs(Op.values());
     }
 }

--- a/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/filter/OpTest.java
@@ -15,11 +15,16 @@
  */
 package io.syndesis.common.model.filter;
 
+import java.io.IOException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.syndesis.common.util.json.JsonUtils;
+
 import org.apache.camel.language.simple.types.BinaryOperatorType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +51,21 @@ public class OpTest {
             .map(Op::getLabel)
             .collect(Collectors.toSet()))
                 .hasSameSizeAs(Op.values());
+    }
+
+    @ParameterizedTest
+    @MethodSource("operations")
+    public void shouldSerializeAndDeserializeToKnownJson(final Op op) {
+        assertThat(JsonUtils.toString(op)).isEqualTo("{\"label\":\"" + op.getLabel() + "\",\"operator\":\"" + op.getOperator() + "\"}");
+    }
+
+    @ParameterizedTest
+    @MethodSource("operations")
+    public void shouldDeserializeAndDeserializeToKnownJson(final Op op) throws IOException {
+        assertThat(JsonUtils.reader().readValue("{\"label\":\"" + op.getLabel() + "\",\"operator\":\"" + op.getOperator() + "\"}", Op.class)).isEqualTo(op);
+    }
+
+    static Stream<Op> operations() {
+        return Stream.of(Op.values());
     }
 }

--- a/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestFreeMarkerTemplatePreProcessor.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestFreeMarkerTemplatePreProcessor.java
@@ -68,7 +68,6 @@ public class TestFreeMarkerTemplatePreProcessor implements StringConstants {
 
     /**
      * Freemarker does not allow numbers at the start of its symbols
-     * @throws Exception
      */
     @Test
     public void testTemplateSymbolBeginningWithNumber() throws Exception {
@@ -86,7 +85,6 @@ public class TestFreeMarkerTemplatePreProcessor implements StringConstants {
 
     /**
      * Freemarker does not allow spaces in its symbols
-     * @throws Exception
      */
     @Test
     public void testTemplateSymbolsWithSpaces() throws Exception {

--- a/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestMustacheTemplatePreProcessor.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestMustacheTemplatePreProcessor.java
@@ -98,8 +98,6 @@ public class TestMustacheTemplatePreProcessor implements StringConstants {
      * Unlike other languages, mustache does allow spaces in its symbols
      * Does make the pre-processed template look hideous but then no
      * one is supposed to read it so no real problem.
-     *
-     * @throws Exception
      */
     @Test
     public void testTemplateSymbolsWithSpaces() throws Exception {

--- a/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestVelocityTemplatePreProcessor.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/integration/step/template/TestVelocityTemplatePreProcessor.java
@@ -141,7 +141,6 @@ public class TestVelocityTemplatePreProcessor implements StringConstants {
 
     /**
      * Velocity does not allow numbers at the start of its symbols
-     * @throws Exception
      */
     @Test
     public void testTemplateSymbolBeginningWithNumber() throws Exception {
@@ -159,8 +158,6 @@ public class TestVelocityTemplatePreProcessor implements StringConstants {
 
     /**
      * Velocity does not allow spaces in its symbols
-     *
-     * @throws Exception
      */
     @Test
     public void testTemplateSymbolsWithSpaces() throws Exception {

--- a/app/common/util/src/main/java/io/syndesis/common/util/DurationConverter.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/DurationConverter.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 
 /**
  * Converts from String to a Duration.
- *
  * I wish spring boot could load and apply to config props automatically.
  */
 public class DurationConverter {

--- a/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/ErrorCategory.java
@@ -122,12 +122,7 @@ public final class ErrorCategory {
     public static boolean isCategorized(Throwable exception) {
         return ErrorCategory.RUNTIME_EXCEPTION_CATEGORY_MAP.containsKey(exception.getClass().getName());
     }
-    /**
-     *
-     * @param exception
-     * @param integrationCategories
-     * @return
-     */
+
     public static String getCategory(Throwable exception, Set<String> integrationCategories) {
         if (isCategorized(exception)) {
             String category = ErrorCategory.RUNTIME_EXCEPTION_CATEGORY_MAP.get(exception.getClass().getName());

--- a/app/common/util/src/main/java/io/syndesis/common/util/EventBus.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/EventBus.java
@@ -21,7 +21,6 @@ package io.syndesis.common.util;
 public interface EventBus {
     /**
      * Constants for known event types.
-     *
      * NOTE: May be better to use enums but EventBus is all about strings.
      */
     @SuppressWarnings("PMD.ConstantsInInterface")
@@ -31,7 +30,6 @@ public interface EventBus {
 
     /**
      * Constants for known event action
-     *
      * NOTE: May be better to use enums but EventBus is all about strings.
      */
     @SuppressWarnings("PMD.ConstantsInInterface")
@@ -49,7 +47,6 @@ public interface EventBus {
 
         /**
          * This method must never block.
-         *
          * @param event the type of event being delivered
          * @param data the data associated the the event type
          */
@@ -58,7 +55,6 @@ public interface EventBus {
 
     /**
      * Adds a subscription to the event bus.
-     *
      * @param subscriberId unique id for the subscription.
      * @param handler the callback that will receive the events.
      * @return the previously registered subscription with that id or null.

--- a/app/common/util/src/main/java/io/syndesis/common/util/RandomValueGenerator.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/RandomValueGenerator.java
@@ -19,7 +19,6 @@ import java.security.SecureRandom;
 
 /**
  * Generates strings values according to a generator string.
- *
  * Examples of generator string: "alphanum", "alphanum:50".
  */
 public final class RandomValueGenerator {

--- a/app/common/util/src/main/java/io/syndesis/common/util/SyndesisConnectorException.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/SyndesisConnectorException.java
@@ -38,10 +38,6 @@ public class SyndesisConnectorException extends RuntimeException {
         this.category = category!=null?category:ErrorCategory.SERVER_ERROR;
     }
 
-    /**
-     * Obtains the category.
-     * @return
-     */
     public String getCategory() {
         return category;
     }
@@ -58,11 +54,6 @@ public class SyndesisConnectorException extends RuntimeException {
         return new SyndesisConnectorException(category, detailedMsg, cause);
     }
 
-    /**
-     * Returns a SyndesysConnectorException
-     * @param cause
-     * @return SyndesysConnectorException
-     */
     public static SyndesisConnectorException from(Throwable exception) {
 
         if (exception instanceof SyndesisConnectorException) {

--- a/app/common/util/src/main/java/io/syndesis/common/util/cache/Cache.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/cache/Cache.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 /**
  * The interface for a cache.
- *
  */
 public interface Cache<K, V> {
 

--- a/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/JsonUtils.java
@@ -42,8 +42,6 @@ import io.syndesis.common.util.SyndesisServerException;
 
 /**
  * Utilities for working with Json.
- *
- * @author Christoph Deppisch
  */
 public final class JsonUtils {
 
@@ -73,7 +71,6 @@ public final class JsonUtils {
 
     /**
      * Returns an immutable and thread-safe instance of an ObjectReader, used for object deserialization.
-     * @return
      */
     public static ObjectReader reader() {
         return OBJECT_READER;
@@ -85,7 +82,6 @@ public final class JsonUtils {
 
     /**
      * Returns an immutable and thread-safe instance of an ObjectWriter, used for object serialization
-     * @return
      */
     public static ObjectWriter writer() {
         return OBJECT_WRITER;
@@ -94,9 +90,7 @@ public final class JsonUtils {
     /**
      * The name of this method is super awkward to remind you that there aren't many cases for you to use it.
      * It's main usage is in tests, where you might have reason to configure differently advanced parameters.
-     *
      * This method creates a copy of an ObjectMapper.
-     * @return
      */
     public static ObjectMapper copyObjectMapperConfiguration() {
         return OBJECT_MAPPER.copy();
@@ -129,8 +123,6 @@ public final class JsonUtils {
 
     /**
      * Checks given value to be a Json array of object representation.
-     * @param value
-     * @return
      */
     public static boolean isJson(String value) {
         if (value == null) {
@@ -142,8 +134,6 @@ public final class JsonUtils {
 
     /**
      * Checks given value could be JSON object string.
-     * @param value
-     * @return
      */
     public static boolean isJsonObject(String value) {
         if (Strings.isEmptyOrBlank(value)) {
@@ -157,8 +147,6 @@ public final class JsonUtils {
 
     /**
      * Checks given value could be JSON array string.
-     * @param value
-     * @return
      */
     public static boolean isJsonArray(String value) {
         if (Strings.isEmptyOrBlank(value)) {
@@ -173,9 +161,6 @@ public final class JsonUtils {
     /**
      * Converts array json node to a list of json object strings. Used when splitting a
      * json array with split EIP.
-     * @param json
-     * @return
-     * @throws JsonProcessingException
      */
     public static List<String> arrayToJsonBeans(JsonNode json) throws JsonProcessingException {
         List<String> jsonBeans = new ArrayList<>();
@@ -194,8 +179,6 @@ public final class JsonUtils {
 
     /**
      * Converts list of json object strings to a json array string.
-     * @param jsonBeans
-     * @return
      */
     public static String jsonBeansToArray(List<?> jsonBeans) {
         final StringJoiner joiner = new StringJoiner(",", "[", "]");

--- a/app/common/util/src/main/java/io/syndesis/common/util/json/OptionalStringTrimmingConverter.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/OptionalStringTrimmingConverter.java
@@ -23,13 +23,11 @@ import com.fasterxml.jackson.databind.util.Converter;
 
 /**
  * Trims {@code Optional<String>}s and converts empty strings to {@code Optional.empty()}
- *
  * You can enable it on a {@code Optional<String>} field like:
  * <pre>
- *   @JsonDeserialize(converter = OptionalStringTrimmingConverter.class)
+ *   &#064;JsonDeserialize(converter = OptionalStringTrimmingConverter.class)
  *   Optional<String> value;
  * </pre>
- *
  */
 public class OptionalStringTrimmingConverter implements Converter<String, Optional<String>> {
     @Override

--- a/app/common/util/src/main/java/io/syndesis/common/util/json/StringTrimmingConverter.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/StringTrimmingConverter.java
@@ -21,16 +21,14 @@ import com.fasterxml.jackson.databind.util.Converter;
 
 /**
  * Trims Json Strings and converts empty strings to {@code null}
- *
  * You can enable it on a String field like:
  * <pre>
- *   @JsonDeserialize(converter = StringTrimmingConverter.class)
+ * &#064;JsonDeserialize(converter = StringTrimmingConverter.class)
  *   String value;
  * </pre>
- *
  * Or on a String array:
  * <pre>
- *   @JsonDeserialize(contentConverter = StringTrimmingConverter.class)
+ *   &#064;JsonDeserialize(contentConverter = StringTrimmingConverter.class)
  *   String[] value;
  * </pre>
  */

--- a/app/common/util/src/main/java/io/syndesis/common/util/json/schema/JsonSchemaUtils.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/json/schema/JsonSchemaUtils.java
@@ -33,9 +33,6 @@ import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.deser.std.StringArrayDeserializer;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 
-/**
- * @author Christoph Deppisch
- */
 public final class JsonSchemaUtils {
 
     /** Logger */
@@ -48,13 +45,10 @@ public final class JsonSchemaUtils {
     /**
      * This method creates a copy of the default ObjectMapper configuration and adds special Json schema compatibility handlers
      * for supporting draft-03, draft-04 and draft-06 level at the same time.
-     *
      * Auto converts "$id" to "id" property for draft-04 compatibility.
-     *
      * In case the provided schema specification to read uses draft-04 and draft-06 specific features such as "examples" or a list of "required"
      * properties as array these information is more or less lost and auto converted to draft-03 compatible defaults. This way we can
      * read the specification to draft-03 compatible objects and use those.
-     * @return
      */
     public static ObjectReader reader() {
         return JsonUtils.copyObjectMapperConfiguration()

--- a/app/common/util/src/test/java/io/syndesis/common/util/json/JsonUtilsTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/json/JsonUtilsTest.java
@@ -26,9 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonUtilsTest {
 
     @Test

--- a/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQUtil.java
+++ b/app/connector/activemq/src/main/java/io/syndesis/connector/activemq/ActiveMQUtil.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for ActiveMQ Connection factory configuration.
- *
- * @author dhirajsb
  */
 public final class ActiveMQUtil {
 

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnector.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnector.java
@@ -34,7 +34,6 @@ import io.syndesis.integration.component.proxy.ComponentProxyComponent;
 
 /**
  * AMQP Proxy Component.
- * @author dhirajsb
  */
 class AMQPConnector extends ComponentProxyComponent {
 

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnectorFactory.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPConnectorFactory.java
@@ -20,7 +20,6 @@ import io.syndesis.integration.component.proxy.ComponentProxyFactory;
 
 /**
  * {@link ComponentProxyFactory} to create AMQP Connectors.
- * @author dhirajsb
  */
 public class AMQPConnectorFactory implements ComponentProxyFactory {
 

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPUtil.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPUtil.java
@@ -24,8 +24,6 @@ import io.syndesis.connector.support.util.KeyStoreHelper;
 
 /**
  * Utility class for creating AMQP ConnectionFactory.
- *
- * @author dhirajsb
  */
 public final class AMQPUtil {
 

--- a/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
+++ b/app/connector/amqp/src/main/java/io/syndesis/connector/amqp/AMQPVerifierExtension.java
@@ -33,7 +33,6 @@ import io.syndesis.connector.support.util.ConnectorOptions;
 
 /**
  * Component verifier for AMQP Connector.
- * @author dhirajsb
  */
 public class AMQPVerifierExtension extends DefaultComponentVerifierExtension {
 

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/customizer/DDBConnectorCustomizer.java
@@ -51,8 +51,6 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
 
     /**
      * Extract results and place them on the body.
-     *
-     * @param exchange
      */
     @SuppressWarnings("unchecked")
     protected void doAfterProducer(Exchange exchange) {
@@ -99,8 +97,6 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
 
     /**
      * Setup the common headers for all operations.
-     *
-     * @param exchange
      */
     @SuppressWarnings("unchecked")
     protected void doBeforeProducer(Exchange exchange) {
@@ -158,9 +154,6 @@ public abstract class DDBConnectorCustomizer implements ComponentProxyCustomizer
 
     /**
      * Customizations for each operation.
-     *
-     * @param exchange
-     * @param options
      */
     abstract void customize(Exchange exchange, Map<String,
         Object> options);

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataRetrieval.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/metadata/AWSDDBMetadataRetrieval.java
@@ -127,9 +127,6 @@ public class AWSDDBMetadataRetrieval extends ComponentMetadataRetrieval {
 
     /**
      * Extract columns of query and result to create a data shape.
-     *
-     * @param properties
-     * @return
      */
     private static SyndesisMetadata adaptForDDB(final Map<String, Object> properties,
         Map<String, List<PropertyPair>> enrichedProperties) {

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/util/Util.java
@@ -38,10 +38,6 @@ public final class Util {
 
     /**
      * Extract a map from a JSON in a header as AttributeValue. Useful for the headers.
-     *
-     * @param parameterName
-     * @param options
-     * @return
      */
     public static Map<String, AttributeValue> getAttributeValueMap(
     final String parameterName, Map<String, Object> options) {

--- a/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/verifier/DDBVerifier.java
+++ b/app/connector/aws-ddb/src/main/java/io/syndesis/connector/aws/ddb/verifier/DDBVerifier.java
@@ -35,8 +35,6 @@ import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
 
 /**
  * Factory to create the verifiers for the connection.
- *
- * @author delawen
  */
 public class DDBVerifier extends ComponentVerifier {
     public DDBVerifier() {

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBConfiguration.java
@@ -21,7 +21,6 @@ import com.amazonaws.regions.Regions;
 /**
  * To be able to run these integration tests you have to provide valid credentials, region
  * and a valid table name.
- *
  * These tests (at the moment) do write and read contents on your tables, so make sure
  * you use a table specifically for testing.
  */

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertItemTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBInsertItemTest.java
@@ -42,8 +42,6 @@ public class AWSDDBInsertItemTest extends AWSDDBGenericOperation {
 
     /**
      * Extend the steps to add an intermediate putitem
-     *
-     * @return
      */
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBQueryItemTest.java
+++ b/app/connector/aws-ddb/src/test/java/io/syndesis/connector/aws/ddb/AWSDDBQueryItemTest.java
@@ -42,8 +42,6 @@ public class AWSDDBQueryItemTest extends AWSDDBGenericOperation {
 
     /**
      * Extend the steps to add an intermediate putitem
-     *
-     * @return
      */
     @Override
     protected List<Step> createSteps() {

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/component/EMailComponent.java
@@ -37,10 +37,8 @@ public final class EMailComponent extends ComponentProxyComponent implements EMa
 
     /**
      * These fields are populated using reflection by the HandlerCustomizer class.
-     *
      * The values are resolved then the appropriate setter called, while the original
      * key/value pairs are removed from the options map.
-     *
      * Note:
      * Should a property be secret then its raw value is the property placeholder and
      * the resolving process converts it accordingly hence the importance of doing it

--- a/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
+++ b/app/connector/email/src/main/java/io/syndesis/connector/email/verifier/AbstractEMailVerifier.java
@@ -83,10 +83,6 @@ public abstract class AbstractEMailVerifier extends DefaultComponentVerifierExte
      * Sets the connection timeout property, eg. mail.imap.connectiontimeout, to 'value' seconds.
      * This is necessary for situations where requests to initiate mail connections have themselves a
      * default timeout, eg. http requests, and therefore this timeout needs to be shortened.
-     *
-     * @param parameters
-     * @param configuration
-     * @param timeoutValue
      */
     protected void setConnectionTimeoutProperty(Map<String, Object> parameters,
                                                 MailConfiguration configuration, String timeoutValue) {

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEmailTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/AbstractEmailTest.java
@@ -67,7 +67,6 @@ public class AbstractEmailTest implements EMailConstants {
      * Creates a camel context complete with a properties component that handles
      * lookups of secret values such as passwords. Fetches the values from external
      * properties file.
-     *
      * @return CamelContext
      */
     protected CamelContext createCamelContext() {

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadRouteTest.java
@@ -415,8 +415,6 @@ public class EMailReadRouteTest extends AbstractEmailServerTest implements Route
     /**
      * Receive will parse and strip the html from the message
      * and just leave the plain text.
-     *
-     * @throws Exception
      */
     @Test
     public void testImapMessageHTMLToPlainText() throws Exception {

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadWithTLSRouteTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/consumer/EMailReadWithTLSRouteTest.java
@@ -91,7 +91,6 @@ public class EMailReadWithTLSRouteTest extends AbstractEmailTest implements Rout
     /**
      * This test must be manually run since it requires a StartTLS enabled imap server.
      * No such test server is available (GreenMail doesn't support StartTLS)
-     *
      * Change the credentials in the fields above then execute.
      */
     @Test

--- a/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
+++ b/app/connector/email/src/test/java/io/syndesis/connector/email/verifier/EMailVerifierTest.java
@@ -83,7 +83,6 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         /*
          * With no secure type, the connection to the mail store will fail & timeout
          * However, we want it to fail fast & return fast.
-         *
          * Add a timeout property to cut the default timeout (10secs) to a more
          * test-friendly time of 2secs.
          */
@@ -122,7 +121,6 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         /*
          * With no secure type, the connection to the mail store will fail & timeout
          * However, we want it to fail fast & return fast.
-         *
          * Add a timeout property to cut the default timeout (10secs) to a more
          * test-friendly time of 2secs.
          */
@@ -161,7 +159,6 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
         /*
          * With no secure type, the connection to the mail store will fail & timeout
          * However, we want it to fail fast & return fast.
-         *
          * Add a timeout property to cut the default timeout (10secs) to a more
          * test-friendly time of 2secs.
          */
@@ -308,7 +305,6 @@ public class EMailVerifierTest extends AbstractEmailServerTest {
     /**
      * This test must be manually run since it requires a StartTLS enabled imap server.
      * No such test server is available (GreenMail doesn't support StartTLS)
-     *
      * Change the credentials in the fields above then execute.
      */
     @Test

--- a/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirTestBase.java
+++ b/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirTestBase.java
@@ -57,7 +57,6 @@ public abstract class FhirTestBase extends ConnectorTestSupport {
 
     /**
      * Override to enable basic authentication
-     * @return
      */
     public String getUsername() {
         return null;
@@ -65,7 +64,6 @@ public abstract class FhirTestBase extends ConnectorTestSupport {
 
     /**
      * Override to enable basic authentication.
-     * @return
      */
     public String getPassword() {
         return null;
@@ -73,7 +71,6 @@ public abstract class FhirTestBase extends ConnectorTestSupport {
 
     /**
      * Override to enable bearer token authentication as specified in OAuth 2.0
-     * @return
      */
     public String getBearerToken() {
         return null;

--- a/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirTransactionTest.java
+++ b/app/connector/fhir/src/test/java/io/syndesis/connector/fhir/FhirTransactionTest.java
@@ -31,6 +31,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.okXml;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
+@SuppressWarnings("JavaUtilDate") // TODO refactor
 public class FhirTransactionTest extends FhirTestBase {
 
     @Override

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnector.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnector.java
@@ -28,9 +28,6 @@ import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
 import org.apache.camel.component.google.sheets.GoogleSheetsComponent;
 import org.apache.camel.component.google.sheets.stream.GoogleSheetsStreamComponent;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsConnector extends ComponentProxyComponent {
 
     private String rootUrl;
@@ -72,8 +69,6 @@ public class GoogleSheetsConnector extends ComponentProxyComponent {
 
     /**
      * Specifies the rootUrl.
-     *
-     * @param rootUrl
      */
     public void setRootUrl(String rootUrl) {
         this.rootUrl = rootUrl;
@@ -85,8 +80,6 @@ public class GoogleSheetsConnector extends ComponentProxyComponent {
 
     /**
      * Specifies the serverCertificate.
-     *
-     * @param serverCertificate
      */
     public void setServerCertificate(String serverCertificate) {
         this.serverCertificate = serverCertificate;
@@ -98,8 +91,6 @@ public class GoogleSheetsConnector extends ComponentProxyComponent {
 
     /**
      * Specifies the validateCertificates.
-     *
-     * @param validateCertificates
      */
     public void setValidateCertificates(boolean validateCertificates) {
         this.validateCertificates = validateCertificates;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsConnectorHelper.java
@@ -29,9 +29,6 @@ import org.apache.camel.component.google.sheets.BatchGoogleSheetsClientFactory;
 import org.apache.camel.component.google.sheets.GoogleSheetsClientFactory;
 import org.apache.camel.util.ObjectHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public final class GoogleSheetsConnectorHelper {
 
     public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
@@ -46,12 +43,6 @@ public final class GoogleSheetsConnectorHelper {
 
     /**
      * Create Google sheets client factory with given root URL and server certificate.
-     * @param rootUrl
-     * @param serverCertificate
-     * @param validateCertificates
-     * @return
-     * @throws GeneralSecurityException
-     * @throws IOException
      */
     public static GoogleSheetsClientFactory createClientFactory(String rootUrl, String serverCertificate, boolean validateCertificates) throws GeneralSecurityException, IOException {
         NetHttpTransport.Builder transport = new NetHttpTransport.Builder();
@@ -74,9 +65,6 @@ public final class GoogleSheetsConnectorHelper {
 
     /**
      * Create client from given client factory using properties or default values.
-     * @param clientFactory
-     * @param properties
-     * @return
      */
     public static Sheets makeClient(GoogleSheetsClientFactory clientFactory, Map<String, Object> properties) {
         final String clientId = ConnectorOptions.extractOption(properties, "clientId");

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/GoogleSheetsUpdateValuesCustomizer.java
@@ -75,7 +75,6 @@ public class GoogleSheetsUpdateValuesCustomizer implements ComponentProxyCustomi
 
     /**
      * Gets the api method name. Subclasses may override method names here.
-     * @return
      */
     protected String getApiMethodName() {
         return "update";

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleSheetsMetaDataHelper.java
@@ -35,9 +35,6 @@ import io.syndesis.connector.sheets.model.CellCoordinate;
 import io.syndesis.connector.sheets.model.RangeCoordinate;
 import io.syndesis.connector.support.util.ConnectorOptions;
 
-/**
- * @author Christoph Deppisch
- */
 public final class GoogleSheetsMetaDataHelper {
 
     /** Logger */
@@ -120,10 +117,6 @@ public final class GoogleSheetsMetaDataHelper {
     /**
      * Create dynamic json schema from row dimension. If split only a single object "ROW" holding 1-n column values is
      * created. Otherwise each row results in a separate object with 1-n column values as property.
-     *
-     * @param spec
-     * @param coordinate
-     * @param columnNames
      */
     private static void createSchemaFromRowDimension(ObjectSchema spec, RangeCoordinate coordinate, String ... columnNames) {
         for (int i = coordinate.getColumnStartIndex(); i < coordinate.getColumnEndIndex(); i++) {
@@ -134,9 +127,6 @@ public final class GoogleSheetsMetaDataHelper {
     /**
      * Create dynamic json schema from column dimension. If split only a single object "COLUMN" holding 1-n row values is
      * created. Otherwise each column results in a separate object with 1-n row values as property.
-     *
-     * @param spec
-     * @param coordinate
      */
     private static void createSchemaFromColumnDimension(ObjectSchema spec, RangeCoordinate coordinate) {
         for (int i = coordinate.getRowStartIndex() + 1; i <= coordinate.getRowEndIndex(); i++) {

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/meta/GoogleValueRangeMetaData.java
@@ -18,9 +18,6 @@ package io.syndesis.connector.sheets.meta;
 
 import java.util.Arrays;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleValueRangeMetaData {
 
     private String spreadsheetId;
@@ -37,8 +34,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the spreadsheetId.
-     *
-     * @param spreadsheetId
      */
     public void setSpreadsheetId(String spreadsheetId) {
         this.spreadsheetId = spreadsheetId;
@@ -50,8 +45,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the columnNames.
-     *
-     * @param columnNames
      */
     public void setColumnNames(String ... columnNames) {
         this.columnNames = Arrays.copyOf(columnNames, columnNames.length);
@@ -63,8 +56,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the headerRow.
-     *
-     * @param headerRow
      */
     public void setHeaderRow(String headerRow) {
         this.headerRow = headerRow;
@@ -76,8 +67,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the range.
-     *
-     * @param range
      */
     public void setRange(String range) {
         this.range = range;
@@ -89,8 +78,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the majorDimension.
-     *
-     * @param majorDimension
      */
     public void setMajorDimension(String majorDimension) {
         this.majorDimension = majorDimension;
@@ -102,8 +89,6 @@ public class GoogleValueRangeMetaData {
 
     /**
      * Specifies the split.
-     *
-     * @param split
      */
     public void setSplit(boolean split) {
         this.split = split;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/CellCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/CellCoordinate.java
@@ -22,9 +22,6 @@ import java.util.stream.IntStream;
 
 import org.apache.camel.util.ObjectHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public class CellCoordinate {
 
     private int rowIndex;
@@ -40,9 +37,6 @@ public class CellCoordinate {
     /**
      * Construct grid coordinate from given cell identifier representation in A1 form. For instance convert
      * cell id string "A1" to a coordinate with rowIndex=0, and columnIndex=0.
-     *
-     * @param cellId
-     * @return
      */
     public static CellCoordinate fromCellId(String cellId) {
         CellCoordinate coordinate = new CellCoordinate();
@@ -59,9 +53,6 @@ public class CellCoordinate {
      * Evaluate the column index from cellId in A1 notation. Column name letters are translated to numeric column index values.
      * Column "A" will result in column index 0. Method does support columns with combined name letters such as "AA" where this is
      * the first column after "Z" resulting in a column index of 26.
-     *
-     * @param cellId
-     * @return
      */
     protected static int getColumnIndex(String cellId) {
         char[] characters = cellId.toCharArray();
@@ -76,14 +67,14 @@ public class CellCoordinate {
             int index = 0;
             for (int i = 0; i < chars.size(); i++) {
                 if (i == chars.size() -1) {
-                    index += chars.get(i) - Character.getNumericValue('A');
+                    index += chars.get(i) - Character.digit('A', 26);
                 } else {
-                    index += ((chars.get(i) - Character.getNumericValue('A')) + 1) * 26;
+                    index += ((chars.get(i) - Character.digit('A', 26)) + 1) * 26;
                 }
             }
             return index;
         } else if (chars.size() == 1) {
-            return chars.get(0) - Character.getNumericValue('A');
+            return chars.get(0) - Character.digit('A', 26);
         } else {
             return 0;
         }
@@ -92,9 +83,6 @@ public class CellCoordinate {
     /**
      * Evaluates the row index from a given cellId in A1 notation. Extracts the row number and translates that to an numeric
      * index value beginning with 0.
-     *
-     * @param cellId
-     * @return
      */
     protected static int getRowIndex(String cellId) {
         char[] characters = cellId.toCharArray();
@@ -114,9 +102,6 @@ public class CellCoordinate {
     /**
      * Evaluates column name in A1 notation based on the column index. Index 0 will be "A" and index 25 will be "Z". Method also supports
      * name overflow where index 26 will be "AA" and index 51 will be "AZ" and so on.
-     *
-     * @param columnIndex
-     * @return
      */
     public static String getColumnName(int columnIndex) {
         String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -141,11 +126,6 @@ public class CellCoordinate {
     /**
      * Special getter for column name where user is able to give set of user defined column names. When given column index is resolvable via custom names
      * the custom column name is returned otherwise the evaluated default column name is returned.
-     *
-     * @param columnIndex
-     * @param columnStartIndex
-     * @param columnNames
-     * @return
      */
     public static String getColumnName(int columnIndex, int columnStartIndex, String ... columnNames) {
         String columnName = getColumnName(columnIndex);
@@ -175,8 +155,6 @@ public class CellCoordinate {
 
     /**
      * Specifies the rowIndex.
-     *
-     * @param rowIndex
      */
     public void setRowIndex(int rowIndex) {
         this.rowIndex = rowIndex;
@@ -188,8 +166,6 @@ public class CellCoordinate {
 
     /**
      * Specifies the columnIndex.
-     *
-     * @param columnIndex
      */
     public void setColumnIndex(int columnIndex) {
         this.columnIndex = columnIndex;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleChart.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleChart.java
@@ -19,9 +19,6 @@ package io.syndesis.connector.sheets.model;
 import java.util.Objects;
 import java.util.Optional;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleChart {
 
     private String spreadsheetId;
@@ -48,8 +45,6 @@ public class GoogleChart {
 
         /**
          * Specifies the domainRange.
-         *
-         * @param domainRange
          */
         public void setDomainRange(String domainRange) {
             this.domainRange = domainRange;
@@ -61,8 +56,6 @@ public class GoogleChart {
 
         /**
          * Specifies the dataRange.
-         *
-         * @param dataRange
          */
         public void setDataRange(String dataRange) {
             this.dataRange = dataRange;
@@ -74,8 +67,6 @@ public class GoogleChart {
 
         /**
          * Specifies the legendPosition.
-         *
-         * @param legendPosition
          */
         public void setLegendPosition(String legendPosition) {
             this.legendPosition = legendPosition;
@@ -96,8 +87,6 @@ public class GoogleChart {
 
         /**
          * Specifies the domainRange.
-         *
-         * @param domainRange
          */
         public void setDomainRange(String domainRange) {
             this.domainRange = domainRange;
@@ -109,8 +98,6 @@ public class GoogleChart {
 
         /**
          * Specifies the dataRange.
-         *
-         * @param dataRange
          */
         public void setDataRange(String dataRange) {
             this.dataRange = dataRange;
@@ -122,8 +109,6 @@ public class GoogleChart {
 
         /**
          * Specifies the axisTitleBottom.
-         *
-         * @param axisTitleBottom
          */
         public void setAxisTitleBottom(String axisTitleBottom) {
             this.axisTitleBottom = axisTitleBottom;
@@ -135,8 +120,6 @@ public class GoogleChart {
 
         /**
          * Specifies the axisTitleLeft.
-         *
-         * @param axisTitleLeft
          */
         public void setAxisTitleLeft(String axisTitleLeft) {
             this.axisTitleLeft = axisTitleLeft;
@@ -148,8 +131,6 @@ public class GoogleChart {
 
         /**
          * Specifies the chart type. Default is "COLUMN".
-         *
-         * @param type
          */
         public void setType(String type) {
             this.type = type;
@@ -162,8 +143,6 @@ public class GoogleChart {
 
     /**
      * Specifies the spreadsheetId.
-     *
-     * @param spreadsheetId
      */
     public void setSpreadsheetId(String spreadsheetId) {
         this.spreadsheetId = spreadsheetId;
@@ -175,8 +154,6 @@ public class GoogleChart {
 
     /**
      * Specifies the sheetId.
-     *
-     * @param sheetId
      */
     public void setSheetId(Integer sheetId) {
         this.sheetId = sheetId;
@@ -188,8 +165,6 @@ public class GoogleChart {
 
     /**
      * Specifies the title.
-     *
-     * @param title
      */
     public void setTitle(String title) {
         this.title = title;
@@ -201,8 +176,6 @@ public class GoogleChart {
 
     /**
      * Specifies the subtitle.
-     *
-     * @param subtitle
      */
     public void setSubtitle(String subtitle) {
         this.subtitle = subtitle;
@@ -215,8 +188,6 @@ public class GoogleChart {
     /**
      * Specifies the overlayPosition in A1 notation representing a target cell as anchor. If set
      * the chart is placed as overlayPosition on the same sheet next to the anchor cell.
-     *
-     * @param overlayPosition
      */
     public void setOverlayPosition(String overlayPosition) {
         this.overlayPosition = overlayPosition;
@@ -228,8 +199,6 @@ public class GoogleChart {
 
     /**
      * Specifies the sourceSheetId.
-     *
-     * @param sourceSheetId
      */
     public void setSourceSheetId(Integer sourceSheetId) {
         this.sourceSheetId = sourceSheetId;
@@ -241,8 +210,6 @@ public class GoogleChart {
 
     /**
      * Specifies the basicChart.
-     *
-     * @param basicChart
      */
     public void setBasicChart(BasicChart basicChart) {
         this.basicChart = basicChart;
@@ -254,8 +221,6 @@ public class GoogleChart {
 
     /**
      * Specifies the pieChart.
-     *
-     * @param pieChart
      */
     public void setPieChart(PieChart pieChart) {
         this.pieChart = pieChart;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GooglePivotTable.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GooglePivotTable.java
@@ -19,9 +19,6 @@ package io.syndesis.connector.sheets.model;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author Christoph Deppisch
- */
 public class GooglePivotTable {
 
     private String spreadsheetId;
@@ -57,8 +54,6 @@ public class GooglePivotTable {
 
         /**
          * Specifies the label.
-         *
-         * @param label
          */
         public void setLabel(String label) {
             this.label = label;
@@ -70,8 +65,6 @@ public class GooglePivotTable {
 
         /**
          * Specifies the sortOrder.
-         *
-         * @param sortOrder
          */
         public void setSortOrder(String sortOrder) {
             this.sortOrder = sortOrder;
@@ -84,8 +77,6 @@ public class GooglePivotTable {
         /**
          * Specifies the source column that this grouping is based on. The value is supposed to use
          * A1 notation where the column offset of the source range is calculated at runtime.
-         *
-         * @param sourceColumn
          */
         public void setSourceColumn(String sourceColumn) {
             this.sourceColumn = sourceColumn;
@@ -97,8 +88,6 @@ public class GooglePivotTable {
 
         /**
          * Specifies the showTotals. Defaults to true.
-         *
-         * @param showTotals
          */
         public void setShowTotals(boolean showTotals) {
             this.showTotals = showTotals;
@@ -111,8 +100,6 @@ public class GooglePivotTable {
         /**
          * Specifies the information about which values in a pivot group should be used for sorting.
          * The offset in the GooglePivotTable.valueGroups list which the values in this grouping should be sorted by.
-         *
-         * @param valueGroupIndex
          */
         public void setValueGroupIndex(Integer valueGroupIndex) {
             this.valueGroupIndex = valueGroupIndex;
@@ -125,8 +112,6 @@ public class GooglePivotTable {
         /**
          * Specifies the information about which values in a pivot group should be used for sorting.
          * Determines the bucket from which values are chosen to sort.
-         *
-         * @param valueBucket
          */
         public void setValueBucket(String valueBucket) {
             this.valueBucket = valueBucket;
@@ -148,8 +133,6 @@ public class GooglePivotTable {
 
         /**
          * Specifies the function.
-         *
-         * @param function
          */
         public void setFunction(String function) {
             this.function = function;
@@ -162,11 +145,8 @@ public class GooglePivotTable {
         /**
          * Specifies the source column that this grouping is based on. The value is supposed to use
          * A1 notation where the column offset of the source range is calculated at runtime.
-         *
          * This value is exclusive to formula field meaning that either source column or formula is to be used.
          * A specified formula overwrites this setting.
-         *
-         * @param sourceColumn
          */
         public void setSourceColumn(String sourceColumn) {
             this.sourceColumn = sourceColumn;
@@ -178,8 +158,6 @@ public class GooglePivotTable {
 
         /**
          * Specifies the name.
-         *
-         * @param name
          */
         public void setName(String name) {
             this.name = name;
@@ -192,11 +170,8 @@ public class GooglePivotTable {
         /**
          * Specifies the formula as a custom formula to calculate the value.
          * The formula must start with an = character.
-         *
          * This value is exclusive to source column meaning that either formula or source columns is to be used.
          * The formula setting will overwrite a source column setting.
-         *
-         * @param formula
          */
         public void setFormula(String formula) {
             this.formula = formula;
@@ -209,8 +184,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the spreadsheetId.
-     *
-     * @param spreadsheetId
      */
     public void setSpreadsheetId(String spreadsheetId) {
         this.spreadsheetId = spreadsheetId;
@@ -222,8 +195,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the sheetId.
-     *
-     * @param sheetId
      */
     public void setSheetId(Integer sheetId) {
         this.sheetId = sheetId;
@@ -235,8 +206,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the sourceSheetId.
-     *
-     * @param sourceSheetId
      */
     public void setSourceSheetId(Integer sourceSheetId) {
         this.sourceSheetId = sourceSheetId;
@@ -248,8 +217,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the sourceRange.
-     *
-     * @param sourceRange
      */
     public void setSourceRange(String sourceRange) {
         this.sourceRange = sourceRange;
@@ -261,8 +228,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the valueGroups.
-     *
-     * @param valueGroups
      */
     public void setValueGroups(List<ValueGroup> valueGroups) {
         this.valueGroups = valueGroups;
@@ -274,8 +239,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the columnGroups.
-     *
-     * @param columnGroups
      */
     public void setColumnGroups(List<PivotGroup> columnGroups) {
         this.columnGroups = columnGroups;
@@ -287,8 +250,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the rowGroups.
-     *
-     * @param rowGroups
      */
     public void setRowGroups(List<PivotGroup> rowGroups) {
         this.rowGroups = rowGroups;
@@ -300,8 +261,6 @@ public class GooglePivotTable {
 
     /**
      * Specifies the valueLayout.
-     *
-     * @param valueLayout
      */
     public void setValueLayout(String valueLayout) {
         this.valueLayout = valueLayout;
@@ -314,8 +273,6 @@ public class GooglePivotTable {
     /**
      * Specifies the start cell coordinate of the generated pivot table. This coordinate represents the upper left corner of
      * the newly created pivot table.
-     *
-     * @param start
      */
     public void setStart(String start) {
         this.start = start;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSheet.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSheet.java
@@ -28,8 +28,6 @@ public class GoogleSheet {
 
     /**
      * Specifies the index.
-     *
-     * @param index
      */
     public void setIndex(Integer index) {
         this.index = index;
@@ -41,8 +39,6 @@ public class GoogleSheet {
 
     /**
      * Specifies the sheetId.
-     *
-     * @param sheetId
      */
     public void setSheetId(Integer sheetId) {
         this.sheetId = sheetId;
@@ -54,8 +50,6 @@ public class GoogleSheet {
 
     /**
      * Specifies the title.
-     *
-     * @param title
      */
     public void setTitle(String title) {
         this.title = title;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSpreadsheet.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/GoogleSpreadsheet.java
@@ -34,8 +34,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the spreadsheetId.
-     *
-     * @param spreadsheetId
      */
     public void setSpreadsheetId(String spreadsheetId) {
         this.spreadsheetId = spreadsheetId;
@@ -47,8 +45,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the title.
-     *
-     * @param title
      */
     public void setTitle(String title) {
         this.title = title;
@@ -60,8 +56,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the url.
-     *
-     * @param url
      */
     public void setUrl(String url) {
         this.url = url;
@@ -73,8 +67,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the timeZone.
-     *
-     * @param timeZone
      */
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
@@ -86,8 +78,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the locale.
-     *
-     * @param locale
      */
     public void setLocale(String locale) {
         this.locale = locale;
@@ -99,8 +89,6 @@ public class GoogleSpreadsheet {
 
     /**
      * Specifies the sheets.
-     *
-     * @param sheets
      */
     public void setSheets(List<GoogleSheet> sheets) {
         this.sheets = sheets;

--- a/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
+++ b/app/connector/google-sheets/src/main/java/io/syndesis/connector/sheets/model/RangeCoordinate.java
@@ -18,9 +18,6 @@ package io.syndesis.connector.sheets.model;
 
 import java.util.StringJoiner;
 
-/**
- * @author Christoph Deppisch
- */
 public final class RangeCoordinate extends CellCoordinate {
 
     public static final String DIMENSION_ROWS = "ROWS";
@@ -42,10 +39,7 @@ public final class RangeCoordinate extends CellCoordinate {
     /**
      * Construct range coordinates from range string representation in A1 form. For instance convert
      * range string "A1:C2" to a coordinate with rowStartIndex=1, rowEndIndex=2, columnStartIndex=1, columnEndIndex=3.
-     *
      * Supports missing range ends with "A5" resulting in rowStartIndex=5, rowEndIndex=6, columnStartIndex=1, columnEndIndex=2.
-     * @param range
-     * @return
      */
     public static RangeCoordinate fromRange(String range) {
         RangeCoordinate coordinate = new RangeCoordinate();
@@ -74,8 +68,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Removes optional sheet name from range expression if any.
-     * @param range
-     * @return
      */
     private static String normalizeRange(String range) {
         if (range.contains("!")) {
@@ -87,7 +79,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Get all names of columns included in this range.
-     * @return
      */
     public String getColumnNames() {
         StringJoiner delimitedList = new StringJoiner(",");
@@ -103,8 +94,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Specifies the rowStartIndex.
-     *
-     * @param rowStartIndex
      */
     public void setRowStartIndex(int rowStartIndex) {
         this.rowStartIndex = rowStartIndex;
@@ -116,8 +105,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Specifies the rowEndIndex.
-     *
-     * @param rowEndIndex
      */
     public void setRowEndIndex(int rowEndIndex) {
         this.rowEndIndex = rowEndIndex;
@@ -129,8 +116,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Specifies the columnStartIndex.
-     *
-     * @param columnStartIndex
      */
     public void setColumnStartIndex(int columnStartIndex) {
         this.columnStartIndex = columnStartIndex;
@@ -142,8 +127,6 @@ public final class RangeCoordinate extends CellCoordinate {
 
     /**
      * Specifies the columnEndIndex.
-     *
-     * @param columnEndIndex
      */
     public void setColumnEndIndex(int columnEndIndex) {
         this.columnEndIndex = columnEndIndex;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/AbstractGoogleSheetsCustomizerTestSupport.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/AbstractGoogleSheetsCustomizerTestSupport.java
@@ -38,8 +38,6 @@ public abstract class AbstractGoogleSheetsCustomizerTestSupport {
 
     /**
      * Gets the test component that is about to be customized.
-     *
-     * @return
      */
     public ComponentProxyComponent getComponent() {
         return component;
@@ -47,8 +45,6 @@ public abstract class AbstractGoogleSheetsCustomizerTestSupport {
 
     /**
      * Gets the test spreadsheetId.
-     *
-     * @return
      */
     public String getSpreadsheetId() {
         return spreadsheetId;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddChartCustomizerTest.java
@@ -40,9 +40,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsAddChartCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
     private GoogleSheetsAddChartCustomizer customizer;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsAddPivotTableCustomizerTest.java
@@ -34,9 +34,6 @@ import com.google.api.services.sheets.v4.model.UpdateCellsRequest;
 import io.syndesis.connector.sheets.model.GooglePivotTable;
 import io.syndesis.connector.support.util.ConnectorOptions;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsAddPivotTableCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
     private GoogleSheetsAddPivotTableCustomizer customizer;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsCreateSpreadsheetCustomizerTest.java
@@ -35,9 +35,6 @@ import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import io.syndesis.connector.support.util.ConnectorOptions;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsCreateSpreadsheetCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
     private GoogleSheetsCreateSpreadsheetCustomizer customizer;

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/GoogleSheetsUpdateSpreadsheetCustomizerTest.java
@@ -41,9 +41,6 @@ import io.syndesis.connector.sheets.model.GoogleSheet;
 import io.syndesis.connector.sheets.model.GoogleSpreadsheet;
 import io.syndesis.connector.support.util.ConnectorOptions;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsUpdateSpreadsheetCustomizerTest extends AbstractGoogleSheetsCustomizerTestSupport {
 
     public static final String SYNDESIS_TEST = "SyndesisTest";

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/CellCoordinateTest.java
@@ -23,9 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Christoph Deppisch
- */
 public class CellCoordinateTest {
 
     public static Collection<Object[]> data() {

--- a/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/RangeCoordinateTest.java
+++ b/app/connector/google-sheets/src/test/java/io/syndesis/connector/sheets/model/RangeCoordinateTest.java
@@ -23,9 +23,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Christoph Deppisch
- */
 public class RangeCoordinateTest {
 
     public static Collection<Object[]> data() {

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataRetrieval.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataRetrieval.java
@@ -120,9 +120,6 @@ public class KafkaMetaDataRetrieval extends ComponentMetadataRetrieval {
     /**
      * For each Kafka resource found on Kubernetes, extract the listeners and
      * add them to the brokers list.
-     *
-     * @param brokers
-     * @param item
      */
     private static void processKafkaResource(List<PropertyPair> brokers, Kafka item) {
         //Extract an identifier of this broker
@@ -138,7 +135,6 @@ public class KafkaMetaDataRetrieval extends ComponentMetadataRetrieval {
 
     /**
      * Get the list of addresses for this connection and add it to the brokers list.
-     *
      * @param listener metadata for this broker
      * @param brokers  list where all brokers are going to be added
      * @param name     identifier of this broker

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaVerifierExtension.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Component verifier for Kafka Connector.
- *
- * @author valdar
  */
 public class KafkaVerifierExtension extends DefaultComponentVerifierExtension {
 

--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/service/KafkaBrokerService.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/service/KafkaBrokerService.java
@@ -24,13 +24,11 @@ public interface KafkaBrokerService {
 
     /**
      * Check if a cluster is up and running
-     *
      */
     void ping() throws KafkaBrokerServiceException;
 
     /**
      * Connect to a cluster and recover the list of topics
-     *
      * @return the list of topics
      */
     Set<String> listTopics();

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/common/KuduSupport.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/common/KuduSupport.java
@@ -53,8 +53,6 @@ public final class KuduSupport {
 
     /**
      * Convenience method to convert a Camel Map output to a JSON Bean String.
-     *
-     * @param map
      * @return JSON bean String
      */
     public static String toJSONBean(final Map<String, Object> map) {

--- a/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/model/KuduTable.java
+++ b/app/connector/kudu/src/main/java/io/syndesis/connector/kudu/model/KuduTable.java
@@ -24,17 +24,12 @@ public class KuduTable {
     private CreateTableOptions builder;
 
 
-    /**
-     * @return name of the table
-     */
     public String getName() {
         return name;
     }
 
     /**
      * Specifies the name of the table
-     *
-     * @param name
      */
     public void setName(String name) {
         this.name = name;

--- a/app/connector/kudu/src/main/java/org/apache/camel/component/kudu/KuduEndpoint.java
+++ b/app/connector/kudu/src/main/java/org/apache/camel/component/kudu/KuduEndpoint.java
@@ -116,8 +116,6 @@ public class KuduEndpoint extends DefaultEndpoint {
 
     /**
      * Set the client to connect to a kudu resource
-     *
-     * @param kuduClient
      */
     public void setKuduClient(KuduClient kuduClient) {
         this.kuduClient = kuduClient;
@@ -129,8 +127,6 @@ public class KuduEndpoint extends DefaultEndpoint {
 
     /**
      * The name of the table where the rows are stored
-     *
-     * @param tableName
      */
     public void setTableName(String tableName) {
         this.tableName = tableName;
@@ -142,8 +138,6 @@ public class KuduEndpoint extends DefaultEndpoint {
 
     /**
      * What kind of operation is to be performed in the table
-     *
-     * @param operation
      */
     public void setOperation(String operation) {
         this.operation = operation;
@@ -155,8 +149,6 @@ public class KuduEndpoint extends DefaultEndpoint {
 
     /**
      * Port where kudu service is listening
-     *
-     * @param port
      */
     public void setPort(String port) {
         this.port = port;
@@ -168,8 +160,6 @@ public class KuduEndpoint extends DefaultEndpoint {
 
     /**
      * Kudu type
-     *
-     * @param type
      */
     public void setType(String type) {
         this.type = type;

--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoCustomizersUtil.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/MongoCustomizersUtil.java
@@ -39,8 +39,6 @@ public final class MongoCustomizersUtil {
     /**
      * Used to convert any result MongoOperation (either {@link DeleteResult} or {@link UpdateResult}
      * to a {@link Long}
-     *
-     * @param exchange
      */
     static void convertMongoResultToLong(Exchange exchange) {
         Message in = exchange.getIn();
@@ -57,8 +55,6 @@ public final class MongoCustomizersUtil {
 
     /**
      * Used to convert any {@link Document} object to Json text list
-     *
-     * @param exchange
      */
     static void convertMongoDocumentsToJsonTextList(Exchange exchange) {
         List<String> convertedToJson = new ArrayList<>();
@@ -79,8 +75,6 @@ public final class MongoCustomizersUtil {
     /**
      * Utility method used to replace the adminDB parameter if it was not provided
      * by user
-     *
-     * @param params
      */
     public static void replaceAdminDBIfMissing(Map<String, Object> params) {
         // Fallback admin database parameter
@@ -93,9 +87,6 @@ public final class MongoCustomizersUtil {
 
     /**
      * Merge the filter expression with body and set the result as the new body
-     *
-     * @param exchange
-     * @param filter
      */
     static void executeFilterComponent(Exchange exchange, String filter) {
         executeFilterComponent(exchange, filter, null);
@@ -103,10 +94,6 @@ public final class MongoCustomizersUtil {
 
     /**
      * Merge the filter expression with body and set the result as an header
-     *
-     * @param exchange
-     * @param filter
-     * @param header
      */
     static void executeFilterComponent(Exchange exchange, String filter, String header) {
         // Merge the filter parameter expression with values coming in the input body

--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/meta/FilterUtil.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/meta/FilterUtil.java
@@ -35,7 +35,6 @@ public final class FilterUtil {
 
     /**
      * Extract any <strong>:#variable</strong> parameter format
-     *
      * @param filter the filter expression, ie {"test": ":#var1"}
      * @return a list of parameters expected by the filter
      */
@@ -51,9 +50,6 @@ public final class FilterUtil {
 
     /**
      * Check whether the filter contains any parameter or is a static one
-     *
-     * @param filter
-     * @return
      */
     public static boolean hasAnyParameter(String filter) {
         return filter != null && filter.contains(":#");
@@ -61,10 +57,8 @@ public final class FilterUtil {
 
     /**
      * Merge the parameters found in the filter with the values found in the JSON message
-     *
      * @param filter an expression containing :#variable parameters
      * @param jsonMessage a message formatted as JSON
-     * @return
      */
     public static String merge(String filter, String jsonMessage) {
         if (filter == null){

--- a/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/ODataUtil.java
+++ b/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/ODataUtil.java
@@ -64,6 +64,7 @@ public class ODataUtil implements ODataConstants {
     }
 
     /**
+     * One more method to check if URL is HTTPS or not.
      * @return whether url is an ssl (https) url or not.
      */
     public static boolean isServiceSSL(String url) {
@@ -119,7 +120,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link HttpClientBuilder} for the given options.
-     *
      * @return the new http client builder
      */
     public static HttpClientBuilder createHttpClientBuilder(Map<String, Object> options) {
@@ -143,7 +143,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link HttpClientBuilder} for the given options.
-     *
      * @return the new http client builder
      */
     public static HttpAsyncClientBuilder createHttpAsyncClientBuilder(Map<String, Object> options) {
@@ -167,7 +166,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link CloseableHttpClient} for the given options.
-     *
      * @return the new http(s) client
      */
     public static CloseableHttpClient createHttpClient(Map<String, Object> options) {
@@ -176,7 +174,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Remove the slashes at the end of the given string
-     *
      * @return string sans slashes
      */
     public static String removeEndSlashes(String path) {
@@ -230,6 +227,7 @@ public class ODataUtil implements ODataConstants {
     }
 
     /**
+     * Another method to format key predicates.
      * @param keyPredicate the predicate to be formatted
      * @return the keyPredicate formatted with quotes and brackets
      */

--- a/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/component/ODataComponent.java
+++ b/app/connector/odata-v2/src/main/java/io/syndesis/connector/odata2/component/ODataComponent.java
@@ -39,15 +39,12 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
 
     /**
      * These fields are populated using reflection by the HandlerCustomizer class.
-     *
      * The values are resolved then the appropriate setter called, while the original
      * key/value pairs are removed from the options map.
-     *
      * Note 1:
      * Should a property be secret then its raw value is the property placeholder and
      * the resolving process converts it accordingly hence the importance of doing it
      * this way rather than using the options map directly.
-     *
      * Note 2:
      * methodName not included as not required here but required later in the options map.
      */

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataRouteTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataRouteTest.java
@@ -118,7 +118,6 @@ public abstract class AbstractODataRouteTest extends AbstractODataTest {
     /*
      * Taken with appreciation from camel-olingo4 code found at
      * https://github.com/apache/camel/blob/master/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/AbstractOlingo4TestSupport.java#L77
-     *
      * Every request to the demo OData 4.0
      * (http://services.odata.org/TripPinRESTierService) generates unique
      * service URL with postfix like (S(tuivu3up5ygvjzo5fszvnwfv)) for each

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/AbstractODataTest.java
@@ -131,6 +131,7 @@ public abstract class AbstractODataTest implements ODataConstants {
     }
 
     /**
+     * Another method to read the stream into a String, use carefuly.
      * @return a string representation of the content of the given stream
      */
     public static String streamToString(InputStream inStream) throws IOException {

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/server/Certificates.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/server/Certificates.java
@@ -23,9 +23,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/**
- * @author Christoph Deppisch
- */
 public enum Certificates {
 
     TEST_SERVICE("certs/server-cert.pem"),

--- a/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/verifier/ODataVerifierTest.java
+++ b/app/connector/odata-v2/src/test/java/io/syndesis/connector/odata2/verifier/ODataVerifierTest.java
@@ -31,22 +31,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.filter;
 
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 public class ODataVerifierTest extends AbstractODataTest {
 
     @BeforeEach

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataUtil.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/ODataUtil.java
@@ -77,8 +77,8 @@ public class ODataUtil implements ODataConstants {
     }
 
     /**
-     * @param url
-     * @return whether url is an ssl (https) url or not.
+     * Determines whether url is an ssl (https) url or not.
+     * @return true if URL is SSL, false otherwise
      */
     public static boolean isServiceSSL(String url) {
         if (url == null) {
@@ -133,9 +133,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link HttpClientBuilder} for the given options.
-     *
-     * @param options
-     *
      * @return the new http client builder
      */
     public static HttpClientBuilder createHttpClientBuilder(Map<String, Object> options) {
@@ -159,12 +156,7 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link HttpClientBuilder} for the given options.
-     *
-     * @param options
-     *
      * @return the new http client builder
-     *
-     * @throws Exception
      */
     public static HttpAsyncClientBuilder createHttpAsyncClientBuilder(Map<String, Object> options) {
         HttpAsyncClientBuilder builder = HttpAsyncClientBuilder.create();
@@ -187,11 +179,7 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Creates a new {@link CloseableHttpClient} for the given options.
-     * @param options
-     *
      * @return the new http(s) client
-     *
-     * @throws Exception
      */
     public static CloseableHttpClient createHttpClient(Map<String, Object> options) {
         return createHttpClientBuilder(options).build();
@@ -203,8 +191,6 @@ public class ODataUtil implements ODataConstants {
 
     /**
      * Remove the slashes at the end of the given string
-     *
-     * @param path
      * @return string sans slashes
      */
     public static String removeEndSlashes(String path) {
@@ -241,6 +227,7 @@ public class ODataUtil implements ODataConstants {
     }
 
     /**
+     * Formats key predicate.
      * @param keyPredicate the predicate to be formatted
      * @param includeBrackets whether brackets should be added around the key predicate string
      * @return the keyPredicate formatted with quotes and brackets

--- a/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
+++ b/app/connector/odata/src/main/java/io/syndesis/connector/odata/component/ODataComponent.java
@@ -36,15 +36,12 @@ public final class ODataComponent extends ComponentProxyComponent implements ODa
 
     /**
      * These fields are populated using reflection by the HandlerCustomizer class.
-     *
      * The values are resolved then the appropriate setter called, while the original
      * key/value pairs are removed from the options map.
-     *
      * Note 1:
      * Should a property be secret then its raw value is the property placeholder and
      * the resolving process converts it accordingly hence the importance of doing it
      * this way rather than using the options map directly.
-     *
      * Note 2:
      * methodName not included as not required here but required later in the options map.
      */

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataRouteTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataRouteTest.java
@@ -117,7 +117,6 @@ public abstract class AbstractODataRouteTest extends AbstractODataTest {
     /*
      * Taken with appreciation from camel-olingo4 code found at
      * https://github.com/apache/camel/blob/master/components/camel-olingo4/camel-olingo4-component/src/test/java/org/apache/camel/component/olingo4/AbstractOlingo4TestSupport.java#L77
-     *
      * Every request to the demo OData 4.0
      * (http://services.odata.org/TripPinRESTierService) generates unique
      * service URL with postfix like (S(tuivu3up5ygvjzo5fszvnwfv)) for each

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/AbstractODataTest.java
@@ -126,9 +126,8 @@ public abstract class AbstractODataTest implements ODataConstants {
     }
 
     /**
-     * @param inStream
+     * Another method that converts streams to Strings, use carefuly.
      * @return a string representation of the content of the given stream
-     * @throws IOException
      */
     public static String streamToString(InputStream inStream) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8));
@@ -166,7 +165,6 @@ public abstract class AbstractODataTest implements ODataConstants {
      * Creates a camel context complete with a properties component that handles
      * lookups of secret values such as passwords. Fetches the values from external
      * properties file.
-     *
      * @return CamelContext
      */
     protected CamelContext createCamelContext() {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/consumer/ODataReadRouteNoSplitResultsTest.java
@@ -340,8 +340,6 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
      * Despite split being set to false, the existence of a key predicate
      * forces the split since a predicate demands only 1 result which is
      * pointless putting into an array.
-     *
-     * @throws Exception
      */
     @Test
     public void testODataRouteWithKeyPredicate() throws Exception {
@@ -372,8 +370,6 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
      * Despite split being set to false, the existence of a key predicate
      * forces the split since a predicate demands only 1 result which is
      * pointless putting into an array.
-     *
-     * @throws Exception
      */
     @Test
     public void testODataRouteWithKeyPredicateWithBrackets() throws Exception {
@@ -480,8 +476,6 @@ public class ODataReadRouteNoSplitResultsTest extends AbstractODataReadRouteTest
      * Despite split being set to false, the existence of a key predicate
      * forces the split since a predicate demands only 1 result which is
      * pointless putting into an array.
-     *
-     * @throws Exception
      */
     @Test
     public void testReferenceODataRouteAlreadySeenWithKeyPredicate() throws Exception {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/producer/ODataUpdateTests.java
@@ -398,8 +398,6 @@ public class ODataUpdateTests extends AbstractODataRouteTest {
     /**
      * Tests alternative key predicate that is a string value
      * @see https://github.com/syndesisio/syndesis/issues/5241
-     *
-     * @throws Exception
      */
     @Test
     public void testPatchODataRouteOnRefServer() throws Exception {

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataPathFilter.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataPathFilter.java
@@ -31,7 +31,6 @@ import io.syndesis.common.util.StringConstants;
  * Fixes an issue with olingo4 not being able to handle URI ending with
  * a '/'. The olingo4 library results in a 'URI is malformed' exception. This
  * filter takes the request and wraps it to exclude the '/'.
- *
  */
 public class ODataPathFilter implements Filter, StringConstants {
 

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/server/ODataTestServer.java
@@ -364,8 +364,6 @@ public class ODataTestServer extends Server implements ODataConstants {
 
     /**
      * Run our own OData Server
-     *
-     * @param args
      */
     public static void main(String... args) throws Exception {
        ODataTestServer server = new ODataTestServer(Options.HTTP_PORT, Options.HTTPS_PORT, Options.SSL);

--- a/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
+++ b/app/connector/odata/src/test/java/io/syndesis/connector/odata/verifier/ODataVerifierTest.java
@@ -28,22 +28,6 @@ import io.syndesis.connector.odata.server.ODataTestServer;
 import io.syndesis.connector.support.verifier.api.Verifier;
 import io.syndesis.connector.support.verifier.api.VerifierResponse;
 
-/*
- * Copyright (C) 2016 Red Hat, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 public class ODataVerifierTest extends AbstractODataTest {
 
     @BeforeEach

--- a/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
+++ b/app/connector/rest-swagger/src/main/java/io/syndesis/connector/rest/swagger/SpecificationResourceCustomizer.java
@@ -66,7 +66,6 @@ public final class SpecificationResourceCustomizer implements ComponentProxyCust
 
     /**
      * Get the name from the security definition or an empty value
-     *
      * @param securityDefinitionSelectedByUser with format type:name (ie,
      *            apiKey: api-key-security)
      * @return the name of the definition or an empty value
@@ -85,7 +84,6 @@ public final class SpecificationResourceCustomizer implements ComponentProxyCust
      * configuration (such as apikey) through other channels not requested by
      * user, for example, query parameters when the user only wants to provide
      * api key through http headers.
-     *
      * @param specification the swagger/openapi original specification
      * @param securityDefinitionSelectedByUser the securityDefinition picked by
      *            the user

--- a/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
+++ b/app/connector/rest-swagger/src/test/java/io/syndesis/connector/rest/swagger/DescriptorTest.java
@@ -15,25 +15,22 @@
  */
 package io.syndesis.connector.rest.swagger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.syndesis.common.model.Dependency;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
+import io.syndesis.common.model.connection.Connector;
+import io.syndesis.common.util.json.JsonUtils;
+import io.syndesis.connector.rest.swagger.auth.apikey.ApiKey.Placement;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import io.syndesis.common.model.Dependency;
-import io.syndesis.common.model.Dependency.Type;
-import io.syndesis.common.model.connection.ConfigurationProperty;
-import io.syndesis.common.model.connection.ConfigurationProperty.PropertyValue;
-import io.syndesis.common.model.connection.Connector;
-import io.syndesis.common.util.json.JsonUtils;
-import io.syndesis.connector.rest.swagger.auth.apikey.ApiKey.Placement;
-
 import org.apache.camel.CamelContext;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class DescriptorTest {
 
@@ -76,7 +73,8 @@ public class DescriptorTest {
                 .displayName("Placement of the API key parameter")
                 .addAllEnum(Stream.of(Placement.values())
                     .sorted()
-                    .map(p -> new PropertyValue.Builder().label(p.toString()).value(p.toString()).build())::iterator)
+                    .map(p -> new PropertyValue.Builder().label(p.toString()).value(p.toString()).build())
+                    .collect(Collectors.toList()))
                 .javaType("java.lang.String")
                 .order(4)
                 .required(true)
@@ -236,7 +234,7 @@ public class DescriptorTest {
     static Dependency mavenDependency(final String id) {
         return new Dependency.Builder()
             .id(id)
-            .type(Type.MAVEN)
+            .type(Dependency.Type.MAVEN)
             .build();
     }
 }

--- a/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrieval.java
+++ b/app/connector/salesforce/src/main/java/io/syndesis/connector/salesforce/SalesforceMetadataRetrieval.java
@@ -15,15 +15,11 @@
  */
 package io.syndesis.connector.salesforce;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.SimpleTypeSchema;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.util.SyndesisServerException;
@@ -31,18 +27,18 @@ import io.syndesis.connector.support.util.ConnectorOptions;
 import io.syndesis.connector.support.verifier.api.ComponentMetadataRetrieval;
 import io.syndesis.connector.support.verifier.api.PropertyPair;
 import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
-
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.MetaDataExtension.MetaData;
 import org.apache.camel.component.salesforce.SalesforceEndpointConfig;
 import org.apache.camel.component.salesforce.api.SalesforceException;
 import org.apache.camel.component.salesforce.api.utils.JsonUtils;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
-import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
-import com.fasterxml.jackson.module.jsonSchema.types.SimpleTypeSchema;
 
 public final class SalesforceMetadataRetrieval extends ComponentMetadataRetrieval {
 
@@ -142,7 +138,7 @@ public final class SalesforceMetadataRetrieval extends ComponentMetadataRetrieva
         return schema;
     }
 
-    static PropertyPair createFieldPairPropertyFromSchemaEntry(final Entry<String, JsonSchema> e) {
+    static PropertyPair createFieldPairPropertyFromSchemaEntry(final Map.Entry<String, JsonSchema> e) {
         return new PropertyPair(e.getKey(), ((SimpleTypeSchema) e.getValue()).getTitle());
     }
 

--- a/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackPlainMessage.java
+++ b/app/connector/slack/src/main/java/io/syndesis/connector/slack/SlackPlainMessage.java
@@ -15,10 +15,6 @@
  */
 package io.syndesis.connector.slack;
 
-/**
- * @author roland
- * @since 30.04.18
- */
 public class SlackPlainMessage {
 
     private String message;

--- a/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/RequestSoapPayloadConverter.java
+++ b/app/connector/soap/src/main/java/io/syndesis/connector/soap/cxf/payload/RequestSoapPayloadConverter.java
@@ -40,7 +40,6 @@ public final class RequestSoapPayloadConverter extends AbstractSoapPayloadConver
     private final SoapVersion soapVersion;
 
     public RequestSoapPayloadConverter(SoapVersion soapVersion) {
-        super();
         this.soapVersion = soapVersion;
     }
 
@@ -84,7 +83,7 @@ public final class RequestSoapPayloadConverter extends AbstractSoapPayloadConver
         }
     }
 
-    protected static Source bodyAsSource(final Message in) throws InvalidPayloadException {
+    static Source bodyAsSource(final Message in) throws InvalidPayloadException {
         return new StreamSource(in.getMandatoryBody(InputStream.class));
     }
 

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlMetadataRetrieval.java
@@ -226,8 +226,6 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
     }
     /**
      * Puts all stored procedures in the list, as all queries adhere to the `To` pattern.
-     *
-     * @param procedureMap
      * @return list of property pairs containing the stored procedure names
      */
     private static List<PropertyPair> obtainToProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
@@ -241,8 +239,6 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
     /**
      * Puts stored procedures in the list that have NO input parameters, which adheres to the `From`
      * pattern.
-     *
-     * @param procedureMap
      * @return list of property pairs containing the stored procedure names
      */
     private static List<PropertyPair> obtainFromProcedureList (Map<String, StoredProcedureMetadata> procedureMap) {
@@ -257,8 +253,6 @@ public final class SqlMetadataRetrieval extends ComponentMetadataRetrieval {
     }
     /**
      * Checks if the given stored procedure contains input parameters.
-     *
-     * @param storedProcedure
      * @return boolean - true if input params present, false if no input params.
      */
     private static boolean containsInputParams(StoredProcedureMetadata storedProcedure) {

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlVerifier.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/SqlVerifier.java
@@ -19,10 +19,6 @@ import io.syndesis.connector.support.verifier.api.ComponentVerifier;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.extension.ComponentVerifierExtension;
 
-/**
- * @author kstam
- * @since 8/29/2017
- */
 public class SqlVerifier extends ComponentVerifier {
     public SqlVerifier() {
         super("sql");

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbEnum.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/DbEnum.java
@@ -24,10 +24,6 @@ import org.slf4j.LoggerFactory;
  * Enumeration of Database products we have tested, and for which we ship
  * drivers for. One caveat is the Oracle Driver which cannot be shipped due to
  * restrictions on its license.
- *
- * @since 09/11/17
- * @author kstam
- *
  */
 public enum DbEnum {
     APACHE_DERBY("APACHE DERBY"),

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/JSONBeanUtil.java
@@ -35,9 +35,6 @@ import org.springframework.jdbc.core.SqlParameterValue;
  * Utility to help with parsing the data from the simple serialized java bean.
  * The resulting property map can then be used by the
  * SqlStoredComponentConnector.
- *
- * @author kstam
- *
  */
 public final class JSONBeanUtil {
 
@@ -54,7 +51,6 @@ public final class JSONBeanUtil {
     /**
      * Convenience method to parse the properties from a simple BeanJSON.
      * Properties can be read by Camel.
-     *
      * @param json simple JSON representation of a Java Bean used as input Data
      *            for the SqlStoredConnector
      * @return Properties representation of the simple JSON bean
@@ -110,8 +106,6 @@ public final class JSONBeanUtil {
 
     /**
      * Validate JSON bean for being a proper parameter information object.
-     * @param json
-     * @return
      */
     private static boolean isValidJSONBean(String json) {
         return json != null && !json.isEmpty() && json.trim().startsWith("{") && json.trim().endsWith("}");
@@ -119,8 +113,6 @@ public final class JSONBeanUtil {
 
     /**
      * Convenience method to convert a Camel Map output to a JSON Bean String.
-     *
-     * @param list
      * @return JSON bean String
      */
     @SuppressWarnings("unchecked")
@@ -146,8 +138,6 @@ public final class JSONBeanUtil {
 
     /**
      * Convenience method to convert a Camel Map output to a JSON Bean String.
-     *
-     * @param map
      * @return JSON bean String
      */
     public static String toJSONBean(final Map<String, Object> map) {
@@ -169,9 +159,6 @@ public final class JSONBeanUtil {
 
     /**
      * Converts Camel Map output representing DB result set to a list of JSON Bean Strings.
-     *
-     * @param in
-     * @return
      */
     public static List<String> toJSONBeans(Message in) {
         final List<String> jsonBeans = new ArrayList<>();
@@ -204,8 +191,6 @@ public final class JSONBeanUtil {
 
     /**
      * Converts Camel Generated Key output to a list of JSON Bean Strings.
-     *
-     * @param in
      * @param autoIncrementColumnName the name of the auto increment column name
      * @return List of JSON beans.
      */

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlParam.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("PMD.GodClass") // TODO refactor
+@SuppressWarnings({"PMD.GodClass", "JavaUtilDate"}) // TODO refactor
 public class SqlParam {
 
     private final String name;

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -32,9 +32,7 @@ public class SqlStatementParser {
      * R - SELECT FIRSTNAME, LASTNAME FROM NAME WHERE ID=:id
      * U - UPDATE NAME SET FIRSTNAME=:firstname WHERE ID=:id
      * D - DELETE FROM NAME WHERE ID=:id
-     *
      * DEMO_ADD(INTEGER ${body[A]}
-     *
      * validate no "AS"
      * input params
      * output params
@@ -220,11 +218,8 @@ public class SqlStatementParser {
     /**
      * INSERT INTO table_name (column1, column2, column3, ...)
      * VALUES (value1, value2, value3, ...);
-     *
      * INSERT INTO table_name
      * VALUES (value1, value2, value3, ...);
-     * @param tableName
-     * @return
      */
     List<SqlParam> findInsertParams(String tableName) {
         boolean isColumnName = false;

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/StatementType.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/StatementType.java
@@ -17,10 +17,6 @@ package io.syndesis.connector.sql.common;
 
 /**
  * SQL Statement Types
- *
- * @since 09/11/17
- * @author kstam
- *
  */
 public enum StatementType {
     INSERT, SELECT, UPDATE, DELETE;

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/stored/ColumnMode.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/stored/ColumnMode.java
@@ -18,10 +18,6 @@ package io.syndesis.connector.sql.common.stored;
 /**
  * Complete Enumeration of Column modes in use by
  * Stored Procedures.
- *
- * @since 09/11/17
- * @author kstam
- *
  */
 public enum ColumnMode {
     UNKNOWN, IN, INOUT, RESULT, OUT, RETURN;

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/JSONBeanUtilTest.java
@@ -98,8 +98,6 @@ public class JSONBeanUtilTest {
     /**
      * Address issue when sql is parsed but contains no sql parameters
      * @see https://github.com/syndesisio/syndesis/issues/2706
-     *
-     * @throws JsonProcessingException
      */
     @Test
     public void parseSqlParametersFromJSONBeanWhenNoParameters() throws JsonProcessingException {

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
@@ -75,7 +75,6 @@ public final class SampleStoredProcedures {
             "    OWNER TO postgres;";
     /**
      * Java method implementing the Stored Procedure for Derby.
-     *
      * @param a - input parameter of type integer
      * @param b - input parameter of type integer
      * @param c - output (the result of a + b) of type integer[]
@@ -89,7 +88,6 @@ public final class SampleStoredProcedures {
     }
     /**
      * Java method implementing the Stored Procedure for Derby.
-     *
      * @param c - output (the result of a + b) of type integer[]
      */
     public static void demo_out(

--- a/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
+++ b/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateConnectorInspectionsMojo.java
@@ -156,11 +156,8 @@ public class GenerateConnectorInspectionsMojo extends AbstractMojo {
 
     /**
      * Validate the given file against the connection schema
-     *
-     * @param jsonStream {@link InputStream} of the file to validate.
-     *                                          Method will close the stream after use.
+     * @param jsonFile the file to validate.
      * @return the {@link JsonNode} of the file content or throw exception if an error
-     * @throws MojoExecutionException
      */
     public JsonNode validateWithSchema(File jsonFile) throws MojoExecutionException {
         InputStream jsonStream = null;

--- a/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateResourceInspectionsMojo.java
+++ b/app/connector/support/maven-plugin/src/main/java/io/syndesis/connector/support/maven/GenerateResourceInspectionsMojo.java
@@ -48,12 +48,9 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Generates inspections for resources in the given inputDirectory and stores them in the outputDirectory.
- *
  * It deletes files for which inspections have been created.
- *
  * Currently it supports only xml schemas with .xsd extension.
- *
- * It is possible to provide resourcesProcessorClass, which points to a class implementing BiConsumer<Path, Path>.
+ * It is possible to provide resourcesProcessorClass, which points to a class implementing {@code BiConsumer<Path, Path>}.
  * It can implement any processing on resources before running inspections and accepts input and output directories.
  * When the class is provided within the same project, the plugin must be run no sooner than in the process-classes
  * phase so that the class is available on the classpath.

--- a/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpMessageToDefaultMessageProcessor.java
+++ b/app/connector/support/processor/src/main/java/io/syndesis/connector/support/processor/HttpMessageToDefaultMessageProcessor.java
@@ -26,10 +26,8 @@ import org.apache.camel.util.ExchangeHelper;
  * Integrations may frequently overwrite message body content. HttpMessage is having issues with that
  * as it tries to read the request input stream cache multiple times in that case. This results to stream already closed
  * errors while processing the message body.
- *
  * Normal stream caching mechanisms on the http message implementation do not solve this issue as message body gets frequently
  * replaced while running the integration and this in particular is not covered.
- *
  * This replaces the message on the exchange so the type of the message is no longer HttpMessage and when copies of the message
  * are attempted the HTTP request stream is not read the second time. At which point the HTTP request stream might be closed.
  */

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/CertificateUtil.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/CertificateUtil.java
@@ -31,8 +31,6 @@ import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Utility class for working with X.509 Certificates.
- *
- * @author dhirajsb
  */
 public final class CertificateUtil {
 

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/ConnectorOptions.java
@@ -33,12 +33,7 @@ public final class ConnectorOptions {
     /**
      * Gets the value mapped to the given key,
      * converts to {@link String} & returns or defaultValue otherwise.
-     *
      * Note. Don't use this if the value is not expected to a {@link String}
-     *
-     * @param options
-     * @param key
-     * @param defaultValue
      * @return {@link String} object belonging to the given key in the options map
      */
     public static String extractOption(Map<String, ?> options, String key, String defaultValue) {
@@ -55,9 +50,6 @@ public final class ConnectorOptions {
     /**
      * Gets the value mapped to the given key & converts to {@link String} if present,
      * or null otherwise.
-     *
-     * @param options
-     * @param key
      * @return {@link String} object belonging to the given key in the options map
      */
     public static String extractOption(Map<String, ?> options, String key) {
@@ -67,9 +59,6 @@ public final class ConnectorOptions {
     /**
      * Gets & removes the value mapped to the given key & converts to {@link String} if present,
      * or null otherwise.
-     *
-     * @param options
-     * @param key
      * @return {@link String} object that used to belong to the given key in the options map
      */
     public static String popOption(Map<String, ?> options, String key) {
@@ -87,12 +76,8 @@ public final class ConnectorOptions {
      * Gets the value mapped to the given key, converts to {@link String} if present,
      * then applies the given mapping function to the {@link String} value. Either
      * returns the resulting mapped object or null.
-     *
      * Note. This will only work for values that can be converted to strings so Strings and primitives.
      *            The mappingFn should be able to handle null values.
-     *
-     * @param options
-     * @param key
      * @return Mapped object converted from value belonging to the given key in the options map
      */
     public static <T> T extractOptionAndMap(Map<String, ?> options, String key,
@@ -117,11 +102,7 @@ public final class ConnectorOptions {
      * Gets the value mapped to the given key, converts to {@link String} if present,
      * then applies the given mapping function to the {@link String} value. Either
      * returns the resulting mapped object or null.
-     *
      * Note. mappingFn should be able to handle null values.
-     *
-     * @param options
-     * @param key
      * @return Mapped object converted from value belonging to the given key in the options map
      * @throws any exception that may result from the mapping function
      */
@@ -161,12 +142,6 @@ public final class ConnectorOptions {
     /**
      * Gets the value mapped to the given key, checks it is the required class
      * and returns. Otherwise return defaultValue.
-     *
-     * @param options
-     * @param key
-     * @param requiredClass
-     * @param defaultValue
-     *
      * @return value from options
      */
     public static <T> T extractOptionAsType(Map<String, ?> options,
@@ -184,10 +159,6 @@ public final class ConnectorOptions {
     /**
      * Gets the value mapped to the given key, checks it is the required class
      * and returns. Otherwise return null.
-     *
-     * @param options
-     * @param key
-     * @param requiredClass
      * @return value from options
      */
     public static <T> T extractOptionAsType(Map<String, ?> options,

--- a/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/KeyStoreHelper.java
+++ b/app/connector/support/util/src/main/java/io/syndesis/connector/support/util/KeyStoreHelper.java
@@ -40,8 +40,6 @@ import javax.net.ssl.X509TrustManager;
 
 /**
  * Helper class to create KeyStores from Certificates.
- *
- * @author dhirajsb
  */
 public class KeyStoreHelper {
 
@@ -68,7 +66,6 @@ public class KeyStoreHelper {
     /**
      * Create a keystore helper by generating a local temporary keystore file with a self signed certificate.
      * You may need to use {@link #clean()} method afterward.
-     *
      * @return an helper object used to get keystore location and password
      */
     public KeyStoreHelper store() {

--- a/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/CertificateUtilTest.java
+++ b/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/CertificateUtilTest.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test Certificate utility.
- *
- * @author dhirajsb
  */
 public class CertificateUtilTest {
 

--- a/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/KeyStoreHelperTest.java
+++ b/app/connector/support/util/src/test/java/io/syndesis/connector/support/util/KeyStoreHelperTest.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test {@link KeyStoreHelper}.
- *
- * @author dhirajsb
  */
 public class KeyStoreHelperTest {
 

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/ComponentVerifier.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/ComponentVerifier.java
@@ -30,10 +30,6 @@ import org.apache.camel.component.extension.ComponentVerifierExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author roland
- * @since 28/03/2017
- */
 public class ComponentVerifier implements Verifier {
     private static final Logger LOG = LoggerFactory.getLogger(ComponentVerifier.class);
 

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/Verifier.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/Verifier.java
@@ -20,10 +20,6 @@ import java.util.Map;
 
 import org.apache.camel.CamelContext;
 
-/**
- * @author roland
- * @since 28/03/2017
- */
 public interface Verifier {
 
     List<VerifierResponse> verify(CamelContext context, String connectorId, Map<String, Object> parameters);

--- a/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/VerifierResponse.java
+++ b/app/connector/support/verifier/src/main/java/io/syndesis/connector/support/verifier/api/VerifierResponse.java
@@ -25,10 +25,6 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-/**
- * @author roland
- * @since 20/03/2017
- */
 @JsonDeserialize
 public class VerifierResponse {
 

--- a/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/DirectMessage.java
+++ b/app/connector/twitter/src/main/java/io/syndesis/connector/twitter/DirectMessage.java
@@ -17,6 +17,7 @@ package io.syndesis.connector.twitter;
 
 import java.util.Date;
 
+@SuppressWarnings("JavaUtilDate") // TODO refactor
 public class DirectMessage {
 
     private long id;

--- a/app/extension/annotation-processor/src/main/java/io/syndesis/extension/maven/annotation/processing/ActionProcessor.java
+++ b/app/extension/annotation-processor/src/main/java/io/syndesis/extension/maven/annotation/processing/ActionProcessor.java
@@ -50,7 +50,7 @@ import com.google.errorprone.annotations.FormatMethod;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"PMD.GodClass", "DoNotClaimAnnotations"}) // TODO refactor
 @SupportedSourceVersion(value = SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({
     ActionProcessor.SYNDESIS_ANNOTATION_CLASS_NAME
@@ -156,8 +156,6 @@ public class ActionProcessor extends AbstractProcessor {
 
     /**
      * Explicitly add properties that elude reflection implicit strategy
-     * @param element
-     * @param root
      */
     private boolean augmentProperties(ObjectNode root, TypeElement element) throws InvocationTargetException, IllegalAccessException {
         final Elements elements = processingEnv.getElementUtils();
@@ -216,8 +214,6 @@ public class ActionProcessor extends AbstractProcessor {
 
     /**
      * Explicitly add properties that elude reflection implicit strategy
-     * @param root
-     * @param element
      */
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     private void augmentProperties(ObjectNode root, ExecutableElement element) {
@@ -233,8 +229,6 @@ public class ActionProcessor extends AbstractProcessor {
 
     /**
      * Add action properties to the global properties.
-     * @param root
-     * @param element
      */
     private void addActionProperties(ObjectNode root, Element element) throws InvocationTargetException, IllegalAccessException {
 

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/BinaryExtensionAnalyzer.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/BinaryExtensionAnalyzer.java
@@ -32,7 +32,6 @@ public interface BinaryExtensionAnalyzer {
 
     /**
      * Analyze a binary extension to obtain the embedded {@link Extension} object.
-     *
      * @param binaryExtension the binary stream of the extension
      * @return the embedded {@code Extension} object
      */
@@ -40,8 +39,6 @@ public interface BinaryExtensionAnalyzer {
 
     /**
      * Get the icon file from the binary extension.
-     *
-     * @param binaryExtension
      * @param path the icon path, it must be an allowed icon path
      * @return the icon of the extension or an empty option
      */

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/DefaultExtensionConverter.java
@@ -29,7 +29,6 @@ class DefaultExtensionConverter implements ExtensionConverter {
 
     /**
      * Apply any custom conversion from the public model to the internal model here.
-     *
      * Version of the public model is assumed to be latest ({@link ExtensionConverter#getCurrentSchemaVersion()}).
      */
     private static ObjectNode convertInternalToPublicModel(ObjectNode tree) {
@@ -38,7 +37,6 @@ class DefaultExtensionConverter implements ExtensionConverter {
 
     /**
      * Apply any custom conversion from the internal model to the public model here.
-     *
      * Version of the public model is assumed to be latest ({@link ExtensionConverter#getCurrentSchemaVersion()}).
      */
     private static ObjectNode convertPublicToInternalModel(ObjectNode tree) {
@@ -47,7 +45,6 @@ class DefaultExtensionConverter implements ExtensionConverter {
 
     /**
      * Apply any custom transformation to latest public schema versions.
-     *
      * Normally public versions are backward compatible, so this method is likely to remain empty.
      */
     private static ObjectNode convertToLatestSchemaVersion(ObjectNode tree, String sourceVersion) {

--- a/app/extension/converter/src/main/java/io/syndesis/extension/converter/ExtensionConverter.java
+++ b/app/extension/converter/src/main/java/io/syndesis/extension/converter/ExtensionConverter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
  * User-facing (public) extensions must follow a schema that is subject to backward-compatible changes only.
  * In order to allow the core API to evolve while supporting old extensions, the two schemas must be separated and
  * object should be converted.
- *
  * The public Extension model must respect the json schema contained in the extension-api module (syndesis/syndesis-extension-definition-schema.json).
  */
 public interface ExtensionConverter {

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/GenerateMetadataMojo.java
@@ -83,8 +83,6 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
 
 /**
  * Helper Maven plugin
- *
- * @author pantinor
  */
 @Mojo(name = "generate-metadata",
         defaultPhase = LifecyclePhase.PROCESS_CLASSES,
@@ -366,7 +364,6 @@ public class GenerateMetadataMojo extends AbstractMojo {
 
     /**
      * Loads a partial metadata json file, if configured at Maven Plugin level.
-     * @throws MojoExecutionException
      */
     protected void tryImportingPartialJSON() throws MojoExecutionException {
         File template;

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageExtensionMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageExtensionMojo.java
@@ -69,8 +69,6 @@ import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSessionContainer;
 
 /**
  * Helper Maven plugin
- *
- * @author pantinor
  */
 @SuppressWarnings({"PMD.ExcessiveImports"})
 @Mojo(name = "repackage-extension", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
@@ -268,7 +266,6 @@ public class RepackageExtensionMojo extends SupportMojo {
     /*
      * @param artifact The artifact coordinates in the format
      *            {@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}, must not be {@code null}.
-     *
      */
     protected ArtifactResult downloadAndInstallArtifact(String artifact) throws MojoExecutionException {
         ArtifactResult result;

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageIntegrationMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageIntegrationMojo.java
@@ -21,8 +21,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Helper Maven plugin
- *
- * @author pantinor
  */
 @Mojo(name = "repackage-integration", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true, threadSafe = true, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class RepackageIntegrationMojo extends SupportMojo {

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
@@ -76,8 +76,6 @@ public abstract class SupportMojo extends RepackageMojo {
     /**
      * Optional method used to specify the set of fields you want to write. Often uses `writeFieldViaReflection` to do
      * its job.
-     * @throws NoSuchFieldException
-     * @throws IllegalAccessException
      */
     protected void writeAdditionalPrivateFields() throws NoSuchFieldException, IllegalAccessException{
         // codacy bot should find another job
@@ -103,7 +101,6 @@ public abstract class SupportMojo extends RepackageMojo {
 
     /**
      * Defines the default set of artifacts to exclude from the repackaged module
-     * @return
      */
     protected Collection<ArtifactsFilter> getAdditionalFilters() {
         return new ArrayList<>();
@@ -111,9 +108,6 @@ public abstract class SupportMojo extends RepackageMojo {
 
     /**
      * Utility method to find a reference to a Field in the Superclass hiearchy to be set via reflection.
-     * @param fieldName
-     * @return
-     * @throws NoSuchFieldException
      */
     protected Field obtainAccessibleFieldInAncestors(String fieldName) throws NoSuchFieldException {
         Class<?> clazz = SupportMojo.class.getSuperclass();

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationErrorHandler.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationErrorHandler.java
@@ -18,9 +18,6 @@ package io.syndesis.integration.api;
 
 import java.util.function.Consumer;
 
-/**
- * @author Christoph Deppisch
- */
 @FunctionalInterface
 public interface IntegrationErrorHandler extends Consumer<Throwable> {
     // type to easily use in code, rather than types with long generics

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationProjectGenerator.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationProjectGenerator.java
@@ -24,7 +24,6 @@ import io.syndesis.common.model.integration.Integration;
 public interface IntegrationProjectGenerator {
     /**
      * Generate the project files in form of tar input stream
-     *
      * @param integration the Integration
      * @param errorHandler the error handler is provided with potential async errors raised during project generation
      * @return an {@link InputStream} which holds a tar archive and which can be directly used for

--- a/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationResourceManager.java
+++ b/app/integration/api/src/main/java/io/syndesis/integration/api/IntegrationResourceManager.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.syndesis.common.model.Dependency;
-import io.syndesis.common.model.Dependency.Type;
 import io.syndesis.common.model.WithDependencies;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.connection.ConnectionBase;
@@ -207,7 +206,6 @@ public interface IntegrationResourceManager {
 
     /**
      * Sanitize an integration name according a specific set of characters
-     *
      * @param name the name to sanitize
      * @return a sanitized name replacing illegal characters
      */
@@ -263,7 +261,7 @@ public interface IntegrationResourceManager {
                 flatMap(ConnectionBase::getConnector).
                 flatMap(ctr -> Optional.ofNullable(ctr.getIcon())).
                 filter(icon -> icon.startsWith("db:")).
-                ifPresent(icon -> dependencies.add(Dependency.from(Type.ICON, icon)));
+                ifPresent(icon -> dependencies.add(Dependency.from(Dependency.Type.ICON, icon)));
 
             // Connector extension
             Stream.concat(connectorDependencies.stream(), lookedUpConnectorDependencies.stream())

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentCustomizer.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentCustomizer.java
@@ -26,7 +26,6 @@ public interface ComponentCustomizer<T extends Component> {
     /**
      * Customize the specified {@link Component}. The customizer has to
      * remove remove customizer specific properties once they are consumed.
-     *
      * @param component the component to customize
      * @param options the component options
      */

--- a/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
+++ b/app/integration/component-proxy/src/main/java/io/syndesis/integration/component/proxy/ComponentProxyComponent.java
@@ -123,7 +123,6 @@ public class ComponentProxyComponent extends DefaultComponent {
 
     /**
      * Allows the definition to be overridden if required by specific components
-     *
      * @return definition
      */
     protected ComponentDefinition getDefinition() {

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestConstants.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestConstants.java
@@ -26,17 +26,17 @@ import io.syndesis.common.util.MavenProperties;
 
 final class TestConstants {
 
-    protected static final MavenProperties MAVEN_PROPERTIES;
+    static final MavenProperties MAVEN_PROPERTIES;
 
-    protected static final String SYNDESIS_VERSION;
-    protected static final String CAMEL_VERSION;
-    protected static final ConnectorAction PERIODIC_TIMER_ACTION;
-    protected static final Connector TIMER_CONNECTOR;
-    protected static final ConnectorAction HTTP_GET_ACTION;
-    protected static final ConnectorAction HTTP_POST_ACTION;
-    protected static final Connector HTTP_CONNECTOR;
-    protected static final ConnectorAction TWITTER_MENTION_ACTION;
-    protected static final Connector TWITTER_CONNECTOR;
+    static final String SYNDESIS_VERSION;
+    static final String CAMEL_VERSION;
+    static final ConnectorAction PERIODIC_TIMER_ACTION;
+    static final Connector TIMER_CONNECTOR;
+    static final ConnectorAction HTTP_GET_ACTION;
+    static final ConnectorAction HTTP_POST_ACTION;
+    static final Connector HTTP_CONNECTOR;
+    static final ConnectorAction TWITTER_MENTION_ACTION;
+    static final Connector TWITTER_CONNECTOR;
 
     static {
         MAVEN_PROPERTIES = new MavenProperties();

--- a/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/IntegrationRuntimeAutoConfiguration.java
+++ b/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/IntegrationRuntimeAutoConfiguration.java
@@ -61,7 +61,6 @@ public class IntegrationRuntimeAutoConfiguration {
      * This method is responsible to set up an {@link CamelContextConfiguration}
      * that crates a route builder from the integration.json and set-up a post
      * context start task that dumps the generated routes for debugging purpose.
-     *
      * @return a {@link CamelContextConfiguration}
      */
     @Bean

--- a/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/logging/IntegrationLoggingCamelContextConfiguration.java
+++ b/app/integration/runtime-springboot/src/main/java/io/syndesis/integration/runtime/sb/logging/IntegrationLoggingCamelContextConfiguration.java
@@ -24,9 +24,6 @@ import org.apache.camel.spring.boot.CamelContextConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Christoph Deppisch
- */
 public class IntegrationLoggingCamelContextConfiguration implements CamelContextConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(IntegrationLoggingCamelContextConfiguration.class);

--- a/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/IntegrationTestSupport.java
+++ b/app/integration/runtime-springboot/src/test/java/io/syndesis/integration/runtime/sb/IntegrationTestSupport.java
@@ -154,9 +154,8 @@ public class IntegrationTestSupport implements StringConstants {
     }
 
     /**
-     * @param inStream
+     * Reads the whole stream into a String, use carefuly could lead to large GC cycles.
      * @return a string representation of the content of the given stream
-     * @throws IOException
      */
     public static String streamToString(InputStream inStream) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inStream, "UTF-8"));

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/ActivityTrackingPolicyFactory.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/ActivityTrackingPolicyFactory.java
@@ -22,8 +22,6 @@ public interface ActivityTrackingPolicyFactory {
 
     /**
      * Factory method creating new route policy instance.
-     * @param flowId
-     * @return
      */
     RoutePolicy createRoutePolicy(String flowId);
 

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/IntegrationRouteBuilder.java
@@ -262,9 +262,6 @@ public class IntegrationRouteBuilder extends RouteBuilder {
 
     /**
      * Adds out message capture message processor to save current message to memory for later usage.
-     * @param parent
-     * @param stepId
-     * @return
      */
     private ProcessorDefinition<?> captureOutMessage(final ProcessorDefinition<?> parent, String stepId) {
         ProcessorDefinition<?> definition;

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/AggregateStepHandler.java
@@ -145,8 +145,6 @@ public class AggregateStepHandler implements IntegrationStepHandler {
 
         /**
          * Specifies the script.
-         *
-         * @param script
          */
         public void setScript(String script) {
             this.script = script;
@@ -154,8 +152,6 @@ public class AggregateStepHandler implements IntegrationStepHandler {
 
         /**
          * Specifies the language.
-         *
-         * @param language
          */
         public void setLanguage(String language) {
             this.language = language;

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/ChoiceStepHandler.java
@@ -93,10 +93,6 @@ public class ChoiceStepHandler implements IntegrationStepHandler {
     /**
      * Construct flow endpoint uri using given scheme and flow identifier. By default constructed uri is
      * using "scheme:flowId" pattern.
-     *
-     * @param routingScheme
-     * @param flowId
-     * @return
      */
     private static String getEndpointUri(String routingScheme, String flowId) {
         return routingScheme + ":" + flowId;

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/DataMapperStepHandler.java
@@ -71,9 +71,6 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
     /**
      * In case atlas mapping definition contains Json typed source documents we need to make sure to convert those from list to Json array Strings before passing those
      * source documents to the mapper.
-     * @param route
-     * @param dataSources
-     * @return
      */
     private static void addJsonTypeSourceProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
         List<Map<String, Object>> sourceDocuments = dataSources.stream()
@@ -94,9 +91,6 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
     /**
      * In case mapping definition has Json typed target document we need to make sure to convert the output. This is because mapper provides Json target collection as Json array String representation.
      * We prefer to use list objects where each element is a Json Object String.
-     * @param route
-     * @param dataSources
-     * @return
      */
     private static void addJsonTypeTargetProcessor(ProcessorDefinition<?> route, List<Map<String, Object>> dataSources) {
         boolean isJsonTypeTarget = dataSources.stream()
@@ -109,8 +103,6 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
 
     /**
      * Reads atlas mapping definition from configured step properties and extracts all data source elements.
-     * @param configuredProperties
-     * @return
      */
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> getAtlasmapDataSources(Map<String, String> configuredProperties) {
@@ -161,7 +153,6 @@ public class DataMapperStepHandler implements IntegrationStepHandler {
 
         /**
          * Convert list typed message body to Json array String representation.
-         * @param message
          */
         private static void convertMessageJsonTypeBody(Exchange exchange, Message message) {
             if (message != null && message.getBody() instanceof List) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SplitStepHandler.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/handlers/SplitStepHandler.java
@@ -113,10 +113,8 @@ public class SplitStepHandler implements IntegrationStepHandler {
     /**
      * Split expression that is aware of special list of Json beans representation provided by some connectors such as
      * SQL. Also handles Json array String representation and splits its array elements accordingly.
-     *
      * Expression receives a delegate expression that usually evaluates the part of the body or header that should be split. By
      * default this is a simple body expression.
-     *
      * When delegate expression evaluates to something else that a Json array or list of Json beans nothing is performed on top of
      * the delegate expression.
      */
@@ -149,7 +147,6 @@ public class SplitStepHandler implements IntegrationStepHandler {
     /**
      * Expression extracts body property from unified Json schema typed input. The unified Json holds the actual body in
      * a nested property. This property is extracted and set as expression result so follow up expressions can operate on the body.
-     *
      * Expression receives a delegate expression that usually evaluates the part of the body or header that should be
      * treated as unified Json. By default this is a simple body expression.
      */
@@ -183,7 +180,6 @@ public class SplitStepHandler implements IntegrationStepHandler {
     /**
      * Helper tries to convert given value to a String representation that can be split. For instance a remote file object
      * with Json array as content is converted to String and then split using the elements in that Json array.
-     *
      * Some types are already supported by Camel's splitter such as List or Scanner. Do not touch these types and skip conversion.
      * @param value the value to convert.
      * @param exchange the current exchange.

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/jmx/CamelContextMetadataMBean.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/jmx/CamelContextMetadataMBean.java
@@ -29,10 +29,9 @@ import org.slf4j.LoggerFactory;
 /**
  * A simple mapping mbean to convert some {@link org.apache.camel.api.management.mbean.ManagedCamelContextMBean}
  * metadata fields to Prometheus metrics.
- *
- * @author dhirajsb
  */
 @ManagedResource(description = "Managed Syndesis CamelContext")
+@SuppressWarnings("JavaUtilDate") // it's what Camel API gives us
 public class CamelContextMetadataMBean implements Service, CamelContextAware {
 
     public static final Logger LOG = LoggerFactory.getLogger(CamelContextMetadataMBean.class);

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/ActivityTrackingInterceptStrategy.java
@@ -93,7 +93,7 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
                 );
             }
 
-            return super.process(exchange, callback::done);
+            return super.process(exchange, callback);
         }
     }
 
@@ -139,8 +139,6 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
 
     /**
      * Activity tracking is only active for pipelines.
-     * @param definition
-     * @return
      */
     private static boolean shouldTrack(ProcessorDefinition<?> definition) {
         return definition instanceof PipelineDefinition &&
@@ -150,10 +148,7 @@ public class ActivityTrackingInterceptStrategy implements InterceptStrategy {
     /**
      * Activities that do hold nested activities (such as {@link org.apache.camel.model.FilterDefinition}, {@link org.apache.camel.model.ChoiceDefinition})
      * should not track the done event because this leads to reversed order of log events.
-     *
      * Only log done events with duration measurement for no output definitions like {@link org.apache.camel.model.ToDefinition}.
-     * @param definition
-     * @return
      */
     private static boolean shouldTrackDoneEvent(ProcessorDefinition<?> definition) {
         if (ObjectHelper.isEmpty(definition.getOutputs())) {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/BodyLogger.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/BodyLogger.java
@@ -38,7 +38,6 @@ public interface BodyLogger {
      * in readable format even if objects overwrite {@link Object#toString()}. This is required when grouped body aggregation
      * exchanges are logged because these exchanges do overwrite {@link Object#toString()}
      * in {@link org.apache.camel.processor.aggregate.AbstractListAggregationStrategy}
-     *
      * Other body types are delegated to simple language "${body}" expression for logging the body as String.
      */
     class Default implements BodyLogger {

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/FlowActivityTrackingPolicy.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/FlowActivityTrackingPolicy.java
@@ -19,9 +19,6 @@ import io.syndesis.integration.runtime.util.DefaultRoutePolicy;
 import org.apache.camel.Exchange;
 import org.apache.camel.Route;
 
-/**
- * @author Christoph Deppisch
- */
 public final class FlowActivityTrackingPolicy extends DefaultRoutePolicy {
     private final ActivityTracker tracker;
 

--- a/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/FlowActivityTrackingPolicyFactory.java
+++ b/app/integration/runtime/src/main/java/io/syndesis/integration/runtime/logging/FlowActivityTrackingPolicyFactory.java
@@ -19,9 +19,6 @@ import io.syndesis.common.model.integration.Flow;
 import io.syndesis.integration.runtime.ActivityTrackingPolicyFactory;
 import org.apache.camel.spi.RoutePolicy;
 
-/**
- * @author Christoph Deppisch
- */
 public class FlowActivityTrackingPolicyFactory implements ActivityTrackingPolicyFactory {
 
     private final ActivityTracker tracker;

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/BodyLoggerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/logging/BodyLoggerTest.java
@@ -31,9 +31,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Christoph Deppisch
- */
 public class BodyLoggerTest {
 
     public static Stream<Arguments> data() {

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityFormalSyntaxTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityFormalSyntaxTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for velocity formal template step handler, ie. using the formal
  * syntax for velocity symbols, eg. ${xyz}
- *
  */
 public class VelocityFormalSyntaxTest extends AbstractVelocityTemplateStepHandlerTest {
 

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityInformalSyntaxTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/template/velocity/VelocityInformalSyntaxTest.java
@@ -21,7 +21,6 @@ import io.syndesis.common.model.integration.step.template.TemplateStepLanguage.S
 /**
  * Tests for velocity informal template step handler, ie. using the informal
  * syntax for velocity symbols, eg. $xyz
- *
  */
 public class VelocityInformalSyntaxTest extends AbstractVelocityTemplateStepHandlerTest {
 

--- a/app/integration/support/camel-acme/pom.xml
+++ b/app/integration/support/camel-acme/pom.xml
@@ -72,7 +72,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <annotationProcessorPaths>
+          <annotationProcessorPaths combine.children="append">
             <annotationProcessorPath>
                <groupId>org.apache.camel</groupId>
                <artifactId>apt</artifactId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -81,7 +81,8 @@
 
     <maven.version>3.5.4</maven.version>
 
-    <errorprone.version>2.3.3</errorprone.version>
+    <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
+    <errorprone.version>2.6.0</errorprone.version>
     <commons.compress.version>1.20</commons.compress.version>
 
     <!-- opentracing dependencies -->
@@ -153,7 +154,7 @@
     <resteasy.version>4.5.6.Final</resteasy.version>
     <resteasy-spring-boot-starter.version>4.6.1.Final</resteasy-spring-boot-starter.version>
 
-    <immutables.version>2.8.1</immutables.version>
+    <immutables.version>2.8.2</immutables.version>
 
     <jdbi.version>2.78</jdbi.version>
     <postgresql.version>42.2.16</postgresql.version>
@@ -875,36 +876,30 @@
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <fork>true</fork>
               <compilerArgs>
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/generated-sources/.* -Xep:ConstantField:WARN -Xep:ExpectedExceptionChecker:WARN -Xep:FieldCanBeFinal:WARN -Xep:LambdaFunctionalInterface:WARN -Xep:MethodCanBeStatic:WARN -XepOpt:MethodCanBeStatic:FindingPerSite -Xep:PackageLocation:WARN -Xep:PrivateConstructorForUtilityClass:WARN -Xep:RemoveUnusedImports:WARN -Xep:SwitchDefault:WARN -Xep:TestExceptionChecker:WARN -Xep:ThrowsUncheckedException:WARN -Xep:TryFailRefactoring:WARN -Xep:UnnecessaryStaticImport:WARN -Xep:WildcardImport:WARN -Xep:BanSerializableRead -Xep:ClassName -Xep:ComparisonContractViolated ${errorprone.autofix.arg1} ${errorprone.autofix.arg2}</arg>
                 <arg>-Xlint:all</arg>
                 <arg>-Xlint:-deprecation</arg>
                 <arg>-Xlint:-processing</arg>
                 <arg>-Xlint:-serial</arg>
+                <!--
+                  com.sun.xml.bind.*:* jars have Classpath in META-INF/MANIFEST.MF,
+                  that trips the compiler to add them on paths that do not make
+                  much sense like $HOME/.m2/repository/com/sun/xml/bind/jaxb-core/2.3.0/jaxb-api.jar
+                -->
+                <arg>-Xlint:-path</arg>
                 <arg>${javac.werror}</arg>
-                <arg>-XepDisableWarningsInGeneratedCode</arg>
-                <arg>-XepExcludedPaths:.*/generated-sources/.*</arg>
-                <arg>-Xep:ConstantField:WARN</arg>
-                <arg>-Xep:ExpectedExceptionRefactoring:WARN</arg>
-                <arg>-Xep:FieldCanBeFinal:WARN</arg>
-                <arg>-Xep:LambdaFunctionalInterface:WARN</arg>
-                <arg>-Xep:MethodCanBeStatic:WARN</arg>
-                <arg>-XepOpt:MethodCanBeStatic:FindingPerSite</arg>
-                <arg>-Xep:PackageLocation:WARN</arg>
-                <arg>-Xep:PrivateConstructorForUtilityClass:WARN</arg>
-                <arg>-Xep:RemoveUnusedImports:WARN</arg>
-                <arg>-Xep:SwitchDefault:WARN</arg>
-                <arg>-Xep:TestExceptionRefactoring:WARN</arg>
-                <arg>-Xep:ThrowsUncheckedException:WARN</arg>
-                <arg>-Xep:TryFailRefactoring:WARN</arg>
-                <arg>-Xep:UnnecessaryStaticImport:WARN</arg>
-                <arg>-Xep:WildcardImport:WARN</arg>
                 <arg>-implicit:none</arg>
-                <arg>${errorprone.autofix.arg1}</arg>
-                <arg>${errorprone.autofix.arg2}</arg>
               </compilerArgs>
               <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </annotationProcessorPath>
                 <annotationProcessorPath>
                   <groupId>org.immutables</groupId>
                   <artifactId>value</artifactId>
@@ -919,16 +914,9 @@
             </configuration>
             <dependencies>
               <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                <version>2.8.5</version>
-              </dependency>
-              <!-- override plexus-compiler-javac-errorprone's dependency on
-             Error Prone with the latest version -->
-              <dependency>
                 <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${errorprone.version}</version>
+                <artifactId>javac</artifactId>
+                <version>${errorprone.javac.version}</version>
               </dependency>
             </dependencies>
           </plugin>
@@ -941,7 +929,7 @@
       <properties>
         <!-- -Werror is given to javac it never reaches the GENERATE task, and fails in COMPILATION, and refactorings are applied in GENERATE task, so they would be skipped -->
         <javac.werror></javac.werror>
-        <errorprone.autofix.arg1>-XepPatchChecks:BadImport,DeadException,DefaultCharset,MissingOverride,UnnecessaryParentheses,UnusedVariable,UnusedMethod,FieldCanBeFinal,MethodCanBeStatic,ClassCanBeStatic,RemoveUnusedImports,ThrowsUncheckedException</errorprone.autofix.arg1>
+        <errorprone.autofix.arg1>-XepPatchChecks:BadImport,DeadException,DefaultCharset,MissingOverride,UnnecessaryParentheses,UnusedVariable,UnusedMethod,FieldCanBeFinal,MethodCanBeStatic,ClassCanBeStatic,RemoveUnusedImports,ThrowsUncheckedException,EmptyBlockTag,UnnecessaryMethodReference,ProtectedMembersInFinalClass,InvalidParam,NonCanonicalType,ZoneIdOfZ</errorprone.autofix.arg1>
         <errorprone.autofix.arg2>-XepPatchLocation:IN_PLACE</errorprone.autofix.arg2>
       </properties>
     </profile>
@@ -1516,7 +1504,7 @@
         <version>${net.jqwik.version}</version>
         <scope>test</scope>
       </dependency>
-  
+
       <dependency>
         <groupId>net.jqwik</groupId>
         <artifactId>jqwik</artifactId>
@@ -2886,7 +2874,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>27.0.1-jre</version>
+        <version>30.1.1-jre</version>
       </dependency>
 
       <dependency>

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/ConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/ConnectorGenerator.java
@@ -15,14 +15,6 @@
  */
 package io.syndesis.server.api.generator;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import io.syndesis.common.model.api.APISummary;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
@@ -31,6 +23,12 @@ import io.syndesis.common.model.connection.ConnectorSettings;
 import io.syndesis.common.model.connection.ConnectorTemplate;
 import io.syndesis.common.util.KeyGenerator;
 import io.syndesis.server.api.generator.util.IconGenerator;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class ConnectorGenerator {
 
@@ -69,7 +67,7 @@ public abstract class ConnectorGenerator {
         final Map<String, String> configuredProperties = connectorSettings.getConfiguredProperties()
             .entrySet().stream()
             .filter(e -> properties.contains(e.getKey()))
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         configuredProperties.putAll(baseConnector.getConfiguredProperties());
 
         final String name = Optional.ofNullable(connectorSettings.getName())
@@ -101,7 +99,6 @@ public abstract class ConnectorGenerator {
 
     /**
      * Determines the newly created connector description.
-     *
      * @param connectorTemplate connector template
      * @param connectorSettings custom connector definition
      */
@@ -111,7 +108,6 @@ public abstract class ConnectorGenerator {
 
     /**
      * Determines the newly created connector name.
-     *
      * @param connectorTemplate connector template
      * @param connectorSettings custom connector definition
      */

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
@@ -15,20 +15,7 @@
  */
 package io.syndesis.server.api.generator.openapi;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import static java.util.Optional.ofNullable;
 
 import io.apicurio.datamodels.core.models.Extension;
 import io.apicurio.datamodels.core.models.common.Info;
@@ -53,15 +40,26 @@ import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 import io.syndesis.server.api.generator.openapi.util.OpenApiModelParser;
 import io.syndesis.server.api.generator.openapi.util.OperationDescription;
 import io.syndesis.server.api.generator.openapi.util.SpecificationOptimizer;
-import io.syndesis.server.api.generator.openapi.v2.Oas20ParameterGenerator;
 import io.syndesis.server.api.generator.openapi.v2.Oas20DescriptorGenerator;
+import io.syndesis.server.api.generator.openapi.v2.Oas20ParameterGenerator;
 import io.syndesis.server.api.generator.openapi.v2.Oas20PropertyGenerators;
-import io.syndesis.server.api.generator.openapi.v3.Oas30ParameterGenerator;
 import io.syndesis.server.api.generator.openapi.v3.Oas30DescriptorGenerator;
+import io.syndesis.server.api.generator.openapi.v3.Oas30ParameterGenerator;
 import io.syndesis.server.api.generator.openapi.v3.Oas30PropertyGenerators;
 import io.syndesis.server.api.generator.util.ActionComparator;
-
-import static java.util.Optional.ofNullable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class OpenApiConnectorGenerator extends ConnectorGenerator {
 
@@ -224,7 +222,7 @@ public class OpenApiConnectorGenerator extends ConnectorGenerator {
         for (final OasPathItem path : OasModelHelper.getPathItems(paths)) {
             final Map<String, OasOperation> operationMap = OasModelHelper.getOperationMap(path);
 
-            for (final Entry<String, OasOperation> entry : operationMap.entrySet()) {
+            for (final Map.Entry<String, OasOperation> entry : operationMap.entrySet()) {
                 final OasOperation operation = entry.getValue();
                 final String operationId = operation.operationId;
                 if (operationId == null) {
@@ -254,7 +252,7 @@ public class OpenApiConnectorGenerator extends ConnectorGenerator {
                     .name(description.name)
                     .description(description.description)
                     .pattern(Action.Pattern.To)
-                    .descriptor(descriptor).tags(OasModelHelper.sanitizeTags(operation.tags).distinct()::iterator)
+                    .descriptor(descriptor).tags(OasModelHelper.sanitizeTags(operation.tags).distinct().collect(Collectors.toList()))
                     .build();
 
                 actions.add(action);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiDescriptorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiDescriptorGenerator.java
@@ -25,7 +25,6 @@ import io.syndesis.common.model.action.ConnectorDescriptor;
 /**
  * Generator creates a connector descriptor and adds properties and data shapes generated from the
  * OpenAPI operation specification. This is the abstract base class for specific specific 2.x and 3.x OpenAPI implementations.
- * @author Christoph Deppisch
  */
 public class OpenApiDescriptorGenerator<T extends OasDocument, O extends OasOperation> {
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiParameterGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiParameterGenerator.java
@@ -31,8 +31,6 @@ import static org.apache.commons.lang3.StringUtils.trimToNull;
 /**
  * Generator creates configuration properties from OpenAPI document parameters. Created configuration properties are added
  * to the connector builder. This is the abstract  base class for specific 2.x and 3.x OpenAPI implementations.
- *
- * @author Christoph Deppisch
  */
 public abstract class OpenApiParameterGenerator<T extends OasDocument> {
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiSchemaValidator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiSchemaValidator.java
@@ -37,9 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Optional.ofNullable;
 
-/**
- * @author Christoph Deppisch
- */
 public interface OpenApiSchemaValidator {
 
     /**

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiValidationRules.java
@@ -40,7 +40,6 @@ import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 
 /**
  * This class contains Syndesis custom validation rules for Open API specifications.
- *
  */
 public abstract class OpenApiValidationRules<T extends OasResponse, S extends SecurityScheme, D extends OasSchema> implements Function<OpenApiModelInfo, OpenApiModelInfo> {
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedJsonDataShapeSupport.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedJsonDataShapeSupport.java
@@ -32,9 +32,6 @@ import io.syndesis.common.model.DataShapeMetaData;
 import io.syndesis.server.api.generator.openapi.util.JsonSchemaHelper;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public abstract class UnifiedJsonDataShapeSupport<T extends OasDocument, O extends OasOperation> implements DataShapeGenerator<T, O> {
 
     private static final List<String> PROPERTIES_TO_REMOVE_ON_MERGE = Arrays.asList("$schema", "title");

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedXmlDataShapeSupport.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/UnifiedXmlDataShapeSupport.java
@@ -40,9 +40,6 @@ import org.dom4j.Element;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
-/**
- * @author Christoph Deppisch
- */
 public abstract class UnifiedXmlDataShapeSupport<T extends OasDocument, O extends OasOperation, R extends OasResponse> implements DataShapeGenerator<T, O> {
 
     protected static final String SCHEMA_SET_NS = "http://atlasmap.io/xml/schemaset/v2";

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/OasModelHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/OasModelHelper.java
@@ -44,9 +44,6 @@ import org.apache.commons.lang3.StringUtils;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
-/**
- * @author Christoph Deppisch
- */
 public final class OasModelHelper {
 
     public static final String URL_EXTENSION = "x-syndesis-swagger-url";

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/OpenApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/OpenApiModelParser.java
@@ -42,9 +42,6 @@ import org.yaml.snakeyaml.Yaml;
 
 import static java.util.Optional.ofNullable;
 
-/**
- * @author Christoph Deppisch
- */
 public final class OpenApiModelParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenApiModelParser.class);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/SpecificationOptimizer.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/util/SpecificationOptimizer.java
@@ -31,9 +31,6 @@ import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import io.syndesis.common.util.json.JsonUtils;
 
-/**
- * @author Christoph Deppisch
- */
 public final class SpecificationOptimizer {
 
     private SpecificationOptimizer() {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20DescriptorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20DescriptorGenerator.java
@@ -20,9 +20,6 @@ import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Operation;
 import io.syndesis.server.api.generator.openapi.OpenApiDescriptorGenerator;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas20DescriptorGenerator extends OpenApiDescriptorGenerator<Oas20Document, Oas20Operation> {
 
     public Oas20DescriptorGenerator() {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20FlowGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20FlowGenerator.java
@@ -23,9 +23,6 @@ import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Operation;
 import io.syndesis.server.api.generator.openapi.OpenApiFlowGenerator;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas20FlowGenerator extends OpenApiFlowGenerator<Oas20Document, Oas20Operation> {
 
     public Oas20FlowGenerator() {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ModelHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ModelHelper.java
@@ -102,8 +102,6 @@ final class Oas20ModelHelper {
 
     /**
      * Find parameter that is defined to live in body.
-     * @param operation
-     * @return
      */
     static Optional<OasParameter> findBodyParameter(Oas20Operation operation) {
         if (operation.parameters == null) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ParameterGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ParameterGenerator.java
@@ -23,9 +23,6 @@ import io.apicurio.datamodels.openapi.v2.models.Oas20ParameterDefinitions;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.server.api.generator.openapi.OpenApiParameterGenerator;
 
-/**
- * @author Christoph Deppisch
- */
 public final class Oas20ParameterGenerator extends OpenApiParameterGenerator<Oas20Document> {
 
     @Override

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20SchemaValidator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20SchemaValidator.java
@@ -19,9 +19,6 @@ package io.syndesis.server.api.generator.openapi.v2;
 import com.github.fge.jsonschema.main.JsonSchema;
 import io.syndesis.server.api.generator.openapi.OpenApiSchemaValidator;
 
-/**
- * @author Christoph Deppisch
- */
 public final class Oas20SchemaValidator implements OpenApiSchemaValidator {
 
     private static final JsonSchema SWAGGER_2_0_SCHEMA = OpenApiSchemaValidator.loadSchema("schema/swagger-2.0-schema.json", "http://swagger.io/v2/schema.json#");

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v2/Oas20ValidationRules.java
@@ -37,9 +37,6 @@ import io.syndesis.server.api.generator.openapi.OpenApiModelInfo;
 import io.syndesis.server.api.generator.openapi.OpenApiValidationRules;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas20ValidationRules extends OpenApiValidationRules<Oas20Response, Oas20SecurityScheme, Oas20SchemaDefinition> {
 
     Oas20ValidationRules(APIValidationContext context) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30DescriptorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30DescriptorGenerator.java
@@ -20,9 +20,6 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
 import io.syndesis.server.api.generator.openapi.OpenApiDescriptorGenerator;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30DescriptorGenerator extends OpenApiDescriptorGenerator<Oas30Document, Oas30Operation> {
 
     public Oas30DescriptorGenerator() {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30FlowGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30FlowGenerator.java
@@ -23,9 +23,6 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Operation;
 import io.syndesis.server.api.generator.openapi.OpenApiFlowGenerator;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30FlowGenerator extends OpenApiFlowGenerator<Oas30Document, Oas30Operation> {
 
     public Oas30FlowGenerator() {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGenerator.java
@@ -27,9 +27,6 @@ import io.syndesis.server.api.generator.openapi.OpenApiParameterGenerator;
 import io.syndesis.server.api.generator.openapi.util.JsonSchemaHelper;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public final class Oas30ParameterGenerator extends OpenApiParameterGenerator<Oas30Document> {
 
     @Override

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30PropertyGenerators.java
@@ -101,7 +101,6 @@ public class Oas30PropertyGenerators extends OpenApiPropertyGenerator<Oas30Docum
     /**
      * Extracts authorization flow name from security scheme. In OpenAPI 3.x the security scheme "oauth2" can define multiple authorization flow types.
      * This method searches for authorizationCode flow type first in favor of any other flow type as this is the one Syndesis is supporting at the moment.
-     *
      * Only if that specific flow type is not specified go and visit other flow types defined. Returns null when no authorization flow type is defined
      * which is usually the case for non oauth2 security schemes.
      * @param scheme the security scheme maybe holding authorization flows.

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30SchemaValidator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30SchemaValidator.java
@@ -20,9 +20,6 @@ import io.syndesis.server.api.generator.openapi.OpenApiSchemaValidator;
 
 import com.github.fge.jsonschema.main.JsonSchema;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30SchemaValidator implements OpenApiSchemaValidator {
 
     private static final JsonSchema OPENAPI_3_0_SCHEMA = OpenApiSchemaValidator.loadSchema("schema/openapi-3.0-schema.json", "https://spec.openapis.org/oas/3.0/schema/2019-04-02");

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRules.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/v3/Oas30ValidationRules.java
@@ -42,9 +42,6 @@ import io.syndesis.server.api.generator.openapi.OpenApiModelInfo;
 import io.syndesis.server.api.generator.openapi.OpenApiValidationRules;
 import io.syndesis.server.api.generator.openapi.util.OasModelHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public final class Oas30ValidationRules extends OpenApiValidationRules<Oas30Response, Oas30SecurityScheme, Oas30SchemaDefinition> {
 
     Oas30ValidationRules(APIValidationContext context) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaExtractor.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaExtractor.java
@@ -238,7 +238,6 @@ class XmlSchemaExtractor {
 
     /**
      * Copy all objects from source schema to target schema after calling extract methods to setup objects to extract.
-     *
      * @throws ParserException on error.
      */
     public void copyObjects() throws ParserException {

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/util/OpenApiModelParserTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/util/OpenApiModelParserTest.java
@@ -30,9 +30,6 @@ import org.junit.jupiter.api.Test;
 import static io.syndesis.server.api.generator.openapi.TestHelper.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class OpenApiModelParserTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/Oas20ParameterGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/Oas20ParameterGeneratorTest.java
@@ -27,9 +27,6 @@ import org.junit.jupiter.api.Test;
 import static io.syndesis.server.api.generator.openapi.TestHelper.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas20ParameterGeneratorTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/Oas20SchemaValidatorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/Oas20SchemaValidatorTest.java
@@ -27,9 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas20SchemaValidatorTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v2/UnifiedXmlDataShapeGeneratorTest.java
@@ -15,12 +15,10 @@
  */
 package io.syndesis.server.api.generator.openapi.v2;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.v2.models.Oas20Document;
 import io.apicurio.datamodels.openapi.v2.models.Oas20PathItem;
@@ -28,18 +26,16 @@ import io.apicurio.datamodels.openapi.v2.models.Oas20Schema;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.server.api.generator.openapi.UnifiedXmlDataShapeSupport;
 import io.syndesis.server.api.generator.openapi.util.XmlSchemaHelper;
-
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnifiedXmlDataShapeGeneratorTest {
 
@@ -52,7 +48,7 @@ public class UnifiedXmlDataShapeGeneratorTest {
     public void shouldCreateArrayFromExamples(final String jsonSchemaSnippet, final String xmlSchemaSnippet, final String arrayItemName,
         final String arrayElementName) throws IOException {
         final Map<String, Oas20Schema> namedPropertyMap = propertyFrom(jsonSchemaSnippet);
-        final Entry<String, Oas20Schema> namedProperty = namedPropertyMap.entrySet().iterator().next();
+        final Map.Entry<String, Oas20Schema> namedProperty = namedPropertyMap.entrySet().iterator().next();
 
         final String propertyName = namedProperty.getKey();
         final Oas20Schema array = namedProperty.getValue();

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30DataShapeGeneratorHelperTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30DataShapeGeneratorHelperTest.java
@@ -27,9 +27,6 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30PathItem;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30DataShapeGeneratorHelperTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30ParameterGeneratorTest.java
@@ -28,9 +28,6 @@ import org.junit.jupiter.api.Test;
 import static io.syndesis.server.api.generator.openapi.TestHelper.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30ParameterGeneratorTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30SchemaValidatorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/Oas30SchemaValidatorTest.java
@@ -27,9 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class Oas30SchemaValidatorTest {
 
     @Test

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/UnifiedXmlDataShapeGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/v3/UnifiedXmlDataShapeGeneratorTest.java
@@ -15,12 +15,10 @@
  */
 package io.syndesis.server.api.generator.openapi.v3;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.v3.models.Oas30Document;
 import io.apicurio.datamodels.openapi.v3.models.Oas30PathItem;
@@ -28,18 +26,16 @@ import io.apicurio.datamodels.openapi.v3.models.Oas30Schema;
 import io.syndesis.common.util.json.JsonUtils;
 import io.syndesis.server.api.generator.openapi.UnifiedXmlDataShapeSupport;
 import io.syndesis.server.api.generator.openapi.util.XmlSchemaHelper;
-
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.dom4j.Document;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnifiedXmlDataShapeGeneratorTest {
 
@@ -52,7 +48,7 @@ public class UnifiedXmlDataShapeGeneratorTest {
     public void shouldCreateArrayFromExamples(final String jsonSchemaSnippet, final String xmlSchemaSnippet, final String arrayItemName,
         final String arrayElementName) throws IOException {
         final Map<String, Oas30Schema> namedPropertyMap = propertyFrom(jsonSchemaSnippet);
-        final Entry<String, Oas30Schema> namedProperty = namedPropertyMap.entrySet().iterator().next();
+        final Map.Entry<String, Oas30Schema> namedProperty = namedPropertyMap.entrySet().iterator().next();
 
         final String propertyName = namedProperty.getKey();
         final Oas30Schema array = namedProperty.getValue();

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaTestHelper.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaTestHelper.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public final class XmlSchemaTestHelper {
 
-    protected static final String NAME_ATTRIBUTE = "name";
+    static final String NAME_ATTRIBUTE = "name";
     private static SchemaFactory schemaFactory;
     private static Validator validator;
     private static Validator schemaSetValidator;

--- a/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
+++ b/app/server/builder/maven-plugin/src/main/java/io/syndesis/server/builder/maven/ExtractConnectorDescriptorsMojo.java
@@ -54,9 +54,6 @@ import org.apache.maven.shared.artifact.resolve.ArtifactResult;
 
 /**
  * Simple maven plugin for creating a JSON file holding all connectors descriptors which are supported.
- *
- * @author roland
- * @since 23.09.17
  */
 @Mojo(name = "extract-connector-descriptors", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
@@ -111,7 +108,7 @@ public class ExtractConnectorDescriptorsMojo extends AbstractMojo {
                 try {
                     classLoader.close();
                 } catch (IOException ignored) {
-
+                  // ignored
                 }
             }
         }

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/IntegrationPublishValidator.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/IntegrationPublishValidator.java
@@ -28,10 +28,6 @@ import io.syndesis.server.dao.manager.DataManager;
 import io.syndesis.server.openshift.OpenShiftService;
 import org.springframework.stereotype.Component;
 
-/**
- * @author roland
- * @since 2019-02-11
- */
 @Component
 public class IntegrationPublishValidator {
 
@@ -68,7 +64,6 @@ public class IntegrationPublishValidator {
 
     /**
      * Count the deployments of the owner of the specified integration.
-     *
      * @param deployment The specified IntegrationDeployment.
      * @return The number of deployed integrations (excluding the current).
      */
@@ -90,7 +85,6 @@ public class IntegrationPublishValidator {
 
     /**
      * Counts active integrations (in DB) of the owner of the specified integration.
-     *
      * @param deployment The specified IntegrationDeployment.
      * @return The number of integrations (excluding the current).
      */

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1Applicator.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth1Applicator.java
@@ -21,6 +21,7 @@ import io.syndesis.common.model.connection.Connection;
 
 import org.springframework.social.oauth1.OAuthToken;
 
+@SuppressWarnings("JavaUtilDate") // TODO refactor
 public class OAuth1Applicator implements Applicator<OAuthToken> {
 
     private String accessTokenSecretProperty;

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2Applicator.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2Applicator.java
@@ -32,6 +32,7 @@ import org.springframework.social.oauth2.AccessGrant;
  * {@code camel.component.salesforce.clientSecret} properties on the Salesforce
  * connector.
  */
+@SuppressWarnings("JavaUtilDate") // TODO refactor
 public class OAuth2Applicator implements Applicator<AccessGrant> {
 
     private String accessTokenExpiresAtProperty;

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/OAuth2CredentialProvider.java
@@ -15,15 +15,12 @@
  */
 package io.syndesis.server.credential;
 
+import io.syndesis.common.model.connection.Connection;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
-
-import io.syndesis.common.model.connection.Connection;
-
 import org.springframework.social.connect.support.OAuth2ConnectionFactory;
 import org.springframework.social.oauth2.AccessGrant;
 import org.springframework.social.oauth2.OAuth2Operations;
@@ -57,7 +54,7 @@ public final class OAuth2CredentialProvider<S> extends BaseCredentialProvider {
         this.applicator = applicator;
         this.configured = configured;
         this.additionalQueryParameters = additionalQueryParameters.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> Collections.singletonList(e.getValue())));
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> Collections.singletonList(e.getValue())));
     }
 
     @Override

--- a/app/server/credential/src/main/java/io/syndesis/server/credential/SocialProperties.java
+++ b/app/server/credential/src/main/java/io/syndesis/server/credential/SocialProperties.java
@@ -18,7 +18,6 @@ package io.syndesis.server.credential;
 
 /**
  * Basic configuration properties for spring social.
- *
  * Taken from https://docs.spring.io/spring-boot/docs/2.0.0.M3/api/org/springframework/boot/autoconfigure/social/SocialProperties.html
  * as temporary solution in order to align our code with newer Spring Boot versions.
  */

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/audit/AuditEvent.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/audit/AuditEvent.java
@@ -61,7 +61,7 @@ public final class AuditEvent {
             return false;
         }
         final AuditEvent that = (AuditEvent) o;
-        return Objects.equals(hashCode(), that.hashCode()) &&
+        return hashCode() == that.hashCode() &&
             Objects.equals(type, that.type) &&
             Objects.equals(property, that.property) &&
             Objects.equals(previous, that.previous) &&

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/audit/AuditRecord.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/audit/AuditRecord.java
@@ -72,7 +72,7 @@ public final class AuditRecord {
             return false;
         }
         final AuditRecord that = (AuditRecord) o;
-        return Objects.equals(hashCode(), that.hashCode()) &&
+        return hashCode() == that.hashCode() &&
             Objects.equals(id, that.id) &&
             Objects.equals(type, that.type) &&
             Objects.equals(name, that.name) &&

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/file/FileDAO.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/file/FileDAO.java
@@ -21,12 +21,9 @@ public interface FileDAO {
 
     /**
      * Write a file on a path.
-     *
      * The path must be absolute (e.g. "/path/to/file.zip").
-     *
      * If a file already exists it is overwritten.
      * Parent directories are created automatically.
-     *
      * @param path the destination path
      * @param file the content of the file
      */
@@ -34,9 +31,7 @@ public interface FileDAO {
 
     /**
      * Write a file on a temporary path.
-     *
      * The path wil be decided by the file store and returned to the client.
-     *
      * @param file the content of the file
      * @return the path created for the file
      */
@@ -44,9 +39,7 @@ public interface FileDAO {
 
     /**
      * Read a file from a path.
-     *
      * The path must be absolute (e.g. "/path/to/file.zip").
-     *
      * @param path the path to read
      * @return the file content or null if the file is not present
      */
@@ -54,9 +47,7 @@ public interface FileDAO {
 
     /**
      * Delete a file corresponding to a path.
-     *
      * The path must be absolute (e.g. "/path/to/file.zip").
-     *
      * @param path the path to the file to delete
      * @return true if the file existed before deleting
      */
@@ -64,13 +55,10 @@ public interface FileDAO {
 
     /**
      * Moves a file from a source path to a destination path.
-     *
      * Both paths must be absolute (e.g. "/path/to/file.zip").
-     *
      * If a file already exists in the destination path, it is overwritten.
      * If the source file does not exist, the operation is cancelled and the
      * destination file (if present) is left unchanged.
-     *
      * @param fromPath the source path
      * @param toPath the destination path
      * @return true if the source file existed before moving it

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/init/ReadApiClientData.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/init/ReadApiClientData.java
@@ -51,14 +51,6 @@ public class ReadApiClientData {
         this.encryptionComponent = encryptionComponent;
     }
 
-    /**
-     *
-     * @param fileName
-     * @return
-     * @throws JsonParseException
-     * @throws JsonMappingException
-     * @throws IOException
-     */
     public List<ModelData<?>> readDataFromFile(String fileName) throws JsonParseException, JsonMappingException, IOException {
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
             if (is==null) {
@@ -85,7 +77,6 @@ public class ReadApiClientData {
     /**
      * Finds tokens surrounded by "@" signs (for example @POSTGRESQL_SAMPLEDB_PASSWORD@) and replaces them
      * with values from System.env if a value is set in the environment.
-     *
      * @param jsonText - String containing tokens
      * @param env - containing tokens
      * @return String with tokens resolved from env

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataAccessObject.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataAccessObject.java
@@ -24,14 +24,15 @@ import io.syndesis.common.model.WithId;
 public interface DataAccessObject<T extends WithId<T>> {
 
     /**
-     * @return true if this object cannot be used to create/update entities.
+     * Returns true if this object cannot be used to create/update entities.
+     * @return true if the object is readonly
      */
     default boolean isReadOnly() {
         return false;
     }
 
     /**
-     * @return The Type of entity it supports.
+     * The Type of entity it supports.
      */
     Class<T> getType();
 
@@ -44,7 +45,6 @@ public interface DataAccessObject<T extends WithId<T>> {
 
     /**
      * Fetches all ids that have the specified property with the given value.
-     *
      * @param property      The name of the property.
      * @param propertyValue The value of the property.
      * @return              All identifiers with specified property and value combination.
@@ -53,7 +53,6 @@ public interface DataAccessObject<T extends WithId<T>> {
 
     /**
      * Fetches all ids.
-     *
      * @return All identifiers
      */
     Set<String> fetchIds();
@@ -93,7 +92,6 @@ public interface DataAccessObject<T extends WithId<T>> {
     /**
      * Creates or Updates the specified entity.
      * @param entity    The entity.
-     * @return          The previous value or null.
      */
     default void set(T entity) {
         T fetched = fetch(entity.getId().get());
@@ -118,7 +116,6 @@ public interface DataAccessObject<T extends WithId<T>> {
      * @return          True on successful deletion, false otherwise.
      */
     boolean delete(String id);
-
 
     default void deleteAll() {
         fetchAll().forEach(this::delete);

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/EncryptionComponent.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/EncryptionComponent.java
@@ -31,7 +31,6 @@ import org.springframework.stereotype.Component;
 
 /**
  * Handy methods used to apply encryption to configured secrets.
- *
  */
 @Component
 public class EncryptionComponent {

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/IdPrefixFilter.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/IdPrefixFilter.java
@@ -24,7 +24,6 @@ import io.syndesis.common.model.WithResourceId;
 
 /**
  * Filters the by id prefix.
- *
  * @param <T> The type of the elements in the filtered list.
  */
 public final class IdPrefixFilter<T extends WithResourceId> implements Function<ListResult<T>, ListResult<T>> {
@@ -33,7 +32,6 @@ public final class IdPrefixFilter<T extends WithResourceId> implements Function<
 
     /**
      * Creates the filter with the specified prefix filter.
-     *
      * @param prefix the prefix to match
      */
     public IdPrefixFilter(String prefix) {
@@ -42,7 +40,6 @@ public final class IdPrefixFilter<T extends WithResourceId> implements Function<
 
     /**
      * Applies the filter to the provided list.
-     *
      * @param result The result to filter.
      * @return  all entries with ids that start with specified prefix
      */

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/ReverseFilter.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/ReverseFilter.java
@@ -25,7 +25,6 @@ import io.syndesis.common.model.WithResourceId;
 
 /**
  * Reverse the elements in the list.
- *
  * @param <T> The type of the elements in the filtered list.
  */
 public final class ReverseFilter<T extends WithResourceId> implements Function<ListResult<T>, ListResult<T>> {

--- a/app/server/dao/src/test/java/io/syndesis/server/dao/DeploymentDescriptorIT.java
+++ b/app/server/dao/src/test/java/io/syndesis/server/dao/DeploymentDescriptorIT.java
@@ -15,12 +15,17 @@
  */
 package io.syndesis.server.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
@@ -28,11 +33,6 @@ import java.util.Spliterators;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.catalog.connector.CamelConnectorCatalog;
@@ -40,9 +40,6 @@ import org.apache.camel.catalog.connector.DefaultCamelConnectorCatalog;
 import org.apache.camel.catalog.maven.DefaultMavenArtifactProvider;
 import org.apache.camel.catalog.maven.MavenArtifactProvider;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Downloads all connectors defined in {@code deployment.json} and tries to
@@ -138,7 +135,7 @@ public class DeploymentDescriptorIT {
 
         final Map<String, Long> multipleCoordinates = coordinatesWithCount.entrySet().stream()
             .filter(e -> e.getValue() > 1)
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         assertThat(multipleCoordinates).as("Expected connector GAV coordinates to be unique").isEmpty();
     }
@@ -151,7 +148,7 @@ public class DeploymentDescriptorIT {
             .map(action -> action.get("name").asText()).collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
         final Map<String, Long> multipleNames = namesWithCount.entrySet().stream().filter(e -> e.getValue() > 1)
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         assertThat(multipleNames).as("Expected unique action names").isEmpty();
     }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/PaginationFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/PaginationFilter.java
@@ -23,7 +23,6 @@ import io.syndesis.common.model.ListResult;
 
 /**
  * Filters the list with the provided pagination options.
- *
  * @param <T> The type of the elements in the filtered list.
  */
 public class PaginationFilter<T> implements Function<ListResult<T>, ListResult<T>> {
@@ -33,7 +32,6 @@ public class PaginationFilter<T> implements Function<ListResult<T>, ListResult<T
 
     /**
      * Creates the filter with the specified pagination options.
-     *
      * @param options The pagination options. Note that page and per_page must both be greater than 0.
      * @throws IllegalArgumentException If page or perPage are less than 1.
      */
@@ -50,7 +48,6 @@ public class PaginationFilter<T> implements Function<ListResult<T>, ListResult<T
 
     /**
      * Applies the filter to the provided list.
-     *
      * @param result The result to filter.
      * @return The relevant page of the provided list. Returns an empty list if the requested page would be outside of the provided list range.
      */

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/PaginationOptions.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/util/PaginationOptions.java
@@ -21,14 +21,12 @@ package io.syndesis.server.endpoint.util;
 public interface PaginationOptions {
 
     /**
-     *
-     * @return The requested page number.
+     * Returns the requested page number.
      */
     int getPage();
 
     /**
-     *
-     * @return The requested number per page.
+     * Returns the requested number of entries per page.
      */
     int getPerPage();
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/CacheFor.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/CacheFor.java
@@ -30,12 +30,12 @@ import java.util.concurrent.TimeUnit;
 public @interface CacheFor {
 
     /**
-     * @return The amount of time to cache this resource.
+     * The amount of time to cache this resource.
      */
     long value();
 
     /**
-     * @return The {@link TimeUnit} for the given {@link #value()}.
+     * The {@link TimeUnit} for the given {@link #value()}.
      */
     TimeUnit unit() default TimeUnit.SECONDS;
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/CacheForFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/CacheForFilter.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * This filter will set the Cache-Control header depending on if and what the
- * @CacheFor annotation is configured with.  When not set, it disables response caching.
+ * {@link CacheFor} annotation is configured with.  When not set, it disables response caching.
  */
 @Provider
 @Service

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Meta.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Meta.java
@@ -15,12 +15,9 @@
  */
 package io.syndesis.server.endpoint.v1.dto;
 
-import java.util.Collections;
-
-import io.syndesis.server.endpoint.v1.dto.MetaData.Type;
-import io.syndesis.server.endpoint.v1.handler.exception.Errors;
-
 import com.netflix.hystrix.HystrixInvokableInfo;
+import io.syndesis.server.endpoint.v1.handler.exception.Errors;
+import java.util.Collections;
 
 public final class Meta<T> extends Mixed {
 
@@ -68,11 +65,11 @@ public final class Meta<T> extends Mixed {
     public static <V> Meta<V> withError(final V value, final Throwable throwable) {
         final String message = Errors.userMessageFrom(throwable);
 
-        return new Meta<>(value, ImmutableMetaData.builder().type(Type.DANGER).message(message).build());
+        return new Meta<>(value, ImmutableMetaData.builder().type(MetaData.Type.DANGER).message(message).build());
     }
 
     public static <V> Meta<V> withWarning(final V value, final String message) {
-        return new Meta<>(value, ImmutableMetaData.builder().type(Type.WARNING).message(message).build());
+        return new Meta<>(value, ImmutableMetaData.builder().type(MetaData.Type.WARNING).message(message).build());
     }
 
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/MetaData.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/MetaData.java
@@ -21,10 +21,6 @@ import javax.ws.rs.core.Response.Status;
 
 import org.immutables.value.Value;
 
-/**
- * @author roland
- * @since 07.03.18
- */
 @Value.Immutable
 public interface MetaData {
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Mixed.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/dto/Mixed.java
@@ -39,7 +39,7 @@ abstract class Mixed {
 
             private int level;
 
-            public EnclosedJsonGenerator(final JsonGenerator d) {
+            EnclosedJsonGenerator(final JsonGenerator d) {
                 super(d);
             }
 
@@ -82,7 +82,7 @@ abstract class Mixed {
 
     }
 
-    public Mixed(final Object... parts) {
+    Mixed(final Object... parts) {
         this.parts = Arrays.asList(parts);
     }
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Activity.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Activity.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
-/**
- */
 public class Activity {
 
     private String id;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/ActivityStep.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/ActivityStep.java
@@ -20,8 +20,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/**
- */
 public class ActivityStep {
     private String id;
     private Long at;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/ActivityTrackingService.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/ActivityTrackingService.java
@@ -18,9 +18,6 @@ package io.syndesis.server.endpoint.v1.handler.activity;
 import java.io.IOException;
 import java.util.List;
 
-/**
- *
- */
 public interface ActivityTrackingService {
     List<Activity> getActivities(String integrationId, String from, Integer limit) throws IOException;
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Feature.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/activity/Feature.java
@@ -15,8 +15,6 @@
  */
 package io.syndesis.server.endpoint.v1.handler.activity;
 
-/**
- */
 public class Feature {
     private boolean enabled;
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/atlas/SyndesisJavaService.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/atlas/SyndesisJavaService.java
@@ -35,10 +35,6 @@ public class SyndesisJavaService extends JavaService {
 
     /**
      * Stub out mavenclasspath processing for now.
-     *
-     * @param request
-     * @return
-     * @throws Exception
      */
     @Override
     @POST

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -143,6 +143,7 @@ public class ConnectionHandler
     }
 
     @Override
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public Connection create(@Context SecurityContext sec, final Connection connection) {
         final Date rightNow = new Date();
 
@@ -201,6 +202,7 @@ public class ConnectionHandler
     }
 
     @Override
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public void update(final String id, final Connection connection) {
         // Lets make sure we store encrypt secrets.
         Map<String, String> configuredProperties = connection.getConfiguredProperties();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
@@ -149,8 +149,6 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     /**
      * Query metadata to retrieve any dynamic property provided by the connector
      * and merge the result into the {@link Connector} returned value
-     *
-     * @param connector
      * @return an enriched {@link Connector}
      */
     Connector enrichConnectorWithDynamicProperties(Connector connector) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
@@ -210,7 +210,7 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
     @Path(value = "/{connectorId}/actions/{actionId}/filters/options")
     public FilterOptions getFilterOptions(@PathParam("connectorId") @Parameter(required = true) final String connectorId,
                                           @PathParam("actionId") @Parameter(required = true) final String actionId) {
-        final FilterOptions.Builder builder = new FilterOptions.Builder().addOps(Op.DEFAULT_OPTS);
+        final FilterOptions.Builder builder = new FilterOptions.Builder().addOps(Op.values());
         final Connector connector = getDataManager().fetch(Connector.class, connectorId);
 
         if (connector == null) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorTemplateHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorTemplateHandler.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 public final class ConnectorTemplateHandler extends BaseHandler
     implements Lister<ConnectorTemplate>, Getter<ConnectorTemplate> {
 
-    protected ConnectorTemplateHandler(final DataManager dataMgr) {
+    ConnectorTemplateHandler(final DataManager dataMgr) {
         super(dataMgr);
     }
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/environment/EnvironmentHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/environment/EnvironmentHandler.java
@@ -228,6 +228,7 @@ public class EnvironmentHandler extends BaseHandler {
         return tagForRelease(integrationId, environments, false);
     }
 
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public static ContinuousDeliveryEnvironment createOrUpdateTag(Map<String, ContinuousDeliveryEnvironment> deliveryState,
                                                                   String environmentId, Date lastTaggedAt) {
 
@@ -255,6 +256,7 @@ public class EnvironmentHandler extends BaseHandler {
                 .orElseThrow(() -> new ClientErrorException("Missing environment " + environment, Response.Status.NOT_FOUND));
     }
 
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public void updateCDEnvironments(List<Integration> integrations, String environmentId, Date taggedAt,
                                      Function<ContinuousDeliveryEnvironment.Builder, ContinuousDeliveryEnvironment.Builder> operator) {
         integrations.forEach(i -> {
@@ -265,6 +267,7 @@ public class EnvironmentHandler extends BaseHandler {
         });
     }
 
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     private Map<String, ContinuousDeliveryEnvironment> tagForRelease(String integrationId, List<String> environments,
                                                                      boolean deleteOtherTags) {
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/exception/ErrorMap.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/exception/ErrorMap.java
@@ -35,8 +35,6 @@ public final class ErrorMap {
 
     /**
      * Performs best effort to parse the rawMsg. If all parsers fail it returns the raw message.
-     *
-     * @param rawMsg
      * @return the underlying error message.
      */
     public static String from(String rawMsg) {
@@ -52,7 +50,6 @@ public final class ErrorMap {
     /**
      * Tries to parse the rawMsg assuming it is JSON formatted.
      * defaults to the rawMsg if parsing fails.
-     * @param rawMsg
      * @return ErrorMap
      */
     static String parseWith(String rawMsg, ObjectMapper mapper) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionActivator.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionActivator.java
@@ -50,6 +50,7 @@ public class ExtensionActivator {
         this.verifier = verifier;
     }
 
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public void activateExtension(Extension extension) {
         Date rightNow = new Date();
 
@@ -89,6 +90,7 @@ public class ExtensionActivator {
         }
     }
 
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     private void doDelete(Extension extension) {
         Date rightNow = new Date();
         dataManager.update(new Extension.Builder()

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/extension/ExtensionHandler.java
@@ -128,7 +128,7 @@ public class ExtensionHandler extends BaseHandler implements Getter<Extension>, 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    @SuppressWarnings("PMD.CyclomaticComplexity")
+    @SuppressWarnings({"PMD.CyclomaticComplexity","JavaUtilDate"}) // TODO refactor
     public Extension upload(MultipartFormDataInput dataInput, @Context SecurityContext sec, @QueryParam("updatedId") String updatedId) {
         Date rightNow = new Date();
         String id = KeyGenerator.createKey();

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandler.java
@@ -204,6 +204,7 @@ public class PublicApiHandler {
     @GET
     @Path("integrations/{env}/export.zip")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public Response exportResources(@NotNull @PathParam("env") @Parameter(required = true) String environment,
                                     @QueryParam("all") @Parameter boolean exportAll,
                                     @QueryParam("ignoreTimestamp") @Parameter boolean ignoreTimestamp) throws IOException {
@@ -281,6 +282,7 @@ public class PublicApiHandler {
     @Path("integrations")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public ContinuousDeliveryImportResults importResources(@Context SecurityContext sec,
         @NotNull @MultipartForm @Parameter(required = true) ImportFormDataInput formInput) {
 
@@ -351,6 +353,7 @@ public class PublicApiHandler {
     @Path("connections/{id}/properties")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public ConnectionOverview configureConnection(@Context SecurityContext sec,
                                                   @NotNull @PathParam("id") @Parameter(required = true) String connectionId,
                                                   @NotNull @QueryParam("refreshIntegrations") @Parameter Boolean refeshIntegrations,
@@ -393,6 +396,7 @@ public class PublicApiHandler {
     @PUT
     @Path("integrations/{id}/deployments/stop")
     @Produces(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public void stopIntegration(@Context final SecurityContext sec, @NotNull @PathParam("id") @Parameter(required = true) final String integrationId) {
 
         final Integration integration = getIntegration(integrationId);

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandler.java
@@ -182,7 +182,6 @@ public class IntegrationDeploymentHandler extends BaseHandler {
     /**
      * Count the deployments of the owner of the specified integration.
      *
-     * @param deployment The specified IntegrationDeployment.
      * @return The number of deployed integrations (excluding the current).
      */
     private int countDeployments(String integrationId, String username) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -144,7 +144,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     @Produces(MediaType.APPLICATION_JSON)
     @Path(value = "/filters/options")
     public FilterOptions getFilterOptions(final DataShape dataShape) {
-        final FilterOptions.Builder builder = new FilterOptions.Builder().addOps(Op.DEFAULT_OPTS);
+        final FilterOptions.Builder builder = new FilterOptions.Builder().addOps(Op.values());
 
         final List<String> paths = inspectors.getPaths(dataShape.getKind().toString(), dataShape.getType(),
             dataShape.getSpecification(), dataShape.getExemplar());
@@ -156,7 +156,7 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     @Produces(MediaType.APPLICATION_JSON)
     @Path(value = "/filters/options")
     public FilterOptions getGlobalFilterOptions() {
-        return new FilterOptions.Builder().addOps(Op.DEFAULT_OPTS).build();
+        return new FilterOptions.Builder().addOps(Op.values()).build();
     }
 
     public Integration getIntegration(final String id) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/UpdatesHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/UpdatesHelper.java
@@ -130,14 +130,12 @@ final class UpdatesHelper {
 
     /*
      * https://github.com/syndesisio/syndesis/issues/2247
-     *
      * When the UI ask for an integration its component (connector, extensions,
      * etc) are updated and moved to their latest version and this work just
      * fine for static actions. For dynamic action (for which metadata is
      * retrieved from the syndesis-meta service), this is problematic as the
      * action is replaced with its latest version thus all the enriched data are
      * lost.
-     *
      * This _ UGLY _ hack tries to merge old and new actions but it does not
      * take into account properties that may have updated, so if a new property
      * has i.e. new default values, the new default is not taken into account

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandler.java
@@ -34,9 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
-/**
- * @author Christoph Deppisch
- */
 class AggregateMetadataHandler implements StepMetadataHandler {
 
     private static final String JSON_SCHEMA_ORG_SCHEMA = "http://json-schema.org/schema#";
@@ -231,10 +228,6 @@ class AggregateMetadataHandler implements StepMetadataHandler {
      * Converts unified Json body specification. Unified Json schema specifications hold
      * the actual body specification in a property. This method converts this body specification
      * from array to single element if necessary.
-     *
-     * @param specification
-     * @return
-     * @throws IOException
      */
     private static String adaptUnifiedJsonBodySpecToSingleElement(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);
@@ -256,10 +249,6 @@ class AggregateMetadataHandler implements StepMetadataHandler {
      * Converts unified Json body specification. Unified Json schema specifications hold
      * the actual body specification in a property. This method converts this body specification
      * from single element to collection if necessary.
-     *
-     * @param specification
-     * @return
-     * @throws IOException
      */
     private static String adaptUnifiedJsonBodySpecToCollection(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandler.java
@@ -23,9 +23,6 @@ import io.syndesis.common.model.connection.DynamicActionMetadata;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 
-/**
- * @author Christoph Deppisch
- */
 class ChoiceMetadataHandler implements StepMetadataHandler {
 
     @Override

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandler.java
@@ -34,9 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
-/**
- * @author Christoph Deppisch
- */
 class SplitMetadataHandler implements StepMetadataHandler {
 
     /** Logger */
@@ -161,10 +158,6 @@ class SplitMetadataHandler implements StepMetadataHandler {
     /**
      * Extract unified Json body specification from data shape specification. Unified Json schema specifications hold
      * the actual body specification in a property. This method extracts this property as new body specification.
-     *
-     * @param specification
-     * @return
-     * @throws IOException
      */
     private static String extractUnifiedJsonBodySpec(String specification) throws IOException {
         JsonSchema schema = JsonSchemaUtils.reader().readValue(specification);

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHandler.java
@@ -22,15 +22,10 @@ import io.syndesis.common.model.connection.DynamicActionMetadata;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.common.model.integration.StepKind;
 
-/**
- * @author Christoph Deppisch
- */
 interface StepMetadataHandler {
 
     /**
      * Adapt dynamic meta data for given step descriptor;
-     * @param metadata
-     * @return
      */
     default DynamicActionMetadata handle(DynamicActionMetadata metadata) {
         return metadata;
@@ -38,7 +33,6 @@ interface StepMetadataHandler {
 
     /**
      * Determine if this handler can handle the specific step kind.
-     * @param kind
      */
     default boolean canHandle(StepKind kind) {
         return false;
@@ -47,10 +41,6 @@ interface StepMetadataHandler {
     /**
      * Creates dynamic metadata for given step. Is provided with list of previous steps and list of subsequent steps in order
      * to adopt data shapes of these in dynamic metadata.
-     * @param step
-     * @param previousSteps
-     * @param subsequentSteps
-     * @return
      */
     default DynamicActionMetadata createMetadata(Step step, List<Step> previousSteps, List<Step> subsequentSteps) {
         return DynamicActionMetadata.NOTHING;

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/meta/StepMetadataHelper.java
@@ -26,9 +26,6 @@ import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.DataShapeMetaData;
 import io.syndesis.common.model.integration.Step;
 
-/**
- * @author Christoph Deppisch
- */
 final class StepMetadataHelper {
 
     static final DataShape ANY_SHAPE = new DataShape.Builder().kind(DataShapeKinds.ANY).name("Any shape").build();
@@ -95,8 +92,6 @@ final class StepMetadataHelper {
 
     /**
      * Checks if given shape is a unified Json schema shape.
-     * @param dataShape
-     * @return
      */
     static boolean isUnifiedJsonSchemaShape(DataShape dataShape) {
         if (dataShape.getKind() == DataShapeKinds.JSON_SCHEMA) {

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthApp.java
@@ -15,26 +15,22 @@
  */
 package io.syndesis.server.endpoint.v1.handler.setup;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedSet;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
 import io.syndesis.common.model.WithId;
 import io.syndesis.common.model.WithName;
 import io.syndesis.common.model.WithProperties;
 import io.syndesis.common.model.connection.ConfigurationProperty;
 import io.syndesis.common.model.connection.Connector;
 import io.syndesis.server.credential.Credentials;
-
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -54,10 +50,10 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
     class Builder extends ImmutableOAuthApp.Builder {
 
         Builder withTaggedPropertyFrom(final Connector connector, final String tag) {
-            final Optional<Entry<String, ConfigurationProperty>> maybeProperty = connector.propertyEntryTaggedWith(tag);
+            final Optional<Map.Entry<String, ConfigurationProperty>> maybeProperty = connector.propertyEntryTaggedWith(tag);
 
             if (maybeProperty.isPresent()) {
-                final Entry<String, ConfigurationProperty> property = maybeProperty.get();
+                final Map.Entry<String, ConfigurationProperty> property = maybeProperty.get();
 
                 final ConfigurationProperty configuration = property.getValue();
                 if ("hidden".equals(configuration.getType())) {
@@ -82,7 +78,7 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
         final Map<String, String> current = getConfiguredProperties();
         final Map<String, String> replacement = new HashMap<>();
 
-        for (final Entry<String, ConfigurationProperty> property : getProperties().entrySet()) {
+        for (final Map.Entry<String, ConfigurationProperty> property : getProperties().entrySet()) {
             final ConfigurationProperty configurationProperty = property.getValue();
             final SortedSet<String> tags = configurationProperty.getTags();
 
@@ -122,10 +118,10 @@ public interface OAuthApp extends WithId<OAuthApp>, WithName, WithProperties {
         final Map<String, String> updated = new HashMap<>(current);
 
         for (final String tag : OAUTH_TAGS) {
-            final Optional<Entry<String, ConfigurationProperty>> maybeProperty = connector.propertyEntryTaggedWith(tag);
+            final Optional<Map.Entry<String, ConfigurationProperty>> maybeProperty = connector.propertyEntryTaggedWith(tag);
 
             if (maybeProperty.isPresent()) {
-                final Entry<String, ConfigurationProperty> property = maybeProperty.get();
+                final Map.Entry<String, ConfigurationProperty> property = maybeProperty.get();
                 final ConfigurationProperty propertyDefinition = property.getValue();
                 final String propertyName = property.getKey();
 

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserConfigurationProperties.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserConfigurationProperties.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Let's grab the settings from the 'controllers' section, since
  * they are already defined there.
- *
  */
 @Configuration
 @ConfigurationProperties("controllers")

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/user/UserHandler.java
@@ -92,8 +92,6 @@ public class UserHandler extends BaseHandler implements Lister<User>, Getter<Use
 
     /**
      * Counts active integrations (in DB) of the owner of the specified integration.
-     *
-     * @param deployment The specified IntegrationDeployment.
      * @return The number of integrations (excluding the current).
      */
     private int countActiveIntegrations(String username) {
@@ -107,7 +105,6 @@ public class UserHandler extends BaseHandler implements Lister<User>, Getter<Use
 
     /**
      * Count the deployments of the owner of the specified integration.
-     *
      * @param username The specified user
      * @return The number of deployed integrations.
      */

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/PaginationOptionsFromQueryParams.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/operations/PaginationOptionsFromQueryParams.java
@@ -60,7 +60,6 @@ public class PaginationOptionsFromQueryParams implements PaginationOptions {
     }
 
     /**
-     *
      * @return The requested page number.
      */
     @Override
@@ -69,7 +68,6 @@ public class PaginationOptionsFromQueryParams implements PaginationOptions {
     }
 
     /**
-     *
      * @return The requested number per page.
      */
     @Override

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/util/ReflectiveSorterTest.java
@@ -26,10 +26,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * @author roland
- * @since 13/12/16
- */
 public class ReflectiveSorterTest {
 
     @Test

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
@@ -411,6 +411,7 @@ public class PublicApiHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("JavaUtilDate") // TODO refactor
     public void testPatchTagsForRelease() throws Exception {
         final DataManager dataManager = mock(DataManager.class);
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/AggregateMetadataHandlerTest.java
@@ -37,9 +37,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.StringUtils;
 
-/**
- * @author Christoph Deppisch
- */
 public class AggregateMetadataHandlerTest {
 
     private final AggregateMetadataHandler metadataHandler = new AggregateMetadataHandler();

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/ChoiceMetadataHandlerTest.java
@@ -28,9 +28,6 @@ import io.syndesis.common.model.integration.StepKind;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class ChoiceMetadataHandlerTest {
 
     private final ChoiceMetadataHandler metadataHandler = new ChoiceMetadataHandler();

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/Person.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/Person.java
@@ -16,17 +16,12 @@
 
 package io.syndesis.server.endpoint.v1.handler.meta;
 
-/**
- * @author Christoph Deppisch
- */
 class Person {
     private String name;
     private int age;
 
     /**
      * Obtains the name.
-     *
-     * @return
      */
     public String getName() {
         return name;
@@ -34,8 +29,6 @@ class Person {
 
     /**
      * Specifies the name.
-     *
-     * @param name
      */
     public void setName(String name) {
         this.name = name;
@@ -43,8 +36,6 @@ class Person {
 
     /**
      * Obtains the age.
-     *
-     * @return
      */
     public int getAge() {
         return age;
@@ -52,8 +43,6 @@ class Person {
 
     /**
      * Specifies the age.
-     *
-     * @param age
      */
     public void setAge(int age) {
         this.age = age;

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/meta/SplitMetadataHandlerTest.java
@@ -38,9 +38,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.StringUtils;
 
-/**
- * @author Christoph Deppisch
- */
 public class SplitMetadataHandlerTest {
 
     private final SplitMetadataHandler metadataHandler = new SplitMetadataHandler();

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/support/RegexBasedMasqueradeReaderTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/support/RegexBasedMasqueradeReaderTest.java
@@ -23,10 +23,6 @@ import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * @author roland
- * @since 29.08.17
- */
 public class RegexBasedMasqueradeReaderTest {
     @Test
     public void basicFilter() throws IOException {

--- a/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
+++ b/app/server/filestore/src/main/java/io/syndesis/server/filestore/impl/SqlFileStore.java
@@ -24,8 +24,11 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,6 +55,18 @@ public class SqlFileStore {
     enum DatabaseKind {
         PostgreSQL, H2, Apache_Derby
     }
+
+    private static final DateTimeFormatter FILE_DATE_FORMAT =  new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR, 4)
+        .appendLiteral('-')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+        .appendLiteral('-')
+        .appendValue(ChronoField.DAY_OF_MONTH, 2)
+        .appendLiteral('-')
+        .appendValue(ChronoField.HOUR_OF_DAY, 2)
+        .appendLiteral('-')
+        .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+        .toFormatter();
 
     private final DBI dbi;
 
@@ -309,8 +324,7 @@ public class SqlFileStore {
     }
 
     private static String newRandomTempFilePath() {
-        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.ROOT);
-        return "/tmp/" + fmt.format(new Date()) + "_" + UUID.randomUUID();
+        return "/tmp/" + LocalDateTime.now(ZoneOffset.UTC).format(FILE_DATE_FORMAT) + "_" + UUID.randomUUID();
     }
 
     private boolean tableExists(Handle h, String tableName) {

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/DataMapperBaseInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/DataMapperBaseInspector.java
@@ -161,7 +161,6 @@ abstract class DataMapperBaseInspector<T> implements Inspector {
      * Checks if the the specified class name is terminal (we can't further
      * expand the path). Examples of terminals are primitive, or java.lang
      * classes.
-     *
      * @param fullyQualifiedName The specified class name.
      * @return True if terminal, false otherwise.
      */

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/Inspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/Inspector.java
@@ -23,7 +23,6 @@ interface Inspector {
     /**
      * Collects recursively all possible 'path' of the given shape definition.
      * Each item in the path corresponds to fields, fields of fields and so on.
-     *
      * @param kind the kind of data shape
      * @param type the type of data shape
      * @param specification specification of data shape
@@ -34,7 +33,6 @@ interface Inspector {
 
     /**
      * Can this {@link Inspector} implementation support the given data shape.
-     *
      * @param kind the kind of data shape
      * @param type the type of data shape
      * @param specification specification of data shape

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonInstanceInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonInstanceInspector.java
@@ -29,9 +29,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/**
- * @author Christoph Deppisch
- */
 @Component
 public class JsonInstanceInspector implements Inspector {
 

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonSchemaInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/JsonSchemaInspector.java
@@ -15,18 +15,16 @@
  */
 package io.syndesis.server.inspector;
 
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import io.syndesis.common.util.json.schema.JsonSchemaUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-
-import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
-import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
-import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
-import io.syndesis.common.util.json.schema.JsonSchemaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -82,7 +80,7 @@ public class JsonSchemaInspector implements Inspector {
     }
 
     static void fetchPaths(final String context, final List<String> paths, final Map<String, JsonSchema> properties) {
-        for (final Entry<String, JsonSchema> entry : properties.entrySet()) {
+        for (final Map.Entry<String, JsonSchema> entry : properties.entrySet()) {
             final JsonSchema subschema = entry.getValue();
 
             String path;

--- a/app/server/inspector/src/main/java/io/syndesis/server/inspector/SpecificationClassInspector.java
+++ b/app/server/inspector/src/main/java/io/syndesis/server/inspector/SpecificationClassInspector.java
@@ -15,17 +15,15 @@
  */
 package io.syndesis.server.inspector;
 
-import java.io.IOException;
-import java.util.Map.Entry;
-import java.util.Optional;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.syndesis.common.util.json.JsonUtils;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 @Component
 public final class SpecificationClassInspector extends DataMapperBaseInspector<JsonNode> {
@@ -60,7 +58,7 @@ public final class SpecificationClassInspector extends DataMapperBaseInspector<J
     }
 
     private static JsonNode findClassNode(final String fullyQualifiedName, final JsonNode root) {
-        for (final Entry<String, JsonNode> pair : (Iterable<Entry<String, JsonNode>>) root::fields) {
+        for (final Map.Entry<String, JsonNode> pair : (Iterable<Map.Entry<String, JsonNode>>) root::fields) {
             final String fieldName = pair.getKey();
             final JsonNode value = pair.getValue();
 

--- a/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
+++ b/app/server/inspector/src/test/java/io/syndesis/server/inspector/JsonInstanceInspectorTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonInstanceInspectorTest {
 
     private static final String JSON_INSTANCE_KIND = "json-instance";

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/Filter.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/Filter.java
@@ -20,9 +20,6 @@ import java.util.Arrays;
 import io.syndesis.server.jsondb.impl.ChildFilter;
 import io.syndesis.server.jsondb.impl.LogicalFilter;
 
-/**
- *
- */
 public interface Filter {
 
     enum Op {

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/JsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/JsonDB.java
@@ -32,12 +32,14 @@ import java.util.function.Consumer;
 public interface JsonDB {
 
     /**
+     * Deltes entry on path.
      * @param path to the json object or value to delete
      * @return true if the object or value existed and was deleted.
      */
     boolean delete(String path);
 
     /**
+     * Checks if entry exists on path.
      * @param path to the json object or value to check if it exists
      * @return true if the object or value exists.
      */
@@ -52,7 +54,6 @@ public interface JsonDB {
     /**
      * Generates a sortable unique id as described at:
      * https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html
-     *
      * @return a sortable unique id
      */
     String createKey();
@@ -71,6 +72,7 @@ public interface JsonDB {
     }
 
     /**
+     * Reads path and returns the String of entries at that path.
      * @param path - the object or value to get
      * @param options options that control formatting of the result.
      * @return the json result or null if the path does not exist
@@ -86,7 +88,6 @@ public interface JsonDB {
     /**
      * Creates or Replaces the object or value at the given path
      * with the supplied json document.
-     *
      * @param path to the object or value to set
      * @param json value to set it to, can be a json primitive or struct
      */
@@ -95,6 +96,7 @@ public interface JsonDB {
     }
 
     /**
+     * Updates a path with the given JSON entry.
      * @param path to the object or value to set
      * @param json value to set it to, can be a json primitive or struct
      */
@@ -105,7 +107,6 @@ public interface JsonDB {
     /**
      * Pushes a new value to the the requested path.
      * Same as: {@code set( path + "/" + createKey(), json)}
-     *
      * @param path to the object or value to set
      * @param json value to set it to, can be a json primitive or struct
      * @return the field name that was added to the path object
@@ -171,10 +172,6 @@ public interface JsonDB {
 
     /**
      * If a non-null consumer is returned, it must be used to avoid leaking resources.
-     *
-     * @param path
-     * @param options
-     * @return
      */
     Consumer<OutputStream> getAsStreamingOutput(String path, GetOptions options);
 

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/JsonDbDao.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/JsonDbDao.java
@@ -40,7 +40,7 @@ import io.syndesis.server.jsondb.GetOptions;
 import io.syndesis.server.jsondb.JsonDB;
 
 /**
- * Implements a DataAccessObject using the {@see: JsonDB}.
+ * Implements a DataAccessObject using the {@see JsonDB}.
  */
 public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject<T> {
 

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/ChildFilter.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/ChildFilter.java
@@ -18,9 +18,6 @@ package io.syndesis.server.jsondb.impl;
 import io.syndesis.server.jsondb.Filter;
 import io.syndesis.common.model.ToJson;
 
-/**
- *
- */
 public class ChildFilter implements Filter, ToJson {
 
     private final String field;

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/LogicalFilter.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/LogicalFilter.java
@@ -20,9 +20,6 @@ import java.util.List;
 import io.syndesis.server.jsondb.Filter;
 import io.syndesis.common.model.ToJson;
 
-/**
- *
- */
 public class LogicalFilter implements Filter, ToJson {
 
     public enum Op {

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/SqlJsonDB.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/SqlJsonDB.java
@@ -72,7 +72,6 @@ import io.syndesis.server.jsondb.impl.expr.SqlExpressionBuilder;
 
 /**
  * Implements the JsonDB via DBI/JDBC
- *
  * Each value in the JSON tree is stored a simple record with the primary key being the
  * path to the value.
  */

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/expr/SqlExpressionBuilder.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/impl/expr/SqlExpressionBuilder.java
@@ -75,7 +75,7 @@ public abstract class SqlExpressionBuilder {
         }
     }
 
-    private static String toSqlOp(ChildFilter.Op op) {
+    private static String toSqlOp(Filter.Op op) {
         switch(op) {
             case EQ: return " = ";
             case NEQ: return " <> ";

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/ActivityTrackingController.java
@@ -151,8 +151,6 @@ public class ActivityTrackingController implements BackendController, Closeable 
 
     /**
      * TODO: push this into the jsondb API.
-     *
-     * @param path
      */
     int deleteKeepingRetention(String path) {
         return dbi.inTransaction((conn, status) -> {

--- a/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/KubernetesSupport.java
+++ b/app/server/logging/jsondb/src/main/java/io/syndesis/server/logging/jsondb/controller/KubernetesSupport.java
@@ -62,12 +62,10 @@ public class KubernetesSupport {
 
     /*
      * Feeds the controller of the given podName to the callback handler for processing.
-     *
      * We do this instead of using the watchLog() feature of the k8s client lib because it really sucks due to:
      *  1. You can't configure the timestamps option or the sinceTime option.  Need to resume log downloads.
      *  2. It seems to need extra threads..
      *  3. It might be hiding some of the http failure conditions.
-     *
      */
     protected void watchLog(String podName, Consumer<InputStream> handler, String sinceTime, Executor executor) throws IOException {
         try {

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/IntegrationMetricsHandler.java
@@ -52,8 +52,6 @@ public class IntegrationMetricsHandler {
 
     /**
      * Deletes metrics from delete integrations
-     *
-     * @param activeIntegrationIds
      */
     public void curate(Set<String> activeIntegrationIds) {
         Set<String> summaryIds = dataManager.fetchIds(IntegrationMetricsSummary.class);
@@ -67,11 +65,6 @@ public class IntegrationMetricsHandler {
     /**
      * Computes the IntegrationMetricsSummary from the RawMetrics available for the
      * current integration.
-     *
-     * @param integrationId
-     * @param metrics
-     * @param livePodIds
-     * @return
      */
     public IntegrationMetricsSummary compute(
             String integrationId,

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/JsonDBRawMetrics.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/JsonDBRawMetrics.java
@@ -74,11 +74,9 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
 
     /**
      * Obtains all RawMetrics entries in the DB for the current integration
-     *
      * @param integrationId - the integrationId for which we are obtaining the metrics
      * @return a Map containing all RawMetrics entries for the current integration,
      * the key is either HISTORY or the podName.
-     * @throws IOException
      */
     @Override
     public Map<String,RawMetrics> getRawMetrics(String integrationId) throws IOException {
@@ -96,11 +94,6 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
      * Adds the RawMetrics of dead pods to a special HISTORY bucket. Each
      * Integration should only have 1 HISTORY bucket and 1 bucket per live
      * pod.
-     *
-     * @param integrationId
-     * @param metrics
-     * @param livePodIds
-     * @throws IOException
      */
     @Override
     public void curate(
@@ -142,10 +135,6 @@ public class JsonDBRawMetrics implements RawMetricsHandler {
 
     /**
      * If Integrations get deleted we should also delete their metrics
-     *
-     * @param activeIntegrationIds
-     * @throws IOException
-     * @throws JsonMappingException
      */
     @Override
     public void curate(Set<String> activeIntegrationIds) throws IOException, JsonMappingException {

--- a/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/PodMetricsReader.java
+++ b/app/server/metrics/jsondb/src/main/java/io/syndesis/server/metrics/jsondb/PodMetricsReader.java
@@ -48,8 +48,6 @@ public class PodMetricsReader implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PodMetricsReader.class);
 
-    private static final String JOLOKIA_URL_FORMAT = "%sapi/v1/namespaces/%s/pods/https:%s:8778/proxy/jolokia/";
-
     private static final String ROUTE_ID = "RouteId";
     private static final String START_TIMESTAMP = "StartTimestamp";
     private static final String EXCHANGES_TOTAL = "ExchangesTotal";
@@ -144,8 +142,6 @@ public class PodMetricsReader implements Runnable {
      * Code borrowed from the DefaultCamelController: https://github.com/apache/camel/blob/master/platforms/commands/commands-jolokia/src/main/java/org/apache/camel/commands/jolokia/DefaultJolokiaCamelController.java
      * Slight modifications have been applied.
      * Credits to: Claus & Tomo
-     * @throws J4pException
-     * @throws MalformedObjectNameException
      */
     private ObjectName lookupCamelContext(String camelContextName) throws MalformedObjectNameException, J4pException {
         ObjectName on = cache.get(camelContextName);
@@ -228,13 +224,12 @@ public class PodMetricsReader implements Runnable {
 
     /**
      * Creates a {@link J4pClient} for the specified pod.
-     *
      * @param kubernetes The {@link KubernetesClient} instance.
      * @param pod        The name of the pod.
      * @return An instance of the {@link J4pClient}.
      */
     private static J4pClient forPod(KubernetesClient kubernetes, String pod) {
-        String jolokiaUrl = String.format(JOLOKIA_URL_FORMAT, kubernetes.getMasterUrl(), kubernetes.getNamespace(), pod);
+        String jolokiaUrl = String.format("%sapi/v1/namespaces/%s/pods/https:%s:8778/proxy/jolokia/", kubernetes.getMasterUrl(), kubernetes.getNamespace(), pod);
         try {
             return new J4pClientBuilder()
                 .url(jolokiaUrl)
@@ -250,7 +245,6 @@ public class PodMetricsReader implements Runnable {
 
     /**
      * Removes all leading and ending quotes (single and double) from the string
-     *
      * @param s  the string
      * @return the string without leading and ending quotes (single and double)
      */
@@ -273,7 +267,6 @@ public class PodMetricsReader implements Runnable {
 
     /**
      * Tests whether the value is <tt>null</tt> or an empty string.
-     *
      * @param value  the value, if its a String it will be tested for text length as well
      * @return true if empty
      */
@@ -283,7 +276,6 @@ public class PodMetricsReader implements Runnable {
 
     /**
      * Tests whether the value is <b>not</b> <tt>null</tt>, an empty string or an empty collection/map.
-     *
      * @param value  the value, if its a String it will be tested for text length as well
      * @return true if <b>not</b> empty
      */

--- a/app/server/metrics/jsondb/src/test/java/io/syndesis/server/metrics/jsondb/MetricsCollectorTest.java
+++ b/app/server/metrics/jsondb/src/test/java/io/syndesis/server/metrics/jsondb/MetricsCollectorTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -153,7 +152,7 @@ public class MetricsCollectorTest {
         assertThat(summary.getMessages()).isEqualTo(9);
         assertThat(summary.getErrors()).isEqualTo(3);
         //Oldest living pod
-        assertThat(summary.getStart().get()).isEqualTo(ZonedDateTime.of(2018, 01, 31, 10, 20, 56, 0, ZoneId.of("Z")).toInstant());
+        assertThat(summary.getStart().get()).isEqualTo(ZonedDateTime.of(2018, 01, 31, 10, 20, 56, 0, ZoneOffset.UTC).toInstant());
 
         //Update pod2, add 6 messages
         jsondb.update(JsonDBRawMetrics.path("intId1","pod2"), JsonUtils.writer().writeValueAsString(raw("intId1","2","pod2",9L,"31-01-2018 10:22:56")));
@@ -180,7 +179,7 @@ public class MetricsCollectorTest {
         assertThat(summary.getMessages()).isEqualTo(18);
         assertThat(summary.getErrors()).isEqualTo(3);
         //Oldest living pod is now pod2
-        assertThat(summary.getStart().get()).isEqualTo(ZonedDateTime.of(2018, 01, 31, 10, 22, 56, 0, ZoneId.of("Z")).toInstant());
+        assertThat(summary.getStart().get()).isEqualTo(ZonedDateTime.of(2018, 01, 31, 10, 22, 56, 0, ZoneOffset.UTC).toInstant());
 
         collector.close();
     }

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/QueryResult.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/QueryResult.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Query result from Prometheus HTTP API.
- * @author dhirajb
  */
 @Value.Immutable
 @SuppressWarnings("immutables")

--- a/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/Utils.java
+++ b/app/server/metrics/prometheus/src/main/java/io/syndesis/server/metrics/prometheus/Utils.java
@@ -36,8 +36,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * Catch all for utility methods.
- *
- * @author dhirajsb
  */
 public final class Utils {
 
@@ -64,6 +62,7 @@ public final class Utils {
         return OBJECT_READER;
     }
 
+    @SuppressWarnings("JavaUtilDate")
     public static class EpochMillisTimeModule extends SimpleModule {
         public EpochMillisTimeModule() {
             super();

--- a/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/DeploymentStateMonitor.java
+++ b/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/DeploymentStateMonitor.java
@@ -19,7 +19,6 @@ import io.syndesis.common.model.integration.IntegrationDeploymentState;
 
 /**
  * Interface to register {@link StateHandler}s with {@link DeploymentStateMonitorController}.
- * @author dhirajsb
  */
 public interface DeploymentStateMonitor {
     /**

--- a/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/DeploymentStateMonitorController.java
+++ b/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/DeploymentStateMonitorController.java
@@ -42,7 +42,6 @@ import java.util.stream.Stream;
 /**
  * Monitor Integrations based on their deployment state.
  * Used for PUBLISHING status updates. Can be utilized in the future for other purposes.
- * @author dhirajsb
  */
 @Service
 @ConditionalOnProperty(value = "features.monitoring.enabled", havingValue = "true")

--- a/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/PublishingStateMonitor.java
+++ b/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/PublishingStateMonitor.java
@@ -46,7 +46,6 @@ import static io.syndesis.common.model.monitoring.LinkType.LOGS;
 /**
  * Monitor Integrations based on their deployment state.
  * Used for PUBLISHING status updates. Can be utilized in the future for other purposes.
- * @author dhirajsb
  */
 @Service
 @ConditionalOnProperty(value = "features.monitoring.enabled", havingValue = "true")

--- a/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/StateHandler.java
+++ b/app/server/monitoring/src/main/java/io/syndesis/server/monitoring/StateHandler.java
@@ -22,7 +22,6 @@ import io.syndesis.common.model.integration.IntegrationDeployment;
 /**
  * Handles integration deployment states.
  * Primarily for publish/un-publish state detail tracking.
- * @author dhirajsb
  */
 public interface StateHandler extends Consumer<IntegrationDeployment> {
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftService.java
@@ -53,7 +53,6 @@ public interface OpenShiftService {
 
     /**
      * Start a previously created build with the data from the given directory
-     *
      * @param name name of the build
      * @param data the deployment data to use
      * @param tarInputStream input stream representing a tar file containing the project files
@@ -63,7 +62,6 @@ public interface OpenShiftService {
 
     /**
      * Perform a deployment
-     *
      * @param data the deployment data to use
      * @param name name of the deployment to trigger
      * @return the revision of the deployment.
@@ -72,7 +70,6 @@ public interface OpenShiftService {
 
     /**
      * Check whether a deployment is ready
-     *
      * @param name name of the deployment to check
      * @return true if deployment is ready, false otherwise
      */
@@ -101,7 +98,6 @@ public interface OpenShiftService {
 
     /**
      * Scale the deployment (Deployment and Build configurations, Image Streams etc)
-     *
      * @param name of the deployment to delete
      * @param labels a set of labels that need to be match.
      * @param desiredReplicas how many replicas to scale to
@@ -141,7 +137,6 @@ public interface OpenShiftService {
 
     /**
      * Returns the hostname exposed by Openshift for the integration, if any.
-     *
      * @param name the name of the route to check
      * @return a Optional containing the URL
      */
@@ -149,7 +144,6 @@ public interface OpenShiftService {
 
     /**
      * Create a Custom Resource Definition (CRD) given the Yaml definition as an InputStream
-     *
      * @param cdrYamlStream the CRD yaml definition as an {@link InputStream}
      * @return a List of {@link HasMetadata} as the operation result
      */
@@ -157,7 +151,6 @@ public interface OpenShiftService {
 
     /**
      * Create a Custom Resource Definition.
-     *
      * @param crd the {@link CustomResourceDefinition} to create
      * @return the {@link CustomResourceDefinition} created
      */
@@ -165,7 +158,6 @@ public interface OpenShiftService {
 
     /**
      * Get a Custom Resource Definition (CRD) given the Name
-     *
      * @param crdName the CRD name
      * @return an Optional containing the {@link CustomResourceDefinition}
      */
@@ -173,7 +165,6 @@ public interface OpenShiftService {
 
     /**
      * Delete the given CR.
-     *
      * @param <T>   The Kubernetes resource type.
      * @param <L>   The list variant of the Kubernetes resource type.
      * @param <D>   The doneable variant of the Kubernetes resource type.
@@ -189,7 +180,6 @@ public interface OpenShiftService {
 
     /**
      * Delete the given CR.
-     *
      * @param <T>   The Kubernetes resource type.
      * @param <L>   The list variant of the Kubernetes resource type.
      * @param <D>   The doneable variant of the Kubernetes resource type.
@@ -253,7 +243,7 @@ public interface OpenShiftService {
      * @param resourceType the type of T
      * @param resourceListType the type of L
      * @param doneableResourceType the type of D
-     * @param watcher a BiConsumer<Watcher.Action,T> function to be executed for each received Action on T
+     * @param watcher a {@code BiConsumer<Watcher.Action,T>} function to be executed for each received Action on T
      * @return the Watch
      */
     <T extends HasMetadata, L extends KubernetesResourceList<T>, D extends Doneable<T>> Watch watchCR(CustomResourceDefinition crd, Class<T> resourceType, Class<L> resourceListType, Class<D> doneableResourceType, BiConsumer<Watcher.Action,T> watcher);

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -692,8 +692,6 @@ public class OpenShiftServiceImpl implements OpenShiftService {
 
     /**
      * Checks if Excpetion can be retried and if retries are left.
-     * @param e
-     * @param retries
      */
     private static void checkRetryPolicy(KubernetesClientException e, int retries) {
         if (retries == 0) {

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/BaseITCase.java
@@ -104,7 +104,8 @@ public abstract class BaseITCase {
         try {
             this.dataManager.clearCache();
             this.jsondb.dropTables();
-        } catch (Exception e) {
+        } catch (Exception ignore) {
+          // ignored
         }
         this.jsondb.createTables();
     }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/T3stSupportITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/T3stSupportITCase.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the /test-support API endpoints
- *
  * Can't call this class TestSupportITCase because it then gets
  * run as a unit test when keycloak is not running.
  */

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationSpecificationITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/integration/IntegrationSpecificationITCase.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegrationSpecificationITCase extends BaseITCase {
     @Test
+    @SuppressWarnings("ReturnValueIgnored")
     public void shouldServeOpenApiSpecificationInJsonFormat() throws IOException, JSONException {
         final MultiValueMap<Object, Object> data = specification("/io/syndesis/server/runtime/test-swagger.json");
 
@@ -72,6 +73,7 @@ public class IntegrationSpecificationITCase extends BaseITCase {
     }
 
     @Test
+    @SuppressWarnings("ReturnValueIgnored")
     public void shouldServeOpenApiSpecificationInYamlFormat() throws IOException, JSONException {
         final MultiValueMap<Object, Object> data = specification("/io/syndesis/server/runtime/test-swagger.yaml");
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion28Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion28Test.java
@@ -41,8 +41,6 @@ import org.springframework.core.io.DefaultResourceLoader;
 /**
  * Test db schema migration to version 28. This migration will auto add split step to integrations with implicit split
  * configured.
- *
- * @author Christoph Deppisch
  */
 public class UpgradeVersion28Test {
 

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/AbstractResourceUpdateHandler.java
@@ -75,7 +75,6 @@ abstract class AbstractResourceUpdateHandler<T extends WithId<T>> implements Res
 
     /**
      * Compute the bulletin boards for the given change.
-     *
      * @param event the event.
      * @return a list of boards or an empty collection.
      */

--- a/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
+++ b/app/server/update-controller/src/main/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandler.java
@@ -75,7 +75,6 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
      * manager. Adds a message with the missing code if there is no connection
      * available or adds a message with the difference code if the connections
      * differ in their metadata.
-     *
      * @param connection the connection to compare
      * @param dbConnection the connection from the data manager
      * @param messages the messages collection to add the message to
@@ -228,7 +227,6 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
          * the data manager. This does it once rather than repeatedly in the
          * various loops since getting stuff from the DataManager is quite
          * expensive and slow.
-         *
          * see #3717
          */
         final List<Integration> integrations = dataManager.fetchAll(Integration.class).getItems();
@@ -396,7 +394,6 @@ public class IntegrationUpdateHandler extends AbstractResourceUpdateHandler<Inte
                              * that, a change event must be broadcast to all
                              * clients and a call to update() provides such an
                              * event.
-                             *
                              * see #4008
                              */
                             dataManager.update(dbConnection);

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/bulletin/IntegrationUpdateHandlerTest.java
@@ -224,7 +224,6 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
      * * DataManager returns the modified connection
      * * DataManager returns the original integration
      * * DataManager returns the original deployment
-     *
      * Both the integration and deployment and computed to be stale
      */
     @Test
@@ -338,7 +337,6 @@ public class IntegrationUpdateHandlerTest implements StringConstants {
      * * DataManager returns the modified connection
      * * DataManager returns the modified integration
      * * DataManager returns the original deployment
-     *
      * Only the deployment is stale while the modified integration is fine.
      */
     @Test

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
@@ -15,12 +15,14 @@
  */
 package io.syndesis.server.update.controller.usage;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import io.syndesis.common.model.ChangeEvent;
 import io.syndesis.common.model.Dependency;
-import io.syndesis.common.model.Dependency.Type;
 import io.syndesis.common.model.ListResult;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.common.model.extension.Extension;
@@ -28,16 +30,10 @@ import io.syndesis.common.model.integration.Flow;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.integration.Step;
 import io.syndesis.server.dao.manager.DataManager;
-
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static java.util.Collections.emptyList;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class UsageUpdateHandlerTest {
 
@@ -61,7 +57,7 @@ public class UsageUpdateHandlerTest {
             .addStep(new Step.Builder()
                 .addDependency(new Dependency.Builder()
                     .id("extension-1")
-                    .type(Type.EXTENSION)
+                    .type(Dependency.Type.EXTENSION)
                     .build())
                 .build())
             .build())
@@ -71,7 +67,7 @@ public class UsageUpdateHandlerTest {
         .id("integration-2")
         .addDependency(new Dependency.Builder()
             .id("extension-1")
-            .type(Type.EXTENSION_TAG)
+            .type(Dependency.Type.EXTENSION_TAG)
             .build())
         .build();
 
@@ -80,7 +76,7 @@ public class UsageUpdateHandlerTest {
         .addFlow(new Flow.Builder()
             .addDependency(new Dependency.Builder()
                 .id("extension-1")
-                .type(Type.EXTENSION_TAG)
+                .type(Dependency.Type.EXTENSION_TAG)
                 .build())
             .build())
         .build();

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/AlwaysOkVerifier.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/AlwaysOkVerifier.java
@@ -24,9 +24,6 @@ import org.springframework.stereotype.Component;
 
 /**
  * Verifier which returns always "OK" and can be used simulating a developer
- *
- * @author roland
- * @since 23/02/2017
  */
 
 @Component

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/Verifier.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/Verifier.java
@@ -25,15 +25,11 @@ import org.immutables.value.Value;
 /**
  * The result of a verification of connection parameters.
  * It's format is inspired by the discussion from https://issues.apache.org/jira/browse/CAMEL-10795
- *
- * @author roland
- * @since 23/02/2017
  */
 public interface Verifier {
 
     /**
      * Verify a connector
-     *
      * @param connectorId id of the connector to verify
      * @param parameters options for the connector to verify
      * @return the result of the verification as a list, one element for each scope checked

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/SyndesisIntegrationTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/SyndesisIntegrationTestSupport.java
@@ -40,9 +40,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import com.consol.citrus.dsl.junit.jupiter.CitrusExtension;
 import com.zaxxer.hikari.HikariDataSource;
 
-/**
- * @author Christoph Deppisch
- */
 @ExtendWith(CitrusExtension.class)
 @Testcontainers
 public abstract class SyndesisIntegrationTestSupport {

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/AMQToHttp_IT.java
@@ -39,9 +39,6 @@ import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.jms.endpoint.JmsEndpoint;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class AMQToHttp_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/amq/HttpToAMQ_IT.java
@@ -39,9 +39,6 @@ import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.jms.endpoint.JmsEndpoint;
 
-/**
- * @author Christoph Deppisch
- */
 @org.testcontainers.junit.jupiter.Testcontainers
 public class HttpToAMQ_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnectorBasicAuth_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnectorBasicAuth_IT.java
@@ -49,18 +49,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.CoreMatchers.is;
 
-/**
- * @author delawen
- */
 @Testcontainers
 public class SoapConnectorBasicAuth_IT extends SyndesisIntegrationTestSupport {
 
     private static final int SOAP_SERVER_PORT = SocketUtils.findAvailableTcpPort();
-    public static final String USERNAME = "registered";
-    public static final String PASSWORD = "passw0rd";
-    public static final  List<User> USERS = new ArrayList<User>();
-    public static final String[] ROLES = new String[]{USERNAME};
-    public static final User USER = new User();
+    private static final String USERNAME = "registered";
+    private static final String PASSWORD = "passw0rd";
+    private static final  List<User> USERS = new ArrayList<User>();
+    private static final String[] ROLES = new String[]{USERNAME};
+    private static final User USER = new User();
 
     static {
         org.testcontainers.Testcontainers.exposeHostPorts(SOAP_SERVER_PORT);

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnectorFault_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnectorFault_IT.java
@@ -32,9 +32,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.hamcrest.CoreMatchers.is;
 
-/**
- * @author delawen
- */
 @Testcontainers
 public class SoapConnectorFault_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnector_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/SoapConnector_IT.java
@@ -38,9 +38,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-/**
- * @author Dhiraj Bokde
- */
 @Testcontainers
 public class SoapConnector_IT extends SyndesisIntegrationTestSupport {
 
@@ -63,7 +60,6 @@ public class SoapConnector_IT extends SyndesisIntegrationTestSupport {
     /**
      * Integration uses api connector to send SOAP client requests to a REST endpoint. The client API connector was generated
      * from SOAP WSDL1.1 specification.
-     *
      * The integration invokes following sequence of client requests on the test server
      *  Invoke operation sayHi.
      */

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV2Connector_IT.java
@@ -34,9 +34,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class TodoOpenApiV2Connector_IT extends SyndesisIntegrationTestSupport {
 
@@ -55,7 +52,6 @@ public class TodoOpenApiV2Connector_IT extends SyndesisIntegrationTestSupport {
     /**
      * Integration uses api connector to send OpenAPI client requests to a REST endpoint. The client API connector was generated
      * from OpenAPI 2.x specification.
-     *
      * The integration invokes following sequence of client requests on the test server
      *  POST /api adds a new task
      *  PUT /api update task

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiconnector/TodoOpenApiV3Connector_IT.java
@@ -34,9 +34,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class TodoOpenApiV3Connector_IT extends SyndesisIntegrationTestSupport {
 
@@ -55,7 +52,6 @@ public class TodoOpenApiV3Connector_IT extends SyndesisIntegrationTestSupport {
     /**
      * Integration uses api connector to send OpenAPI client requests to a REST endpoint. The client API connector was generated
      * from OpenAPI 3.x specification.
-     *
      * The integration invokes following sequence of client requests on the test server
      *  POST /api adds a new task
      *  PUT /api update task

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoApi_IT.java
@@ -35,9 +35,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class TodoApi_IT extends SyndesisIntegrationTestSupport {
 
@@ -49,7 +46,6 @@ public class TodoApi_IT extends SyndesisIntegrationTestSupport {
 
     /**
      * Integration uses api provider to enable rest service operations for accessing tasks in the sample database.
-     *
      * Available flows in api
      *  GET /todo/{id} provides the task with the given id as Json object
      *  GET /todos provides all available tasks as Json array (using collection support)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoListApi_IT.java
@@ -35,9 +35,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
 
@@ -49,7 +46,6 @@ public class TodoListApi_IT extends SyndesisIntegrationTestSupport {
 
     /**
      * Integration uses api provider to enable rest service operations for accessing tasks in the sample database.
-     *
      * Available flows in api
      *  POST /todos stores given tasks (Json array) to the sample database (using inbound collection support and split/aggregate)
      *  GET /todos provides all available tasks as Json array (using collection support)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/apiprovider/TodoOpenApiV3_IT.java
@@ -35,9 +35,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
 
@@ -49,7 +46,6 @@ public class TodoOpenApiV3_IT extends SyndesisIntegrationTestSupport {
 
     /**
      * Integration uses api provider to enable rest service operations for accessing tasks in the sample database.
-     *
      * Available flows in api
      *  GET /api/{id} provides the task with the given id as Json object
      *  GET /api provides all available tasks as Json array (using collection support)

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/conditional/ConditionalFlows_IT.java
@@ -31,9 +31,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
 
@@ -44,7 +41,6 @@ public class ConditionalFlows_IT extends SyndesisIntegrationTestSupport {
     /**
      * This integration provides a webhook that expects a POST request to store task entries to the sample database. The
      * webhook defines a Json instance schema that represents a contact with first_name and company properties.
-     *
      * Inbound requests are routed to different conditional flows based on condition evaluation on the message body.
      *  When body.fist_name == 'John' save 'Drink beer with John' as task to the DB
      *  When body.company == 'Red Hat' save 'Meet {{first_name}} from Red Hat' as task to the DB

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpSplitToDB_IT.java
@@ -31,9 +31,6 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class FtpSplitToDB_IT extends FtpTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpTestSupport.java
@@ -40,9 +40,6 @@ import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.ftp.client.FtpEndpointConfiguration;
 import com.consol.citrus.ftp.server.FtpServer;
 
-/**
- * @author Christoph Deppisch
- */
 public abstract class FtpTestSupport extends SyndesisIntegrationTestSupport {
 
     /** Logger */

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/FtpToDB_IT.java
@@ -31,9 +31,6 @@ import com.consol.citrus.context.TestContext;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.ftp.message.FtpMessage;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class FtpToDB_IT extends FtpTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/ftp/WebHookToFtp_IT.java
@@ -45,9 +45,6 @@ import com.consol.citrus.util.FileUtils;
 import com.consol.citrus.validation.json.JsonMessageValidationContext;
 import com.consol.citrus.validation.json.JsonTextMessageValidator;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class WebHookToFtp_IT extends FtpTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/http/HttpToHttp_IT.java
@@ -34,9 +34,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 
-/**
- * @author Christoph Deppisch
- */
 @org.testcontainers.junit.jupiter.Testcontainers
 public class HttpToHttp_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/mail/SendMail_IT.java
@@ -40,9 +40,6 @@ import com.consol.citrus.mail.message.MailMessage;
 import com.consol.citrus.mail.server.MailServer;
 import com.consol.citrus.util.FileUtils;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class SendMail_IT extends SyndesisIntegrationTestSupport {
 
@@ -65,7 +62,6 @@ public class SendMail_IT extends SyndesisIntegrationTestSupport {
     /**
      * This integration provides a webhook that expects a POST request with some contact Json object as payload. The
      * incoming contact (first_name, company, mail) triggers a send mail activity with a welcome message.
-     *
      * After the mail is sent a new task entry for that contact is added to the sample database.
      */
     @Container

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/quickstart/Webhook2DB_IT.java
@@ -31,9 +31,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class Webhook2DB_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBSplitToSheets_IT.java
@@ -32,9 +32,6 @@ import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.dsl.runner.TestRunner;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class DBSplitToSheets_IT extends GoogleSheetsTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/DBToSheets_IT.java
@@ -32,9 +32,6 @@ import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.dsl.runner.TestRunner;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class DBToSheets_IT extends GoogleSheetsTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/GoogleSheetsTestSupport.java
@@ -31,9 +31,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.http.server.HttpServer;
 import com.consol.citrus.http.servlet.RequestCachingServletFilter;
 
-/**
- * @author Christoph Deppisch
- */
 public class GoogleSheetsTestSupport extends SyndesisIntegrationTestSupport {
 
     static final int GOOGLE_SHEETS_SERVER_PORT = SocketUtils.findAvailableTcpPort();

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/MultiSqlToSheets_IT.java
@@ -32,9 +32,6 @@ import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.dsl.runner.TestRunner;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class MultiSqlToSheets_IT extends GoogleSheetsTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/SheetsToSheets_IT.java
@@ -27,9 +27,6 @@ import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.dsl.runner.TestRunner;
 
-/**
- * @author Christoph Deppisch
- */
 public class SheetsToSheets_IT extends GoogleSheetsTestSupport {
 
     /**

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/util/GzipServletFilter.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sheets/util/GzipServletFilter.java
@@ -32,9 +32,6 @@ import com.consol.citrus.http.servlet.GzipHttpServletResponseWrapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-/**
- * @author Christoph Deppisch
- */
 public class GzipServletFilter extends OncePerRequestFilter {
 
     @Override
@@ -63,8 +60,6 @@ public class GzipServletFilter extends OncePerRequestFilter {
     private static class GzipHttpServletRequestWrapper extends HttpServletRequestWrapper {
         /**
          * Constructs a request adaptor wrapping the given request.
-         *
-         * @param request
          * @throws IllegalArgumentException if the request is null
          */
         GzipHttpServletRequestWrapper(HttpServletRequest request) {
@@ -84,9 +79,6 @@ public class GzipServletFilter extends OncePerRequestFilter {
 
             /**
              * Default constructor using wrapped input stream.
-             *
-             * @param request
-             * @throws IOException
              */
             GzipServletInputStream(ServletRequest request) throws IOException {
                 super();

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/sql/DBToHttp_IT.java
@@ -34,9 +34,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.server.HttpServer;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class DBToHttp_IT extends SyndesisIntegrationTestSupport {
 

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/timer/TimerToLog_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/timer/TimerToLog_IT.java
@@ -32,9 +32,6 @@ import io.syndesis.test.integration.source.JsonIntegrationSource;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-/**
- * @author Christoph Deppisch
- */
 public class TimerToLog_IT {
 
     @Test

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookSplitToDB_IT.java
@@ -34,9 +34,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
 
@@ -47,7 +44,6 @@ public class WebHookSplitToDB_IT extends SyndesisIntegrationTestSupport {
     /**
      * This integration provides a webhook that expects a POST request to store contacts to the sample database. The
      * webhook defines a Json instance schema as Json array and saves incoming contacts to the DB.
-     *
      * Inbound requests are split first and then filtered in two ways
      *  Basic filter applies to the company name property to be "Red Hat"
      *  Advanced filter applies to the first_name property to not be like "Unknown"

--- a/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
+++ b/app/test/integration-test/src/test/java/io/syndesis/test/itest/webhook/WebHookToDB_IT.java
@@ -32,9 +32,6 @@ import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
 import com.consol.citrus.dsl.runner.TestRunner;
 import com.consol.citrus.http.client.HttpClient;
 
-/**
- * @author Christoph Deppisch
- */
 @Testcontainers
 public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
 
@@ -45,7 +42,6 @@ public class WebHookToDB_IT extends SyndesisIntegrationTestSupport {
     /**
      * This integration provides a webhook that expects a POST request to store contacts to the sample database. The
      * webhook defines a Json instance schema and saves incoming contacts to the DB.
-     *
      * Inbound requests are filtered in two ways
      *  Basic filter applies to the company name property to be "Red Hat"
      *  Advanced filter applies to the first_name property to not be like "Unknown"

--- a/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/SyndesisTestEnvironment.java
@@ -20,9 +20,6 @@ import java.time.Duration;
 
 import io.syndesis.test.model.IntegrationRuntime;
 
-/**
- * @author Christoph Deppisch
- */
 public final class SyndesisTestEnvironment {
 
     private static final String SYNDESIS_PREFIX = "syndesis.";

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/amq/JBossAMQBrokerContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/amq/JBossAMQBrokerContainer.java
@@ -20,9 +20,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-/**
- * @author Christoph Deppisch
- */
 public class JBossAMQBrokerContainer extends GenericContainer<JBossAMQBrokerContainer> {
 
     private static final int OPENWIRE_PORT = 61616;

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/db/SyndesisDbContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/db/SyndesisDbContainer.java
@@ -22,9 +22,6 @@ import com.github.dockerjava.api.model.Ports;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-/**
- * @author Christoph Deppisch
- */
 public class SyndesisDbContainer extends PostgreSQLContainer<SyndesisDbContainer> {
 
     public static final int DB_PORT = 5432;

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
@@ -26,8 +26,6 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 /**
  * Special on the fly Dockerfile builder that automatically adds project sources as directory of jar file to the image.
  * Also takes care on proper file permissions and user settings in the container.
- *
- * @author Christoph Deppisch
  */
 public class SyndesisDockerfileBuilder extends ImageFromDockerfile {
 
@@ -89,7 +87,6 @@ public class SyndesisDockerfileBuilder extends ImageFromDockerfile {
      * @param projectSrc the source marker as key added to the Dockerfile context.
      * @param projectDest the destination path in the container.
      * @param projectPath the actual path to the project sources on the host.
-     * @return
      */
     public SyndesisDockerfileBuilder project(String projectSrc, String projectDest, Path projectPath) {
         this.projectSrc = projectSrc;

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/integration/SyndesisIntegrationRuntimeContainer.java
@@ -53,13 +53,9 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 /**
  * Container that executes a integration runtime. The container is either provided with a runnable project fat jar or a project directory
  * holding the sources to run the integration.
- *
  * All Syndesis dependencies (artifacts, 3rd party libs) are already bundled with the syndesis-s2i base image.
- *
  * When using a fat jar the fabric8 S2i run script is called to executes the jar. When using a project source directory a plain Spring Boot
  * run command is used to build and run the sources.
- *
- * @author Christoph Deppisch
  */
 public class SyndesisIntegrationRuntimeContainer extends GenericContainer<SyndesisIntegrationRuntimeContainer> {
 
@@ -72,13 +68,6 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
 
     /**
      * Uses Spring Boot Maven build to run the integration project. Much faster as S2i build because we can directly use the project sources.
-     *
-     * @param imageTag
-     * @param integrationName
-     * @param projectDir
-     * @param envProperties
-     * @param runCommand
-     * @param deleteOnExit
      */
     protected SyndesisIntegrationRuntimeContainer(String imageTag, String integrationName, Path projectDir,
                                                 Map<String, String> envProperties, String runCommand, boolean deleteOnExit) {
@@ -95,12 +84,6 @@ public class SyndesisIntegrationRuntimeContainer extends GenericContainer<Syndes
 
     /**
      * Uses project fat jar to run integration. Runs the Java application with run script provided by the Syndesis S2i image.
-     * @param imageTag
-     * @param integrationName
-     * @param projectJar
-     * @param envProperties
-     * @param runCommand
-     * @param deleteOnExit
      */
     protected SyndesisIntegrationRuntimeContainer(String imageTag, String integrationName, File projectJar,
                                                 Map<String, String> envProperties, String runCommand, boolean deleteOnExit) {

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/S2iProjectBuilder.java
@@ -26,9 +26,6 @@ import java.util.Optional;
 import io.syndesis.test.integration.project.ProjectBuilder;
 import io.syndesis.test.integration.source.IntegrationSource;
 
-/**
- * @author Christoph Deppisch
- */
 public class S2iProjectBuilder implements ProjectBuilder {
 
     private final ProjectBuilder delegate;

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
@@ -30,11 +30,8 @@ import org.testcontainers.images.builder.dockerfile.statement.MultiArgsStatement
  * Syndesis S2i container that performs assemble step on a give project
  * directory. The project sources are assembled to a runnable project fat jar
  * using fabric8 S2i assemble script.
- *
  * The container uses the Syndesis S2i image as base. This image already holds
  * all required Syndesis libraries and artifacts with the given version.
- *
- * @author Christoph Deppisch
  */
 public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAssemblyContainer> {
 

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/server/SyndesisServerContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/server/SyndesisServerContainer.java
@@ -34,9 +34,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-/**
- * @author Christoph Deppisch
- */
 public class SyndesisServerContainer extends GenericContainer<SyndesisServerContainer> {
 
     private static final int SERVER_PORT = 8080;

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/customizer/IntegrationCustomizer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/customizer/IntegrationCustomizer.java
@@ -20,9 +20,6 @@ import java.util.function.Function;
 
 import io.syndesis.common.model.integration.Integration;
 
-/**
- * @author Christoph Deppisch
- */
 @FunctionalInterface
 public interface IntegrationCustomizer extends Function<Integration, Integration> {
 }

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/customizer/JsonPathIntegrationCustomizer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/customizer/JsonPathIntegrationCustomizer.java
@@ -27,9 +27,6 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.util.json.JsonUtils;
 import org.apache.camel.util.ObjectHelper;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonPathIntegrationCustomizer implements IntegrationCustomizer {
 
     private final String expression;

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/project/AbstractMavenProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/project/AbstractMavenProjectBuilder.java
@@ -43,9 +43,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Christoph Deppisch
- */
 public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProjectBuilder<T>> implements ProjectBuilder {
 
     /** Logger */
@@ -197,8 +194,6 @@ public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProject
 
     /**
      * Obtains the name.
-     *
-     * @return
      */
     public String getName() {
         return name;
@@ -206,8 +201,6 @@ public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProject
 
     /**
      * Obtains the projectGeneratorConfiguration.
-     *
-     * @return
      */
     public ProjectGeneratorConfiguration getProjectGeneratorConfiguration() {
         return projectGeneratorConfiguration;
@@ -215,8 +208,6 @@ public abstract class AbstractMavenProjectBuilder<T extends AbstractMavenProject
 
     /**
      * Obtains the mavenProperties.
-     *
-     * @return
      */
     public MavenProperties getMavenProperties() {
         return mavenProperties;

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/project/ProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/project/ProjectBuilder.java
@@ -21,24 +21,14 @@ import java.nio.file.Path;
 
 import io.syndesis.test.integration.source.IntegrationSource;
 
-/**
- * @author Christoph Deppisch
- */
 @FunctionalInterface
 public interface ProjectBuilder {
 
     /**
      * Builds the integration project sources and provides the path to that project dir.
-     * @param integrationSource
-     * @return
      */
     Path build(IntegrationSource integrationSource);
 
-    /**
-     * @param source
-     * @param integrationFile
-     * @throws IOException
-     */
     default void customizeIntegrationFile(IntegrationSource source, Path integrationFile) throws IOException {
         // subclasses can add integration file customizations
     };

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/project/SpringBootProjectBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/project/SpringBootProjectBuilder.java
@@ -16,9 +16,6 @@
 
 package io.syndesis.test.integration.project;
 
-/**
- * @author Christoph Deppisch
- */
 public class SpringBootProjectBuilder extends AbstractMavenProjectBuilder<SpringBootProjectBuilder> {
 
     public SpringBootProjectBuilder(String name, String syndesisVersion) {

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/CustomizedIntegrationSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/CustomizedIntegrationSource.java
@@ -23,9 +23,6 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.openapi.OpenApi;
 import io.syndesis.test.integration.customizer.IntegrationCustomizer;
 
-/**
- * @author Christoph Deppisch
- */
 public class CustomizedIntegrationSource implements IntegrationSource {
 
     private final IntegrationSource delegate;

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationExportSource.java
@@ -33,9 +33,6 @@ import io.syndesis.common.util.json.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Christoph Deppisch
- */
 public class IntegrationExportSource implements IntegrationSource {
 
     /** Logger */

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/IntegrationSource.java
@@ -23,9 +23,6 @@ import java.util.function.Supplier;
 import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.model.openapi.OpenApi;
 
-/**
- * @author Christoph Deppisch
- */
 @FunctionalInterface
 public interface IntegrationSource extends Supplier<Integration> {
 

--- a/app/test/test-support/src/main/java/io/syndesis/test/integration/source/JsonIntegrationSource.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/integration/source/JsonIntegrationSource.java
@@ -26,9 +26,6 @@ import io.syndesis.common.model.integration.Integration;
 import io.syndesis.common.util.IOStreams;
 import io.syndesis.common.util.json.JsonUtils;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonIntegrationSource implements IntegrationSource {
 
     private final byte[] json;

--- a/app/test/test-support/src/test/java/io/syndesis/test/integration/customizer/JsonPathIntegrationCustomizerTest.java
+++ b/app/test/test-support/src/test/java/io/syndesis/test/integration/customizer/JsonPathIntegrationCustomizerTest.java
@@ -31,9 +31,6 @@ import io.syndesis.common.model.integration.StepKind;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonPathIntegrationCustomizerTest {
 
     @Test

--- a/app/test/test-support/src/test/java/io/syndesis/test/integration/project/SpringBootProjectBuilderTest.java
+++ b/app/test/test-support/src/test/java/io/syndesis/test/integration/project/SpringBootProjectBuilderTest.java
@@ -31,9 +31,6 @@ import io.syndesis.test.SyndesisTestEnvironment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class SpringBootProjectBuilderTest {
 
     Integration integration = new Integration.Builder()

--- a/app/test/test-support/src/test/java/io/syndesis/test/integration/source/IntegrationExportSourceTest.java
+++ b/app/test/test-support/src/test/java/io/syndesis/test/integration/source/IntegrationExportSourceTest.java
@@ -25,9 +25,6 @@ import io.syndesis.common.util.json.JsonUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class IntegrationExportSourceTest {
 
     @Test

--- a/app/test/test-support/src/test/java/io/syndesis/test/integration/source/JsonIntegrationSourceTest.java
+++ b/app/test/test-support/src/test/java/io/syndesis/test/integration/source/JsonIntegrationSourceTest.java
@@ -33,9 +33,6 @@ import io.syndesis.common.util.json.JsonUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Christoph Deppisch
- */
 public class JsonIntegrationSourceTest {
 
     @Test


### PR DESCRIPTION
Guava depends on Error Prone of at least (IIRC) version 2.4.1. For
future proofing this updates all of these.

refactor(server): cleanup (ac62820)

Most of these are around javadoc, which is now enforced by Error Prone.
Some of it fell through the cracks, like resource handling or exception
handling, and minor things like access modifiers.

I've added a fair bit of suppressions around the use of `java.util.Date`
some of these could be refactored, and some of these are mandated by a
3rd party API.

refactor(server): convert Op to enum (9a5e514)

No need for this class to be an Immutables object it's simple enough to
be an enum.


