### PR TITLE
feat: GitHub annotations for Java tests

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -170,6 +170,7 @@
     <kafka-clients.version>2.5.0</kafka-clients.version>
     <netty.version>4.1.48.Final</netty.version>
     <net.jqwik.version>1.5.1</net.jqwik.version>
+    <io.github.zregvart.junit-github-reporter.version>0.3.0</io.github.zregvart.junit-github-reporter.version>
 
     <!-- Sonar configuration -->
     <sonar.projectKey>${project.artifactId}</sonar.projectKey>
@@ -932,6 +933,51 @@
         <errorprone.autofix.arg1>-XepPatchChecks:BadImport,DeadException,DefaultCharset,MissingOverride,UnnecessaryParentheses,UnusedVariable,UnusedMethod,FieldCanBeFinal,MethodCanBeStatic,ClassCanBeStatic,RemoveUnusedImports,ThrowsUncheckedException,EmptyBlockTag,UnnecessaryMethodReference,ProtectedMembersInFinalClass,InvalidParam,NonCanonicalType,ZoneIdOfZ</errorprone.autofix.arg1>
         <errorprone.autofix.arg2>-XepPatchLocation:IN_PLACE</errorprone.autofix.arg2>
       </properties>
+    </profile>
+
+    <profile>
+      <id>github</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_WORKSPACE</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <additionalClasspathElements>
+                  <additionalClasspathElement>${settings.localRepository}/io/github/zregvart/junit-github-reporter/${io.github.zregvart.junit-github-reporter.version}/junit-github-reporter-${io.github.zregvart.junit-github-reporter.version}.jar</additionalClasspathElement>
+                </additionalClasspathElements>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>io.github.zregvart</groupId>
+                  <artifactId>junit-github-reporter</artifactId>
+                  <version>${io.github.zregvart.junit-github-reporter.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+            <plugin>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <additionalClasspathElements>
+                  <additionalClasspathElement>${settings.localRepository}/io/github/zregvart/junit-github-reporter/${io.github.zregvart.junit-github-reporter.version}/junit-github-reporter-${io.github.zregvart.junit-github-reporter.version}.jar</additionalClasspathElement>
+                </additionalClasspathElements>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>io.github.zregvart</groupId>
+                  <artifactId>junit-github-reporter</artifactId>
+                  <version>${io.github.zregvart.junit-github-reporter.version}</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
 
   </profiles>


### PR DESCRIPTION
When tests are run in GitHub workflows a line is emitted for each
failing test in the syntax of GitHub workflow command[1], that instructs
GitHub to set annotation on the "Files" section of pull request for each
failing test. This makes it very easy to find out what assertion in what
test failed.
The junit-github-reporter[2] is added to the test classpath via
`additionalClasspathElements` which doesn't support setting GAV
coordinates of the dependency, so a path to the local Maven repository
is computed, and to download the dependency plugin dependency is added.
The added dependency on the plugin doesn't have any effect, but it
provisions the download in the local repository to allow pointing to
the path of the jar in `additionalClasspathElements`.
There is a maximum of 10 errors that can be added this way, so only
first 10 test failures will be reported.

[1] https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
[2] https://github.com/zregvart/junit-github-reporter