### PR TITLE
fix: don't use `pull_request_target`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - '[0-9]+.[0-9]+.x'
-  pull_request_target:
+  pull_request:
     branches:
       - '[0-9]+.[0-9]+.x'
     paths-ignore:
@@ -52,11 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -94,11 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -119,11 +109,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -146,11 +131,6 @@ jobs:
       IMAGES_DIR: syndesis_images
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -199,11 +179,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
`pull_request_target` gives r/w GitHub access token, it's best that we
don't allow it to be exposed to 3rd parties.