### PR TITLE
chore: Update to AtlasMap 2.2.1

### DIFF
--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-790029</camel.version>
-    <atlasmap.version>2.2.0</atlasmap.version>
+    <atlasmap.version>2.2.1</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>
   </properties>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,7 +39,7 @@
     <deploy.archives>false</deploy.archives>
 
     <!-- Atlasmap version -->
-    <atlasmap.version>2.2.0</atlasmap.version>
+    <atlasmap.version>2.2.1</atlasmap.version>
 
     <!-- Image names -->
     <image.s2i>syndesis/syndesis-s2i:%l</image.s2i>

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -84,7 +84,7 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "@atlasmap/atlasmap": "^2.2.0",
+    "@atlasmap/atlasmap": "^2.2.1",
     "react-fast-compare": "^2.0.2"
   },
   "jest": {

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -226,19 +226,19 @@
   dependencies:
     tslib "^1.9.0"
 
-"@atlasmap/atlasmap@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.2.0.tgz#f7f25c8509400004e8bd5763491db16e688113f3"
-  integrity sha512-AjXvrcf2M9O9dIjQRLITH5RO/MYizML8NAQ5+NLmbYjeEVfe1ElNzaR1rhP5OaoRiMdYMqQpLCiNIczg+OsPxg==
+"@atlasmap/atlasmap@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@atlasmap/atlasmap/-/atlasmap-2.2.1.tgz#d847100495ed5915a16e9e42d52d51c736d64474"
+  integrity sha512-ZTZ5YHn7n3odYVvz/s54BeaKqhjyzybbvj2cPshmoxjYoxmw6H4SSTuaDWRq+6TEiLCgJPOhAFs7Zo2uDQOJeQ==
   dependencies:
-    "@atlasmap/core" "^2.2.0"
+    "@atlasmap/core" "^2.2.1"
     react-sage "^0.0.42"
     use-debounce "^3.4.2"
 
-"@atlasmap/core@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.2.0.tgz#c18113f84cd022338e5aa27b74c280ecfe849efc"
-  integrity sha512-mN82LYCBGy+2/oTcI7PyEuGso7pAzp66BAJJhHgGYqC1Lji17JMdGcUhgJyQ9nnW6foFgP9JI3YLdLsuIihJ7g==
+"@atlasmap/core@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@atlasmap/core/-/core-2.2.1.tgz#f3f45d7d7dbe89f6ba577c020620fa47b473e3d3"
+  integrity sha512-G6koYgVqTwtp899QQgfcp2KKX1osNnRltJ19Jm+Qv+IdeV1d4qQCku5KNVCa6zQ3nlFWO1ilAm8xrT5dw/yguQ==
   dependencies:
     file-saver "2.0.2"
     loglevel "^1.6.7"


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ENTESB-16353
Contains: atlasmap/atlasmap#2729 - Regression: UI: Mapping for a collection reference expression missing reference layer input field group (non-preview).

It's not a blocker ATM, so we can skip if it bothers productization.