### PR TITLE
fix(build): remove test report publishing

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,9 +62,6 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
       - name: Build and test
         run: tools/bin/syndesis build --batch-mode --backend
-      - name: Publish Test Reports
-        if: always()
-        uses: scacap/action-surefire-report@v1
       - name: Set up JDK 11
         if: needs.setup.outputs.is_default_branch == 'true'
         uses: actions/setup-java@v1


### PR DESCRIPTION
With `pull_request` (vs `pull_request_target`) event we can't publish
test reports as that requires token with write access.