### PR TITLE
chore: Update to AtlasMap 2.2.0

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-790029</camel.version>
-    <atlasmap.version>2.2.0-M.7</atlasmap.version>
+    <atlasmap.version>2.2.0</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,7 +39,7 @@
     <deploy.archives>false</deploy.archives>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>2.2.0-M.7</atlasmap.version>
+    <atlasmap.version>2.2.0</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -84,7 +84,7 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.2.0-M.7",
+    "@atlasmap/atlasmap": "^2.2.0",
     "react-fast-compare": "^2.0.2"
   },
   "jest": {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -226,19 +226,19 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap@^2.2.0-M.7":
-  version "2.2.0-M.7"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.2.0-M.7.tgz#2f93e34e9476d322a9a0c007873ca4d13fe70dfa"
-  integrity sha512-FOzso73kWxVXzD7MHnj205p8XzMtRhFLwlyD4V+JaBGWdot8WrJiB+mvBUKCEYjO4wgzVpd2dBXLrkFdJmPuCQ==
+"@atlasmap/atlasmap@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.2.0.tgz#f7f25c8509400004e8bd5763491db16e688113f3"
+  integrity sha512-AjXvrcf2M9O9dIjQRLITH5RO/MYizML8NAQ5+NLmbYjeEVfe1ElNzaR1rhP5OaoRiMdYMqQpLCiNIczg+OsPxg==
   dependencies:
-    "@atlasmap/core" "^2.2.0-M.7"
+    "@atlasmap/core" "^2.2.0"
     react-sage "^0.0.42"
     use-debounce "^3.4.2"
 
-"@atlasmap/core@^2.2.0-M.7":
-  version "2.2.0-M.7"
-  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.2.0-M.7.tgz#eb322b1b660bd95b6ebcdfbc5e85f9b3d6656c25"
-  integrity sha512-9ru8cRoaoyDYjgYgUlgcvVZ1MsY9rztdAsgDullxur0uIe9JQG5ptk1dobnw9fiPbfyscFxYNLxTXtdS14Yq/g==
+"@atlasmap/core@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.2.0.tgz#c18113f84cd022338e5aa27b74c280ecfe849efc"
+  integrity sha512-mN82LYCBGy+2/oTcI7PyEuGso7pAzp66BAJJhHgGYqC1Lji17JMdGcUhgJyQ9nnW6foFgP9JI3YLdLsuIihJ7g==
   dependencies:
     file-saver "2.0.2"
     loglevel "^1.6.7"


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-16322
An addition from 2.2.0-M.7 is only atlasmap/atlasmap#2708
Full Release Note: https://github.com/atlasmap/atlasmap/releases/tag/atlasmap-2.2.0