### PR TITLE
fix(c/sql): jsqlparser for parsing SQL statements

### DIFF
--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -43,6 +43,11 @@
       <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.jsqlparser</groupId>
+      <artifactId>jsqlparser</artifactId>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>connector-support-verifier</artifactId>
       <optional>true</optional>

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -130,8 +130,11 @@ public final class SqlStatementParser {
             final SelectBody body = select.getSelectBody();
 
             final TablesNamesFinder tableNames = new TablesNamesFinder();
-            // TODO assumes there will be only one table in a SELECT statement
-            tableName = tableNames.getTableList(select).get(0);
+            final List<String> tableList = tableNames.getTableList(select);
+            if (!tableList.isEmpty()) {
+                // TODO assumes there will be only one table in a SELECT statement
+                tableName = tableList.get(0);
+            }
 
             body.accept(new SelectVisitorAdapter() {
                 @Override
@@ -302,8 +305,13 @@ public final class SqlStatementParser {
             return;
         }
 
+        final List<String> tableNames = metadata.getTableNames();
+        if (tableNames.isEmpty()) {
+            return;
+        }
+
         // TODO assumes there will be only one table in a INSERT statement
-        final String tableName = metadata.getTableNames().get(0);
+        final String tableName = tableNames.get(0);
         final List<SqlParam> autoIncrementParameters = helper.getAutoIncrementColumnList(null, schema, tableName);
         if (autoIncrementParameters.isEmpty()) {
             return;

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -248,10 +248,15 @@ public final class SqlStatementParser {
     }
 
     void assertTablesExist(final List<String> speculativeTables) throws SQLException {
-        final Set<String> tablesInDatabase = helper.fetchTables(null, schema, null);
+        final Set<String> tablesInDatabase = uppercase(helper.fetchTables(null, schema, null));
 
-        final Set<String> nonExistantTables = new HashSet<>(speculativeTables);
-        nonExistantTables.removeAll(tablesInDatabase);
+        final Set<String> nonExistantTables = new HashSet<>();
+        for (final String table : speculativeTables) {
+            if (!tablesInDatabase.contains(table.toUpperCase(Locale.US))) {
+                nonExistantTables.add(table);
+            }
+        }
+
         if (!nonExistantTables.isEmpty()) {
             throw new SQLException(String.format("Table(s) '%s' cannot be found in schema '%s'", String.join("', '", nonExistantTables), schema));
         }
@@ -371,6 +376,16 @@ public final class SqlStatementParser {
         }
 
         throw new IllegalArgumentException("Unsupported statement type: " + statement.getClass().getSimpleName());
+    }
+
+    static Set<String> uppercase(final Set<String> tables) {
+        final Set<String> uppercased = new HashSet<>(tables.size());
+
+        for (final String table : tables) {
+            uppercased.add(table.toUpperCase(Locale.US));
+        }
+
+        return uppercased;
     }
 
 }

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -16,300 +16,361 @@
 package io.syndesis.connector.sql.common;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.JdbcNamedParameter;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.ItemsList;
+import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitorAdapter;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectBody;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.util.TablesNamesFinder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SqlStatementParser {
+public final class SqlStatementParser {
 
-    /*
-     * C - INSERT INTO NAME VALUES (:id, :firstname, :lastname)
-     * R - SELECT FIRSTNAME, LASTNAME FROM NAME WHERE ID=:id
-     * U - UPDATE NAME SET FIRSTNAME=:firstname WHERE ID=:id
-     * D - DELETE FROM NAME WHERE ID=:id
-     * DEMO_ADD(INTEGER ${body[A]}
-     * validate no "AS"
-     * input params
-     * output params
-     * table name
-     */
-    private final Connection connection;
-    private final String schema;
-    private final DbMetaDataHelper dbHelper;
-    private final SqlStatementMetaData statementInfo;
-    private List<String> sqlArray = new ArrayList<>();
-    private final List<String> sqlArrayUpperCase = new ArrayList<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStatementParser.class);
 
-    public SqlStatementParser(Connection connection, String sql) throws SQLException {
+    private final DbMetaDataHelper helper;
+
+    private final String schema;
+
+    private final String sql;
+
+    private static class JdbcNamedParameterVisitor extends ExpressionVisitorAdapter {
+
+        List<String> columnNames = new ArrayList<>();
+
+        String lastColumnName;
+
+        List<String> parameterNames = new ArrayList<>();
+
+        @Override
+        public void visit(final Column column) {
+            final String columnName = column.getColumnName();
+
+            // apparently, some databases (or drivers) require column names to
+            // be uppercase, otherwise no JDBC metadata is returned
+            lastColumnName = columnName.toUpperCase(Locale.US);
+        }
+
+        @Override
+        public void visit(final JdbcNamedParameter parameter) {
+            final String name = parameter.getName();
+
+            parameterNames.add(name.replaceFirst("#", ""));
+            // we might not know the column name from the statement, e.g.
+            // `INSERT INTO VALUES (a, b, c)` doesn't mention any columns
+            // in general we expect if at least one column name is given
+            // that all column names are given for all parameters
+            if (lastColumnName != null) {
+                columnNames.add(lastColumnName);
+            }
+        }
+    }
+
+    private static class ParamsVisitor extends StatementVisitorAdapter {
+
+        List<SqlParam> inParams = new ArrayList<>();
+
+        String tableName;
+
+        @Override
+        public void visit(final Delete delete) {
+            final Table table = delete.getTable();
+            tableName = table.getName();
+
+            final Expression where = delete.getWhere();
+            collectExpressionParameters(where);
+        }
+
+        @Override
+        public void visit(final Insert insert) {
+            final Table table = insert.getTable();
+            tableName = table.getName();
+
+            final List<Column> columns = insert.getColumns();
+
+            final ItemsList items = insert.getItemsList();
+            items.accept(new ItemsListVisitorAdapter() {
+                @Override
+                public void visit(final ExpressionList expressionList) {
+                    int offset = 0;
+                    for (final Expression expression : expressionList.getExpressions()) {
+                        collectExpressionParameters(expression, offset++, columns);
+                    }
+                }
+            });
+        }
+
+        @Override
+        public void visit(final Select select) {
+            final SelectBody body = select.getSelectBody();
+
+            final TablesNamesFinder tableNames = new TablesNamesFinder();
+            // TODO assumes there will be only one table in a SELECT statement
+            tableName = tableNames.getTableList(select).get(0);
+
+            body.accept(new SelectVisitorAdapter() {
+                @Override
+                public void visit(final PlainSelect plainSelect) {
+                    final Expression where = plainSelect.getWhere();
+
+                    collectExpressionParameters(where);
+                }
+            });
+        }
+
+        @Override
+        public void visit(final Update update) {
+            final Table table = update.getTable();
+            tableName = table.getName();
+
+            int offset = 0;
+            final List<Expression> expressions = update.getExpressions();
+            for (final Expression expression : expressions) {
+                collectExpressionParameters(expression, offset++, update.getColumns());
+            }
+
+            final Expression where = update.getWhere();
+            collectExpressionParameters(where, offset);
+        }
+
+        private void collectExpressionParameters(final Expression expression) {
+            collectExpressionParameters(expression, 0);
+        }
+
+        private void collectExpressionParameters(final Expression expression, final int offset) {
+            collectExpressionParameters(expression, offset, Collections.emptyList());
+        }
+
+        private void collectExpressionParameters(final Expression expression, final int offset, final List<Column> columns) {
+            // statements without expressions, like SELECT without a WHERE
+            if (expression == null) {
+                return;
+            }
+
+            // we're not interested in literal values, no easy way to check for
+            // that other than by the class name
+            final String className = expression.getClass().getSimpleName();
+            if (className.endsWith("Value")) {
+                return;
+            }
+
+            final JdbcNamedParameterVisitor params = new JdbcNamedParameterVisitor();
+            expression.accept(params);
+
+            for (int i = 0; i < params.parameterNames.size(); i++) {
+                final String parameterName = params.parameterNames.get(i);
+                final SqlParam param = new SqlParam(parameterName);
+
+                if (!params.columnNames.isEmpty()) {
+                    // if there are params.columnNames we collected the same number
+                    // of columns as params.parameterNames, look at
+                    // JdbcNamedParameterVisitor
+                    final String columnName = params.columnNames.get(i);
+                    param.setColumn(columnName);
+                } else if (columns != null && !columns.isEmpty()) {
+                    // yes, the columns given by the parser can be null
+                    // these are any named columns that are not associated
+                    // with parameter expressions
+                    final Column column = columns.get(i + offset);
+                    // apparently, some databases (or drivers) require column
+                    // names to be uppercase, otherwise no JDBC metadata is
+                    // returned
+                    final String columnName = column.getColumnName().toUpperCase(Locale.US);
+                    param.setColumn(columnName);
+                }
+                param.setColumnPos(i + offset);
+
+                inParams.add(param);
+            }
+        }
+    }
+
+    public SqlStatementParser(final Connection connection, final String sql) throws SQLException {
         this(connection, null, sql);
     }
 
-    public SqlStatementParser(Connection connection, String schema, String sql) throws SQLException {
-        super();
-        statementInfo = new SqlStatementMetaData(sql.trim(), schema);
-        this.connection = connection;
-        dbHelper = new DbMetaDataHelper(connection);
-        this.schema = getSchema(schema);
-    }
+    public SqlStatementParser(final Connection connection, final String schema, final String sql) throws SQLException {
+        this.sql = sql;
+        helper = new DbMetaDataHelper(connection);
 
-    public SqlStatementMetaData parseSelectOnly() throws SQLException {
-
-        statementInfo.setTablesInSchema(dbHelper.fetchTables(null, schema, null));
-        sqlArray = splitSqlStatement(statementInfo.getSqlStatement());
-        for (String word : sqlArray) {
-            sqlArrayUpperCase.add(word.toUpperCase(Locale.US));
-        }
-
-        if ("SELECT".equals(sqlArrayUpperCase.get(0))) {
-            parseSelect();
-            if (! statementInfo.getInParams().isEmpty()) {
-                throw new SQLException("Your statement is invalid and cannot contain input parameters");
-            }
-        } else {
-            throw new SQLException("Your statement is invalid and should start with SELECT");
-        }
-        return statementInfo;
+        this.schema = determineSchemaGiven(schema, helper);
     }
 
     public SqlStatementMetaData parse() throws SQLException {
-
-        statementInfo.setTablesInSchema(dbHelper.fetchTables(null, schema, null));
-        sqlArray = splitSqlStatement(statementInfo.getSqlStatement());
-        for (String word : sqlArray) {
-            sqlArrayUpperCase.add(word.toUpperCase(Locale.US));
+        final Statement statement;
+        try {
+            statement = CCJSqlParserUtil.parse(sql);
+        } catch (final JSQLParserException e) {
+            throw new SQLException(e);
         }
 
-        switch (sqlArrayUpperCase.get(0)) {
-            case "INSERT":
-                parseInsert();
-                break;
-            case "UPDATE":
-                parseUpdate();
-                break;
-            case "DELETE":
-                parseDelete();
-                break;
-            case "SELECT":
-                parseSelect();
-                break;
-            default:
-                throw new SQLException("Your statement is invalid and should start with INSERT, UPDATE, SELECT or DELETE");
-        }
-        return statementInfo;
+        final SqlStatementMetaData metadata = new SqlStatementMetaData(sql, schema);
+
+        final StatementType statementType = determineStatementTypeFrom(statement);
+        metadata.setStatementType(statementType);
+
+        final List<String> tables = collectTableNamesFrom(statement);
+        assertTablesExist(tables);
+        metadata.setTableNames(tables);
+
+        metadata.setInParams(collectInParams(statement));
+
+        metadata.setOutParams(collectOutParams(metadata));
+
+        setAutoIncrementMetadata(metadata);
+
+        return metadata;
     }
 
-    private String getSchema(String userSchema) {
-        //if user set, then use that
-        if (userSchema != null) {
-            return userSchema;
+    void assertTablesExist(final List<String> speculativeTables) throws SQLException {
+        final Set<String> tablesInDatabase = helper.fetchTables(null, schema, null);
+
+        final Set<String> nonExistantTables = new HashSet<>(speculativeTables);
+        nonExistantTables.removeAll(tablesInDatabase);
+        if (!nonExistantTables.isEmpty()) {
+            throw new SQLException(String.format("Table(s) '%s' cannot be found in schema '%s'", String.join("', '", nonExistantTables), schema));
+        }
+    }
+
+    List<SqlParam> collectInParams(final Statement statement) throws SQLException {
+        final ParamsVisitor visitor = new ParamsVisitor();
+
+        statement.accept(visitor);
+
+        final List<SqlParam> inParams = visitor.inParams;
+
+        if (inParams.isEmpty()) {
+            return inParams;
+        }
+
+        if (inParams.get(0).getColumn() == null) {
+            // we're assuming that if the first parameter knows the column name
+            // the rest of the parameters will as well
+            helper.getJDBCInfoByColumnOrder(null, schema, visitor.tableName, inParams);
+        } else {
+            // we might not have collected column names, asserted by the first
+            // parameter here, in that case we'll go by column numbers
+            helper.getJDBCInfoByColumnNames(null, schema, visitor.tableName, inParams);
+        }
+
+        return inParams;
+    }
+
+    List<SqlParam> collectOutParams(final SqlStatementMetaData metadata) throws SQLException {
+        if (metadata.getStatementType() != StatementType.SELECT) {
+            // we fetch output column metadata only for SELECT statements
+            return Collections.emptyList();
+        }
+
+        final String defaultedSqlStatement = metadata.getDefaultedSqlStatement();
+        return helper.getOutputColumnInfo(defaultedSqlStatement);
+    }
+
+    void setAutoIncrementMetadata(final SqlStatementMetaData metadata) throws SQLException {
+        if (metadata.getStatementType() != StatementType.INSERT) {
+            // we fetch auto increment metadata only for INSERT statements
+            return;
+        }
+
+        // TODO assumes there will be only one table in a INSERT statement
+        final String tableName = metadata.getTableNames().get(0);
+        final List<SqlParam> autoIncrementParameters = helper.getAutoIncrementColumnList(null, schema, tableName);
+        if (autoIncrementParameters.isEmpty()) {
+            return;
+        }
+
+        final SqlParam autoIncrementParameter = autoIncrementParameters.get(0);
+        // TODO hmm, but it's called name, i.e. not columnName?
+        final String columnName = autoIncrementParameter.getName();
+        // TODO ^ and here we set column
+        metadata.setAutoIncrementColumnName(columnName);
+
+        // in addition INSERT statement can have one output column metadata
+        final List<SqlParam> existingOutParams = metadata.getOutParams();
+        final List<SqlParam> outParams = new ArrayList<>();
+        outParams.addAll(existingOutParams);
+        outParams.add(autoIncrementParameter);
+        metadata.setOutParams(outParams);
+    }
+
+    static List<String> collectTableNamesFrom(final Statement statement) {
+        final TablesNamesFinder tables = new TablesNamesFinder();
+
+        return tables.getTableList(statement);
+    }
+
+    static String determineSchemaGiven(final String givenSchema, final DbMetaDataHelper helper) {
+        // if user set, then use that
+        if (givenSchema != null) {
+            return givenSchema;
         }
         try {
-            //try grabbing from the connection, not all drivers support this
-            return connection.getSchema();
-        } catch (SQLException e) {
-            LOGGER.error(e.getMessage(),e);
-        } catch (AbstractMethodError e) {
+            // try grabbing from the connection, not all drivers support this
+            return helper.connection.getSchema();
+        } catch (final SQLException e) {
+            LOGGER.error(e.getMessage(), e);
+        } catch (final AbstractMethodError e) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(e.getMessage());
             }
         }
         try {
-            //finally try setting reasonable default
-            DbMetaDataHelper dbHelper = new DbMetaDataHelper(connection);
-            return dbHelper.getDefaultSchema(connection.getMetaData().getUserName());
-        } catch (SQLException e) {
-            LOGGER.error(e.getMessage(),e);
+            final DatabaseMetaData metadata = helper.connection.getMetaData();
+            final String username = metadata.getUserName();
+
+            // finally try setting reasonable default
+            return helper.getDefaultSchema(username);
+        } catch (final SQLException e) {
+            LOGGER.error(e.getMessage(), e);
         }
+
         return null;
     }
 
-    private void parseInsert() throws SQLException {
-        statementInfo.setStatementType(StatementType.INSERT);
-        String tableNameInsert = statementInfo.addTable(sqlArrayUpperCase.get(2));
-        if (! statementInfo.getTablesInSchema().contains(tableNameInsert)) {
-            throw new SQLException(String.format("Table '%s' does not exist", tableNameInsert));
+    static StatementType determineStatementTypeFrom(final Statement statement) {
+        // INSERT, SELECT, UPDATE, DELETE;
+        if (statement instanceof Insert) {
+            return StatementType.INSERT;
         }
-        if (statementInfo.hasInputParams()) {
-            List<SqlParam> inputParams = findInsertParams(tableNameInsert);
-            if (inputParams.get(0).getColumn() != null) {
-                statementInfo.setInParams(
-                        dbHelper.getJDBCInfoByColumnNames(
-                                null, schema, tableNameInsert, inputParams));
-            } else {
-                statementInfo.setInParams(
-                        dbHelper.getJDBCInfoByColumnOrder(
-                                null, schema, tableNameInsert, inputParams));
-            }
+
+        if (statement instanceof Select) {
+            return StatementType.SELECT;
         }
-        List<SqlParam> autoIncrementParamList = dbHelper.getAutoIncrementColumnList(
-                null, schema, tableNameInsert);
-        if (! autoIncrementParamList.isEmpty()) {
-            statementInfo.setOutParams(autoIncrementParamList);
-            //SQL only supports one auto increment column
-            statementInfo.setAutoIncrementColumnName(autoIncrementParamList.get(0).getName());
+
+        if (statement instanceof Update) {
+            return StatementType.UPDATE;
         }
+
+        if (statement instanceof Delete) {
+            return StatementType.DELETE;
+        }
+
+        throw new IllegalArgumentException("Unsupported statement type: " + statement.getClass().getSimpleName());
     }
-
-    private void parseUpdate() throws SQLException  {
-        statementInfo.setStatementType(StatementType.UPDATE);
-        String tableNameUpdate = statementInfo.addTable(sqlArrayUpperCase.get(1));
-        if (! statementInfo.getTablesInSchema().contains(tableNameUpdate)) {
-            throw new SQLException(String.format("Table '%s' does not exist", tableNameUpdate));
-        }
-        if (statementInfo.hasInputParams()) {
-            List<SqlParam> inputParams = findInputParams(Collections.emptyList());
-            statementInfo.setInParams(
-                    dbHelper.getJDBCInfoByColumnNames(
-                            null, schema, tableNameUpdate, inputParams));
-        }
-    }
-
-    private void parseDelete() throws SQLException  {
-        statementInfo.setStatementType(StatementType.DELETE);
-        String tableNameDelete = statementInfo.addTable(sqlArrayUpperCase.get(2));
-        if (! statementInfo.getTablesInSchema().contains(tableNameDelete)) {
-            throw new SQLException(String.format("Table '%s' does not exist", tableNameDelete));
-        }
-        if (statementInfo.hasInputParams()) {
-            List<SqlParam> inputParams = findInputParams(Collections.emptyList());
-            statementInfo.setInParams(
-                    dbHelper.getJDBCInfoByColumnNames(
-                            null, schema, tableNameDelete, inputParams));
-        }
-    }
-
-    private void parseSelect() throws SQLException  {
-        statementInfo.setStatementType(StatementType.SELECT);
-        List<String> tableNamesSelect = findTablesInSelectStatement();
-        if (! tableNamesSelect.isEmpty()) {
-            for (String tableNameSelect : tableNamesSelect) {
-                if (! statementInfo.getTablesInSchema().contains(tableNameSelect)) {
-                    throw new SQLException(String.format("Table '%s' does not exist", tableNameSelect));
-                }
-            }
-        }
-        if (statementInfo.hasInputParams()) {
-            List<SqlParam> inputParams = findInputParams(Collections.emptyList());
-            statementInfo.setTableNames(findTablesInSelectStatement());
-            statementInfo.setInParams(
-                    dbHelper.getJDBCInfoByColumnNames(
-                            null, schema, statementInfo.getTableNames().get(0), inputParams));
-        }
-        statementInfo.setOutParams(dbHelper.getOutputColumnInfo(statementInfo.getDefaultedSqlStatement()));
-    }
-
-    List<String> splitSqlStatement(String sql) {
-        List<String> sqlArray = new ArrayList<>();
-        String[] segments = sql.split("!=|=|<=|>=|<|>|,|\\s|\\(|\\)", -1);
-        for (String segment : segments) {
-            if (!"".equals(segment)) {
-                sqlArray.add(segment);
-            }
-        }
-        return sqlArray;
-    }
-
-    /**
-     * INSERT INTO table_name (column1, column2, column3, ...)
-     * VALUES (value1, value2, value3, ...);
-     * INSERT INTO table_name
-     * VALUES (value1, value2, value3, ...);
-     */
-    List<SqlParam> findInsertParams(String tableName) {
-        boolean isColumnName = false;
-        List<String> columnNames = new ArrayList<>();
-        for (String word: sqlArrayUpperCase) {
-            if ("VALUES".equals(word)) {
-                isColumnName = false;
-            }
-            if (isColumnName) {
-                columnNames.add(word);
-            }
-            if (tableName.equals(word)) {
-                isColumnName = true; //in the next iteration
-            }
-        }
-        int v = sqlArrayUpperCase.indexOf("VALUES") + 1;
-        List<SqlParam> params = Collections.emptyList();
-        if (!columnNames.isEmpty()) {
-            List<String> values = sqlArray.subList(v, v + columnNames.size() );
-            params = findInputParams(values);
-            int paramCounter = 0;
-            for (int i=0; i<columnNames.size(); i++) {
-                if (values.get(i).startsWith(":#")) {
-                    params.get(paramCounter++).setColumn(columnNames.get(i).toUpperCase(Locale.US));
-                }
-            }
-        } else {
-            List<String> values = sqlArray.subList(v, sqlArray.size());
-            params = findInputParams(values);
-        }
-        return params;
-    }
-
-    List<SqlParam> findInputParams(List<String> values) {
-        List<SqlParam> params = new ArrayList<>();
-        String inTable=null;
-        int i=0;
-        for (String word: sqlArray) {
-            if (word.startsWith(":#")) {
-                SqlParam param = new SqlParam(word.substring(2));
-                String column = sqlArray.get(i-1);
-                if ("LIKE".equalsIgnoreCase(column)) {
-                    column = sqlArray.get(i-2);
-                }
-                if ("BETWEEN".equalsIgnoreCase(column)) {
-                    column = sqlArray.get(i-2);
-                }
-                if ("IN".equalsIgnoreCase(column)) {
-                    column = sqlArray.get(i-2);
-                    inTable = column;
-                }
-                if ("AND".equalsIgnoreCase(column)) {
-                    column = sqlArray.get(i-4);
-                }
-                if (inTable != null && column.startsWith(":#")) {
-                    param.setColumn(inTable);
-                } else {
-                    if (column.startsWith(":#") || "VALUES".equalsIgnoreCase(column) || values.contains(column)) {
-                        param.setColumnPos(values.indexOf(word));
-                    } else {
-                        param.setColumn(column.toUpperCase(Locale.US));
-                    }
-                }
-                params.add(param);
-            }
-            i++;
-        }
-        return params;
-    }
-
-    List<String> findTablesInSelectStatement() throws SQLException {
-        boolean isTable = false;
-        List<String> tables = new ArrayList<>();
-        for (String word: sqlArrayUpperCase) {
-            if (! statementInfo.getTablesInSchema().contains(word)) {
-                if (isTable && tables.isEmpty()) {
-                    throw new SQLException(String.format("Table '%s' does not exist in schema '%s'", word, schema));
-                }
-                isTable = false;
-            }
-            if (isTable) {
-                tables.add(word);
-            }
-            if ("FROM".equals(word)) {
-                isTable = true; //in the next iteration
-            }
-
-        }
-        return tables;
-    }
-
 
 }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/MissingTableTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/MissingTableTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@ExtendWith(SqlTest.class)
+public class MissingTableTest {
+
+    final Connection con;
+
+    MissingTableTest(final Connection con) {
+        this.con = con;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NAME_NOTEXIST", "name_notexist", "Name_NotExist"})
+    public void parseSelectFromNoneExistingTable(final String missingTable) throws SQLException {
+        try (Connection connection = con) {
+            final SqlStatementParser parser = new SqlStatementParser(connection,
+                "SELECT FIRSTNAME, LASTNAME FROM " + missingTable + " WHERE FIRSTNAME LIKE :#first");
+
+            assertThatExceptionOfType(SQLException.class).isThrownBy(() -> parser.parse())
+                .withMessage("Table(s) '" + missingTable + "' cannot be found in schema 'SA'");
+        }
+    }
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserPostgresqlTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserPostgresqlTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import io.syndesis.connector.sql.common.DatabaseContainers.Database;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Database("postgres:11.11")
+public class SqlParserPostgresqlTest {
+
+    @ExtendWith(DatabaseContainers.class)
+    @TestTemplate
+    public void parseSelectWithoutFrom(final JdbcDatabaseContainer<?> postgresql) throws SQLException {
+        try (Connection connection = postgresql.createConnection("")) {
+            final SqlStatementParser parser = new SqlStatementParser(connection, "SELECT 3 AS id");
+            final SqlStatementMetaData metaData = parser.parse();
+
+            assertThat(metaData.getInParams()).isEmpty();
+            assertThat(metaData.getOutParams()).extracting(SqlParam::getName).containsOnly("id");
+            assertThat(metaData.getTableNames()).isEmpty();
+        }
+    }
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/SqlParserTest.java
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 @ExtendWith(SqlTest.class)
 @Setup({
     "CREATE TABLE NAME0 (id INTEGER PRIMARY KEY, firstName VARCHAR(255), lastName VARCHAR(255))",
@@ -322,17 +320,6 @@ public class SqlParserTest {
             Assertions.assertEquals("lastname", info.getInParams().get(0).getName());
             Assertions.assertEquals(1, info.getInParams().get(0).getColumnPos());
             Assertions.assertEquals("LASTNAME", info.getInParams().get(0).getColumn());
-        }
-    }
-
-    @Test
-    public void parseSelectFromNoneExistingTable(final Connection con) throws SQLException {
-        try (Connection connection = con) {
-            final SqlStatementParser parser = new SqlStatementParser(connection,
-                "SELECT FIRSTNAME, LASTNAME FROM NAME_NOTEXIST WHERE FIRSTNAME LIKE :#first");
-
-            assertThatExceptionOfType(SQLException.class).isThrownBy(() -> parser.parse())
-                .withMessage("Table(s) 'NAME_NOTEXIST' cannot be found in schema 'SA'");
         }
     }
 

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SampleStoredProcedures.java
@@ -31,14 +31,6 @@ public final class SampleStoredProcedures {
             "LANGUAGE JAVA " +
             "EXTERNAL NAME 'io.syndesis.connector.sql.stored.SampleStoredProcedures.demo_out'";
 
-    public static final String DERBY_FUNCTION_DEMO_OUT_SQL =
-        "CREATE FUNCTION DEMO_OUT_DEGREES " +
-            "( RADIANS DOUBLE ) " +
-            "RETURNS DOUBLE " +
-            "PARAMETER STYLE JAVA " +
-            "NO SQL LANGUAGE JAVA " +
-            "EXTERNAL NAME 'java.lang.Math.toDegrees'";
-
     /**
      * SQL to create the DEMO_ADD procedure in Oracle
      */

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredProcedureTest.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/stored/SqlStoredProcedureTest.java
@@ -30,12 +30,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.syndesis.connector.sql.stored.SampleStoredProcedures.DERBY_FUNCTION_DEMO_OUT_SQL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SqlTest.class)
-@Setup({SampleStoredProcedures.DERBY_DEMO_ADD_SQL, DERBY_FUNCTION_DEMO_OUT_SQL})
-@Teardown("DROP PROCEDURE DEMO_ADD")
+@Setup({SampleStoredProcedures.DERBY_DEMO_ADD_SQL, "CREATE FUNCTION DEMO_OUT_DEGREES ( RADIANS DOUBLE ) RETURNS DOUBLE PARAMETER STYLE JAVA NO SQL LANGUAGE JAVA EXTERNAL NAME 'java.lang.Math.toDegrees'"})
+@Teardown({"DROP PROCEDURE DEMO_ADD", "DROP FUNCTION DEMO_OUT_DEGREES"})
 public class SqlStoredProcedureTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStoredProcedureTest.class);
 


### PR DESCRIPTION
The homegrown SQL parser made a number of assumptions and was very
brittle which made it really difficult to maintain.

This replaces the homegrown SQL parser with jsqlparser, which is more
robust, correct and feature full which should ease maintenance.

Ref. issues.redhat.com/browse/ENTESB-13689

fix(c/sql): make sure test tear down is done (6f85713)

We need to make sure that any object we create is dropped in the test.
Otherwise we might get flaky tests that depend on the order of
execution.