### PR TITLE
fix(operator): pbt test failure with control chars

### DIFF
--- a/install/operator/pkg/generator/generator_test.go
+++ b/install/operator/pkg/generator/generator_test.go
@@ -721,6 +721,7 @@ func TestGeneratorProperty(t *testing.T) {
 	parameters.MaxSize = 10
 
 	arbitraries := arbitrary.DefaultArbitraries()
+	arbitraries.RegisterGen(gen.AlphaNumChar())
 	arbitraries.RegisterGen(gen.Struct(reflect.TypeOf(v1beta2.ResourcesWithPersistentVolume{}), map[string]gopter.Gen{
 		"VolumeLabels": gen.MapOf(gen.Identifier(), gen.Identifier()), // we can't have volume labels with keys that are empty strings
 	}))


### PR DESCRIPTION
The CR PBT test failed with seed 1619763989204725588 that introduced
control characters in string values of the generated YAML. This
configures the generator to generate alphanumeric characters only to fix
that.