### PR TITLE
fix(operator): pbt test failure with control chars

### DIFF
--- a/install/operator/pkg/generator/generator_test.go
+++ b/install/operator/pkg/generator/generator_test.go
@@ -721,12 +721,15 @@ func TestGeneratorProperty(t *testing.T) {
 	parameters.MaxSize = 10
 
 	arbitraries := arbitrary.DefaultArbitraries()
-	arbitraries.RegisterGen(gen.AlphaNumChar())
+	arbitraries.RegisterGen(gen.AlphaString())
 	arbitraries.RegisterGen(gen.Struct(reflect.TypeOf(v1beta2.ResourcesWithPersistentVolume{}), map[string]gopter.Gen{
 		"VolumeLabels": gen.MapOf(gen.Identifier(), gen.Identifier()), // we can't have volume labels with keys that are empty strings
 	}))
 	arbitraries.RegisterGen(gen.Struct(reflect.TypeOf(v1beta2.DatabaseConfiguration{}), map[string]gopter.Gen{
 		"ExternalDbURL": gen.Identifier(),
+	}))
+	arbitraries.RegisterGen(gen.Struct(reflect.TypeOf(v1beta2.MavenConfiguration{}), map[string]gopter.Gen{
+		"Repositories": gen.MapOf(gen.Identifier(), gen.Identifier()), // we can't have Maven repositories with illegal characters
 	}))
 
 	properties := gopter.NewProperties(parameters)


### PR DESCRIPTION
The CR PBT test failed with seed 1620109386871515467 that introduced
control characters in string values of the generated YAML. This
configures the generator to generate alpha strings by default and
identifiers for Maven repository configuration.