### PR TITLE
fix(ui) [ENTESB-16069] conditional step gets duplicated

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
@@ -244,10 +244,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                           activeIndex: positionAsNumber,
                           activeStep: toUIStep(state.step),
                           steps: toUIStepCollection(
-                            getSteps(
-                              state.updatedIntegration || state.integration,
-                              params.flowId
-                            )
+                            getSteps(state.integration, params.flowId)
                           ),
                         })}
                         content={

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/ChoiceStepPage.tsx
@@ -190,7 +190,7 @@ export class ChoiceStepPage extends React.Component<IChoiceStepPageProps> {
                       updatedFlows.push(defaultFlow);
                     }
                     const updatedIntegration = await (this.props.mode ===
-                      'adding'
+                      'adding' && !step.id
                       ? addStep
                       : updateStep)(
                       state.updatedIntegration || state.integration,


### PR DESCRIPTION
fixes [ENTESB-16069](https://issues.redhat.com/browse/ENTESB-16069), where conditional flow steps get duplicated on pressing the 'Back' button in the editor.

![Kapture 2021-04-30 at 17 41 21](https://user-images.githubusercontent.com/3844502/116726979-e469c100-a9db-11eb-9e0d-374b3fad6c6f.gif)
