### PR TITLE
fix(build): remove `paths-ignore`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - '[0-9]+.[0-9]+.x'
-    paths-ignore:
-      - doc/**
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The purpose for `paths-ignore` was not to trigger any check for changes
in the `doc/`. This doesn't seem to work with the required checks, as
those still remain required, and in progress, even though they should
have been skipped. This removes the `paths-ignore`, in that case two
jobs will be run `setup` and `changes`, and since `changes` won't find
any changes in the operator, backend or UI, no other jobs will be run.
This will mark the required (operator, backend, UI) checks as skipped
and allow the pull request to be merged.