### PR TITLE
fix(server): API provider error handling migration

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/Schema.java
@@ -20,7 +20,7 @@ package io.syndesis.common.model;
  */
 public final class Schema {
     // changing this kick of migration of the DB data to this version.
-    public static final int VERSION = 42;
+    public static final int VERSION = 43;
 
     private Schema() {
       // quasi utility class

--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -76,7 +76,7 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getControlHint();
 
-    Object getDefaultValue();
+    String getDefaultValue();
 
     Boolean getDeprecated();
 

--- a/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
+++ b/app/connector/kafka/src/main/resources/META-INF/syndesis/connector/kafka.json
@@ -122,7 +122,7 @@
         "i18nAddElementText": "Add a custom property",
         "minElements": 0
       },
-      "defaultValue": [],
+      "defaultValue": "",
       "displayName": "Extra Options",
       "type": "array"
     },

--- a/app/server/runtime/src/main/resources/migrations/up-43.js
+++ b/app/server/runtime/src/main/resources/migrations/up-43.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var migrateAction = function(action) {
+    if (!action) {
+        return false;
+    }
+
+    if (action.id !== 'io.syndesis:api-provider-end') {
+        return false;
+    }
+
+    var changed = false;
+    var descriptor = action.descriptor;
+    if (descriptor.exceptionHandler !== 'io.syndesis.connector.apiprovider.ApiProviderOnExceptionHandler') {
+        descriptor.exceptionHandler = 'io.syndesis.connector.apiprovider.ApiProviderOnExceptionHandler';
+        changed = true;
+    }
+
+    var propertyDefinitionSteps = descriptor.propertyDefinitionSteps;
+    var configuration = propertyDefinitionSteps[0].properties;
+    var errorResponseCodes = configuration['errorResponseCodes'];
+    if (errorResponseCodes.defaultValue !== '{"SERVER_ERROR":"500"}') {
+        errorResponseCodes.defaultValue = '{"SERVER_ERROR":"500"}';
+        changed = true;
+    }
+
+    var returnBody = configuration['returnBody'];
+    if (returnBody.defaultValue !== true) {
+        returnBody.defaultValue = true;
+        changed = true;
+    }
+
+    return changed;
+}
+
+var migrateConnector = function(connector) {
+    if (!connector) {
+        return false;
+    }
+
+    if (connector.id !== 'api-provider') {
+        return false;
+    }
+
+    if (connector.actions) {
+        var changed = false;
+        connector.actions.forEach(function(action) {
+            changed |= migrateAction(action)
+        });
+
+        return changed;
+    }
+
+    return false;
+}
+
+var migrateConnection = function(connection) {
+    if (!connection) {
+        return false;
+    }
+
+    if (migrateConnector(connection.connector)) {
+        return true;
+    }
+
+    return false;
+}
+
+
+var migrateStep = function(step) {
+    if (!step) {
+        return false;
+    }
+
+    var changed = migrateAction(step.action)
+    changed |= migrateConnection(step.connection)
+
+    return changed
+}
+
+var migrate = function(path, migrateFn) {
+    var elements = jsondb.get(path);
+
+    if (!elements) {
+        return;
+    }
+
+    var migrated = 0;
+
+    Object.keys(elements).forEach(function(elementId) {
+        if (migrateFn(elements[elementId])) {
+            migrated++;
+        }
+    });
+
+    if (migrated > 0) {
+        jsondb.update(path, elements);
+    }
+}
+
+console.log('Migration to schema 43 ...');
+
+migrate('/connectors', migrateConnector);
+migrate('/connections', function(connection) {
+    return migrateConnector(connection.connector);
+});
+migrate('/integrations', function(integration) {
+    var changed = false
+
+    if (integration.steps) {
+        integration.steps.forEach(function(step) {
+            changed |= migrateStep(step)
+        });
+    }
+
+    if (integration.flows) {
+        integration.flows.forEach(function(flow) {
+            flow.steps.forEach(function(step) {
+                changed |= migrateStep(step)
+            });
+        });
+    }
+
+    return changed;
+});
+
+console.log('Migrated to schema 43 completed');

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion43Test.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/migrations/UpgradeVersion43Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.syndesis.server.runtime.migrations;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import io.syndesis.common.model.action.ActionDescriptor.ActionDescriptorStep;
+import io.syndesis.common.model.action.ConnectorAction;
+import io.syndesis.common.model.action.ConnectorDescriptor;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.model.integration.Flow;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.Step;
+import io.syndesis.server.jsondb.CloseableJsonDB;
+import io.syndesis.server.jsondb.dao.Migrator;
+import io.syndesis.server.jsondb.impl.MemorySqlJsonDB;
+import io.syndesis.server.runtime.DefaultMigrator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import static io.syndesis.server.runtime.migrations.MigrationsHelper.load;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpgradeVersion43Test {
+
+    @Test
+    public void shouldPerformSchemaUpgrade() throws IOException {
+        try (CloseableJsonDB jsondb = MemorySqlJsonDB.create(Collections.emptyList());
+            InputStream is = UpgradeVersion43Test.class.getResourceAsStream("/migrations/43/integration.json")) {
+            jsondb.push("/integrations", is);
+
+            final Migrator migrator = new DefaultMigrator(new DefaultResourceLoader());
+            migrator.migrate(jsondb, 43);
+
+            final List<Integration> integrations = load(jsondb, "/integrations", Integration.class);
+
+            assertThat(integrations).hasSize(1);
+
+            final Integration migrated = integrations.get(0);
+            assertThat(migrated.getFlows())
+                .hasSize(5)
+                .allSatisfy(flow -> assertThat(lastStepOf(flow))
+                    .satisfies(step -> assertThat(step.getActionAs(ConnectorAction.class))
+                        .hasValueSatisfying(lastAction -> {
+                            assertThat(lastAction.getId()).hasValue("io.syndesis:api-provider-end");
+
+                            final ConnectorDescriptor descriptor = lastAction.getDescriptor();
+                            assertThat(descriptor.getExceptionHandler()).hasValue("io.syndesis.connector.apiprovider.ApiProviderOnExceptionHandler");
+
+                            final Map<String, ActionDescriptorStep> propertyDefinitionSteps = descriptor.getPropertyDefinitionStepsAsMap();
+                            final Map<String, ConfigurationProperty> configurationProperties = propertyDefinitionSteps.get("configuration").getProperties();
+                            assertThat(configurationProperties.get("errorResponseCodes").getDefaultValue()).isEqualTo("{\"SERVER_ERROR\":\"500\"}");
+                            assertThat(configurationProperties.get("returnBody").getDefaultValue()).isEqualTo("true");
+                        })));
+        }
+    }
+
+    static Step lastStepOf(final Flow flow) {
+        final List<Step> steps = flow.getSteps();
+
+        return steps.get(steps.size() - 1);
+    }
+
+}

--- a/app/server/runtime/src/test/resources/migrations/43/integration.json
+++ b/app/server/runtime/src/test/resources/migrations/43/integration.json
@@ -1,0 +1,5417 @@
+{
+    "createdAt": 1580318846030,
+    "flows": [
+        {
+            "description": "GET /",
+            "id": "i-LzmKKuAdexCgwPv3VhKz",
+            "metadata": {
+                "default-return-code": "200",
+                "excerpt": "200 All is good",
+                "openapi-operationid": "fetch-all-tasks",
+                "return-code-edited": "true"
+            },
+            "name": "List all tasks",
+            "steps": [
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Start a Syndesis integration from a provided API",
+                        "descriptor": {
+                            "componentScheme": "direct",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "name": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The operation ID as defined in the API spec",
+                                            "displayName": "Operation ID",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-start",
+                        "metadata": {
+                            "serverBasePath": "/"
+                        },
+                        "name": "Provided API",
+                        "pattern": "From",
+                        "tags": [
+                            "expose",
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "name": "fetch-all-tasks"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKu-dexCgwPv3VhIz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Invoke SQL to obtain, store, update, or delete data.",
+                        "descriptor": {
+                            "componentScheme": "sql",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none",
+                                "type": "SQL_PARAM_IN"
+                            },
+                            "outputDataShape": {
+                                "description": "Result of SQL [SELECT * FROM TODO]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "collection"
+                                },
+                                "name": "SQL Result",
+                                "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}}",
+                                "type": "SQL_PARAM_OUT"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                    "name": "SQL statement",
+                                    "properties": {
+                                        "batch": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Batch update",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        },
+                                        "query": {
+                                            "dataList": [
+                                                "SELECT * FROM TODO"
+                                            ],
+                                            "defaultValue": "SELECT * FROM TODO",
+                                            "deprecated": false,
+                                            "displayName": "SQL statement",
+                                            "group": "common",
+                                            "javaType": "java.lang.String",
+                                            "kind": "path",
+                                            "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                            "order": 1,
+                                            "placeholder": "for example ':#MYPARAMNAME'",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "dataList"
+                                        },
+                                        "raiseErrorOnNotFound": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Raise error when record not found",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Error when no records are selected, updated or deleted",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "SqlDataAccessError",
+                                    "name": "SQL_DATA_ACCESS_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlEntityNotFoundError",
+                                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlConnectorError",
+                                    "name": "SQL_CONNECTOR_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "sql-connector",
+                        "name": "Invoke SQL",
+                        "pattern": "To",
+                        "tags": [
+                            "dynamic"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "batch": "false",
+                        "query": "SELECT * FROM TODO",
+                        "raiseErrorOnNotFound": "false"
+                    },
+                    "connection": {
+                        "configuredProperties": {
+                            "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                            "schema": "sampledb",
+                            "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                            "user": "sampledb"
+                        },
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "batch": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Batch update",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                                        "order": 1,
+                                                        "placeholder": "for example ':#MYPARAMNAME'",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "raiseErrorOnNotFound": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Raise error when record not found",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Error when no records are selected, updated or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "SqlDataAccessError",
+                                                "name": "SQL_DATA_ACCESS_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlEntityNotFoundError",
+                                                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlConnectorError",
+                                                "name": "SQL_CONNECTOR_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-connector",
+                                    "name": "Invoke SQL",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke SQL to obtain data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that returns results, such as SELECT.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "isRaiseErrorOnNotFound": {
+                                                        "deprecated": false,
+                                                        "displayName": "Raise NotFoundError",
+                                                        "group": "consumer",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed.",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-start-connector",
+                                    "name": "Periodic SQL invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "property",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored procedure template to perform.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-connector",
+                                    "name": "Invoke stored procedure",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored Procedure template to perform.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-start-connector",
+                                    "name": "Periodic stored procedure invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                }
+                            ],
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "jdbc-driver",
+                                    "type": "EXTENSION_TAG"
+                                }
+                            ],
+                            "description": "Invoke SQL to obtain, store, update, or delete data.",
+                            "icon": "assets:sql.svg",
+                            "id": "sql",
+                            "name": "Database",
+                            "properties": {
+                                "password": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Password",
+                                    "group": "security",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common,security",
+                                    "labelHint": "Password for the database connection.",
+                                    "order": 3,
+                                    "required": true,
+                                    "secret": true,
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Schema",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common",
+                                    "labelHint": "Database schema.",
+                                    "order": 4,
+                                    "required": false,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Connection URL",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "JDBC URL of the database.",
+                                    "order": 1,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Username",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "Username for the database connection.",
+                                    "order": 2,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                }
+                            },
+                            "tags": [
+                                "verifier"
+                            ],
+                            "version": 1
+                        },
+                        "connectorId": "sql",
+                        "description": "Connection to SampleDB",
+                        "icon": "assets:sql.svg",
+                        "id": "5",
+                        "isDerived": false,
+                        "name": "PostgresDB",
+                        "tags": [
+                            "sampledb"
+                        ],
+                        "uses": 0
+                    },
+                    "id": "-LzmKo_efTAdq4stfbU-",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}}"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmKo_efTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmKo_efTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKu8dexCgwPv3VhJz\",\"uri\":\"atlas:json:i-LzmKKu8dexCgwPv3VhJz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.324856\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.167891\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.472896\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/<>/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmKo_efTAdq4stfbU-\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body<>/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKu8dexCgwPv3VhJz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmKod9fTAdq4stfbU-",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "End action of Syndesis integrations that start from a provided API",
+                        "descriptor": {
+                            "componentScheme": "bean",
+                            "configuredProperties": {
+                                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                "method": "process"
+                            },
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}}"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Return Path Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "defaultResponse": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Default Response",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 0,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorHandling": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Error Handling",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorResponseCodes": {
+                                            "componentProperty": false,
+                                            "defaultValue": "{}",
+                                            "deprecated": false,
+                                            "description": "The return code to set according to different error situations",
+                                            "displayName": "Error Response Codes",
+                                            "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                            "javaType": "Map",
+                                            "kind": "parameter",
+                                            "order": 4,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "mapset"
+                                        },
+                                        "httpResponseCode": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The return code to set in the HTTP response",
+                                            "displayName": "Return Code",
+                                            "enum": [
+                                                {
+                                                    "label": "200 All is good",
+                                                    "value": "200"
+                                                },
+                                                {
+                                                    "label": "500 Server Error",
+                                                    "value": "500"
+                                                }
+                                            ],
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 1,
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "select"
+                                        },
+                                        "returnBody": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Include error message in the return body",
+                                            "javaType": "Boolean",
+                                            "kind": "parameter",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "ServerError",
+                                    "name": "SERVER_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-end",
+                        "name": "Provided API Return Path",
+                        "pattern": "To",
+                        "tags": [
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "errorResponseCodes": "{}",
+                        "httpResponseCode": "200",
+                        "returnBody": "false"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKu8dexCgwPv3VhJz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                }
+            ],
+            "tags": [
+                "5",
+                "api-provider"
+            ],
+            "type": "API_PROVIDER"
+        },
+        {
+            "description": "POST /",
+            "id": "i-LzmKKuCdexCgwPv3VhNz",
+            "metadata": {
+                "default-return-code": "201",
+                "excerpt": "201 All is good",
+                "openapi-operationid": "create-task",
+                "return-code-edited": "true"
+            },
+            "name": "Create new task",
+            "steps": [
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Start a Syndesis integration from a provided API",
+                        "descriptor": {
+                            "componentScheme": "direct",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "description": "API request payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Request",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "name": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The operation ID as defined in the API spec",
+                                            "displayName": "Operation ID",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-start",
+                        "metadata": {
+                            "serverBasePath": "/"
+                        },
+                        "name": "Provided API",
+                        "pattern": "From",
+                        "tags": [
+                            "expose",
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "name": "create-task"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKuCdexCgwPv3VhLz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "Parameters of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhLz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhLz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL3kqfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL3kqfTAdq4stfbU-\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.762827\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.45448\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.237428\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmL5GrfTAdq4stfbU-",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Invoke SQL to obtain, store, update, or delete data.",
+                        "descriptor": {
+                            "componentScheme": "sql",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "Parameters of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            },
+                            "outputDataShape": {
+                                "description": "Result of SQL [INSERT INTO TODO VALUES (:#id, :#task, :#completed)]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "collection"
+                                },
+                                "name": "SQL Result",
+                                "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}}",
+                                "type": "SQL_PARAM_OUT"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                    "name": "SQL statement",
+                                    "properties": {
+                                        "batch": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Batch update",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        },
+                                        "query": {
+                                            "dataList": [
+                                                "INSERT INTO TODO VALUES (:#id, :#task, :#completed)"
+                                            ],
+                                            "defaultValue": "INSERT INTO TODO VALUES (:#id, :#task, :#completed)",
+                                            "deprecated": false,
+                                            "displayName": "SQL statement",
+                                            "group": "common",
+                                            "javaType": "java.lang.String",
+                                            "kind": "path",
+                                            "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                            "order": 1,
+                                            "placeholder": "for example ':#MYPARAMNAME'",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "dataList"
+                                        },
+                                        "raiseErrorOnNotFound": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Raise error when record not found",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Error when no records are selected, updated or deleted",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "SqlDataAccessError",
+                                    "name": "SQL_DATA_ACCESS_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlEntityNotFoundError",
+                                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlConnectorError",
+                                    "name": "SQL_CONNECTOR_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "sql-connector",
+                        "name": "Invoke SQL",
+                        "pattern": "To",
+                        "tags": [
+                            "dynamic"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "batch": "false",
+                        "query": "INSERT INTO TODO VALUES (:#id, :#task, :#completed)",
+                        "raiseErrorOnNotFound": "false"
+                    },
+                    "connection": {
+                        "configuredProperties": {
+                            "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                            "schema": "sampledb",
+                            "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                            "user": "sampledb"
+                        },
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "batch": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Batch update",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                                        "order": 1,
+                                                        "placeholder": "for example ':#MYPARAMNAME'",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "raiseErrorOnNotFound": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Raise error when record not found",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Error when no records are selected, updated or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "SqlDataAccessError",
+                                                "name": "SQL_DATA_ACCESS_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlEntityNotFoundError",
+                                                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlConnectorError",
+                                                "name": "SQL_CONNECTOR_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-connector",
+                                    "name": "Invoke SQL",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke SQL to obtain data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that returns results, such as SELECT.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "isRaiseErrorOnNotFound": {
+                                                        "deprecated": false,
+                                                        "displayName": "Raise NotFoundError",
+                                                        "group": "consumer",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed.",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-start-connector",
+                                    "name": "Periodic SQL invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "property",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored procedure template to perform.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-connector",
+                                    "name": "Invoke stored procedure",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored Procedure template to perform.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-start-connector",
+                                    "name": "Periodic stored procedure invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                }
+                            ],
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "jdbc-driver",
+                                    "type": "EXTENSION_TAG"
+                                }
+                            ],
+                            "description": "Invoke SQL to obtain, store, update, or delete data.",
+                            "icon": "assets:sql.svg",
+                            "id": "sql",
+                            "name": "Database",
+                            "properties": {
+                                "password": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Password",
+                                    "group": "security",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common,security",
+                                    "labelHint": "Password for the database connection.",
+                                    "order": 3,
+                                    "required": true,
+                                    "secret": true,
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Schema",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common",
+                                    "labelHint": "Database schema.",
+                                    "order": 4,
+                                    "required": false,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Connection URL",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "JDBC URL of the database.",
+                                    "order": 1,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Username",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "Username for the database connection.",
+                                    "order": 2,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                }
+                            },
+                            "tags": [
+                                "verifier"
+                            ],
+                            "version": 1
+                        },
+                        "connectorId": "sql",
+                        "description": "Connection to SampleDB",
+                        "icon": "assets:sql.svg",
+                        "id": "5",
+                        "isDerived": false,
+                        "name": "PostgresDB",
+                        "tags": [
+                            "sampledb"
+                        ],
+                        "uses": 0
+                    },
+                    "id": "-LzmL3kqfTAdq4stfbU-",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhLz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhLz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL5GrfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL5GrfTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmL3kqfTAdq4stfbU-\",\"uri\":\"atlas:json:-LzmL3kqfTAdq4stfbU-\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuCdexCgwPv3VhMz\",\"uri\":\"atlas:json:i-LzmKKuCdexCgwPv3VhMz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.191136\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmL3kqfTAdq4stfbU-\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.200510\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.843803\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhLz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuCdexCgwPv3VhMz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmL81QfTAdq4stfbU0",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "End action of Syndesis integrations that start from a provided API",
+                        "descriptor": {
+                            "componentScheme": "bean",
+                            "configuredProperties": {
+                                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                "method": "process"
+                            },
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Return Path Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "defaultResponse": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Default Response",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 0,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorHandling": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Error Handling",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorResponseCodes": {
+                                            "componentProperty": false,
+                                            "defaultValue": "{}",
+                                            "deprecated": false,
+                                            "description": "The return code to set according to different error situations",
+                                            "displayName": "Error Response Codes",
+                                            "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"201 All is good\",\"value\":\"201\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                            "javaType": "Map",
+                                            "kind": "parameter",
+                                            "order": 4,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "mapset"
+                                        },
+                                        "httpResponseCode": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The return code to set in the HTTP response",
+                                            "displayName": "Return Code",
+                                            "enum": [
+                                                {
+                                                    "label": "201 All is good",
+                                                    "value": "201"
+                                                },
+                                                {
+                                                    "label": "500 Server Error",
+                                                    "value": "500"
+                                                }
+                                            ],
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 1,
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "select"
+                                        },
+                                        "returnBody": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Include error message in the return body",
+                                            "javaType": "Boolean",
+                                            "kind": "parameter",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "ServerError",
+                                    "name": "SERVER_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-end",
+                        "name": "Provided API Return Path",
+                        "pattern": "To",
+                        "tags": [
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "errorResponseCodes": "{}",
+                        "httpResponseCode": "201",
+                        "returnBody": "false"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKuCdexCgwPv3VhMz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                }
+            ],
+            "tags": [
+                "5",
+                "api-provider"
+            ],
+            "type": "API_PROVIDER"
+        },
+        {
+            "description": "GET /{id}",
+            "id": "i-LzmKKurdexCgwPv3VhQz",
+            "metadata": {
+                "default-return-code": "200",
+                "excerpt": "200 All is good",
+                "openapi-operationid": "fetch-task",
+                "return-code-edited": "true"
+            },
+            "name": "Fetches task by given identifier",
+            "steps": [
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Start a Syndesis integration from a provided API",
+                        "descriptor": {
+                            "componentScheme": "direct",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "description": "API request payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Request",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}}}}"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "name": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The operation ID as defined in the API spec",
+                                            "displayName": "Operation ID",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-start",
+                        "metadata": {
+                            "serverBasePath": "/"
+                        },
+                        "name": "Provided API",
+                        "pattern": "From",
+                        "tags": [
+                            "expose",
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "name": "fetch-task"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKurdexCgwPv3VhOz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "Parameters of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhOz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhOz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLISvfTAdq4stfbU0\",\"uri\":\"atlas:json:-LzmLISvfTAdq4stfbU0\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.483154\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhOz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmLJqmfTAdq4stfbU1",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Invoke SQL to obtain, store, update, or delete data.",
+                        "descriptor": {
+                            "componentScheme": "sql",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "Parameters of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            },
+                            "outputDataShape": {
+                                "description": "Result of SQL [SELECT * FROM TODO WHERE ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "collection"
+                                },
+                                "name": "SQL Result",
+                                "specification": "{\"type\":\"array\",\"$schema\":\"http://json-schema.org/schema#\",\"items\":{\"type\":\"object\",\"title\":\"SQL_PARAM_OUT\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true},\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true}}}}",
+                                "type": "SQL_PARAM_OUT"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                    "name": "SQL statement",
+                                    "properties": {
+                                        "batch": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Batch update",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        },
+                                        "query": {
+                                            "dataList": [
+                                                "SELECT * FROM TODO WHERE ID=:#id"
+                                            ],
+                                            "defaultValue": "SELECT * FROM TODO WHERE ID=:#id",
+                                            "deprecated": false,
+                                            "displayName": "SQL statement",
+                                            "group": "common",
+                                            "javaType": "java.lang.String",
+                                            "kind": "path",
+                                            "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                            "order": 1,
+                                            "placeholder": "for example ':#MYPARAMNAME'",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "dataList"
+                                        },
+                                        "raiseErrorOnNotFound": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Raise error when record not found",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Error when no records are selected, updated or deleted",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "SqlDataAccessError",
+                                    "name": "SQL_DATA_ACCESS_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlEntityNotFoundError",
+                                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlConnectorError",
+                                    "name": "SQL_CONNECTOR_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "sql-connector",
+                        "name": "Invoke SQL",
+                        "pattern": "To",
+                        "tags": [
+                            "dynamic"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "batch": "false",
+                        "query": "SELECT * FROM TODO WHERE ID=:#id",
+                        "raiseErrorOnNotFound": "true"
+                    },
+                    "connection": {
+                        "configuredProperties": {
+                            "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                            "schema": "sampledb",
+                            "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                            "user": "sampledb"
+                        },
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "batch": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Batch update",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                                        "order": 1,
+                                                        "placeholder": "for example ':#MYPARAMNAME'",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "raiseErrorOnNotFound": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Raise error when record not found",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Error when no records are selected, updated or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "SqlDataAccessError",
+                                                "name": "SQL_DATA_ACCESS_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlEntityNotFoundError",
+                                                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlConnectorError",
+                                                "name": "SQL_CONNECTOR_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-connector",
+                                    "name": "Invoke SQL",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke SQL to obtain data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that returns results, such as SELECT.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "isRaiseErrorOnNotFound": {
+                                                        "deprecated": false,
+                                                        "displayName": "Raise NotFoundError",
+                                                        "group": "consumer",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed.",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-start-connector",
+                                    "name": "Periodic SQL invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "property",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored procedure template to perform.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-connector",
+                                    "name": "Invoke stored procedure",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored Procedure template to perform.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-start-connector",
+                                    "name": "Periodic stored procedure invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                }
+                            ],
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "jdbc-driver",
+                                    "type": "EXTENSION_TAG"
+                                }
+                            ],
+                            "description": "Invoke SQL to obtain, store, update, or delete data.",
+                            "icon": "assets:sql.svg",
+                            "id": "sql",
+                            "name": "Database",
+                            "properties": {
+                                "password": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Password",
+                                    "group": "security",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common,security",
+                                    "labelHint": "Password for the database connection.",
+                                    "order": 3,
+                                    "required": true,
+                                    "secret": true,
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Schema",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common",
+                                    "labelHint": "Database schema.",
+                                    "order": 4,
+                                    "required": false,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Connection URL",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "JDBC URL of the database.",
+                                    "order": 1,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Username",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "Username for the database connection.",
+                                    "order": 2,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                }
+                            },
+                            "tags": [
+                                "verifier"
+                            ],
+                            "version": 1
+                        },
+                        "connectorId": "sql",
+                        "description": "Connection to SampleDB",
+                        "icon": "assets:sql.svg",
+                        "id": "5",
+                        "isDerived": false,
+                        "name": "PostgresDB",
+                        "tags": [
+                            "sampledb"
+                        ],
+                        "uses": 0
+                    },
+                    "id": "-LzmLISvfTAdq4stfbU0",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhOz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhOz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLJqmfTAdq4stfbU1\",\"uri\":\"atlas:json:-LzmLJqmfTAdq4stfbU1\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLISvfTAdq4stfbU0\",\"uri\":\"atlas:json:-LzmLISvfTAdq4stfbU0\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKurdexCgwPv3VhPz\",\"uri\":\"atlas:json:i-LzmKKurdexCgwPv3VhPz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.785424\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/<>/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.448689\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/<>/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.757114\",\"inputFieldGroup\":{\"jsonType\":\"io.atlasmap.v2.FieldGroup\",\"actions\":[{\"delimiter\":\" \",\"@type\":\"Concatenate\"}],\"field\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/<>/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmLISvfTAdq4stfbU0\",\"userCreated\":false,\"index\":0}]},\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKurdexCgwPv3VhPz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmLM2dfTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "End action of Syndesis integrations that start from a provided API",
+                        "descriptor": {
+                            "componentScheme": "bean",
+                            "configuredProperties": {
+                                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                "method": "process"
+                            },
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Return Path Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "defaultResponse": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Default Response",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 0,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorHandling": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Error Handling",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorResponseCodes": {
+                                            "componentProperty": false,
+                                            "defaultValue": "{}",
+                                            "deprecated": false,
+                                            "description": "The return code to set according to different error situations",
+                                            "displayName": "Error Response Codes",
+                                            "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"404 No task with provided identifier found\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                            "javaType": "Map",
+                                            "kind": "parameter",
+                                            "order": 4,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "mapset"
+                                        },
+                                        "httpResponseCode": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The return code to set in the HTTP response",
+                                            "displayName": "Return Code",
+                                            "enum": [
+                                                {
+                                                    "label": "200 All is good",
+                                                    "value": "200"
+                                                },
+                                                {
+                                                    "label": "404 No task with provided identifier found",
+                                                    "value": "404"
+                                                },
+                                                {
+                                                    "label": "500 Server Error",
+                                                    "value": "500"
+                                                }
+                                            ],
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 1,
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "select"
+                                        },
+                                        "returnBody": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Include error message in the return body",
+                                            "javaType": "Boolean",
+                                            "kind": "parameter",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "ServerError",
+                                    "name": "SERVER_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-end",
+                        "name": "Provided API Return Path",
+                        "pattern": "To",
+                        "tags": [
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "errorResponseCodes": "{\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SERVER_ERROR\":\"500\"}",
+                        "httpResponseCode": "200",
+                        "returnBody": "false"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKurdexCgwPv3VhPz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                }
+            ],
+            "tags": [
+                "5",
+                "api-provider"
+            ],
+            "type": "API_PROVIDER"
+        },
+        {
+            "description": "PUT /{id}",
+            "id": "i-LzmKKuudexCgwPv3VhTz",
+            "metadata": {
+                "default-return-code": "200",
+                "excerpt": "200 All is good",
+                "openapi-operationid": "update-task",
+                "return-code-edited": "true"
+            },
+            "name": "Update task",
+            "steps": [
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Start a Syndesis integration from a provided API",
+                        "descriptor": {
+                            "componentScheme": "direct",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "description": "API request payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Request",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier\"}}},\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "name": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The operation ID as defined in the API spec",
+                                            "displayName": "Operation ID",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-start",
+                        "metadata": {
+                            "serverBasePath": "/"
+                        },
+                        "name": "Provided API",
+                        "pattern": "From",
+                        "tags": [
+                            "expose",
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "name": "update-task"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKutdexCgwPv3VhRz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "Parameters of SQL [UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true},\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKutdexCgwPv3VhRz\",\"uri\":\"atlas:json:i-LzmKKutdexCgwPv3VhRz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLb5PfTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmLb5PfTAdq4stfbU2\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.615600\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.900648\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.909361\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/task\",\"fieldType\":\"STRING\",\"docId\":\"-LzmLb5PfTAdq4stfbU2\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmLb8PfTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Invoke SQL to obtain, store, update, or delete data.",
+                        "descriptor": {
+                            "componentScheme": "sql",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "Parameters of SQL [UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"task\":{\"type\":\"string\",\"required\":true},\"completed\":{\"type\":\"integer\",\"required\":true},\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            },
+                            "outputDataShape": {
+                                "kind": "none",
+                                "type": "SQL_PARAM_OUT"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                    "name": "SQL statement",
+                                    "properties": {
+                                        "batch": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Batch update",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        },
+                                        "query": {
+                                            "dataList": [
+                                                "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id"
+                                            ],
+                                            "defaultValue": "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id",
+                                            "deprecated": false,
+                                            "displayName": "SQL statement",
+                                            "group": "common",
+                                            "javaType": "java.lang.String",
+                                            "kind": "path",
+                                            "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                            "order": 1,
+                                            "placeholder": "for example ':#MYPARAMNAME'",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "dataList"
+                                        },
+                                        "raiseErrorOnNotFound": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Raise error when record not found",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Error when no records are selected, updated or deleted",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "SqlDataAccessError",
+                                    "name": "SQL_DATA_ACCESS_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlEntityNotFoundError",
+                                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlConnectorError",
+                                    "name": "SQL_CONNECTOR_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "sql-connector",
+                        "name": "Invoke SQL",
+                        "pattern": "To",
+                        "tags": [
+                            "dynamic"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "batch": "false",
+                        "query": "UPDATE TODO SET task=:#task, completed=:#completed where ID=:#id",
+                        "raiseErrorOnNotFound": "true"
+                    },
+                    "connection": {
+                        "configuredProperties": {
+                            "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                            "schema": "sampledb",
+                            "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                            "user": "sampledb"
+                        },
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "batch": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Batch update",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                                        "order": 1,
+                                                        "placeholder": "for example ':#MYPARAMNAME'",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "raiseErrorOnNotFound": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Raise error when record not found",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Error when no records are selected, updated or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "SqlDataAccessError",
+                                                "name": "SQL_DATA_ACCESS_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlEntityNotFoundError",
+                                                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlConnectorError",
+                                                "name": "SQL_CONNECTOR_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-connector",
+                                    "name": "Invoke SQL",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke SQL to obtain data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that returns results, such as SELECT.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "isRaiseErrorOnNotFound": {
+                                                        "deprecated": false,
+                                                        "displayName": "Raise NotFoundError",
+                                                        "group": "consumer",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed.",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-start-connector",
+                                    "name": "Periodic SQL invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "property",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored procedure template to perform.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-connector",
+                                    "name": "Invoke stored procedure",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored Procedure template to perform.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-start-connector",
+                                    "name": "Periodic stored procedure invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                }
+                            ],
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "jdbc-driver",
+                                    "type": "EXTENSION_TAG"
+                                }
+                            ],
+                            "description": "Invoke SQL to obtain, store, update, or delete data.",
+                            "icon": "assets:sql.svg",
+                            "id": "sql",
+                            "name": "Database",
+                            "properties": {
+                                "password": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Password",
+                                    "group": "security",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common,security",
+                                    "labelHint": "Password for the database connection.",
+                                    "order": 3,
+                                    "required": true,
+                                    "secret": true,
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Schema",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common",
+                                    "labelHint": "Database schema.",
+                                    "order": 4,
+                                    "required": false,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Connection URL",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "JDBC URL of the database.",
+                                    "order": 1,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Username",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "Username for the database connection.",
+                                    "order": 2,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                }
+                            },
+                            "tags": [
+                                "verifier"
+                            ],
+                            "version": 1
+                        },
+                        "connectorId": "sql",
+                        "description": "Connection to SampleDB",
+                        "icon": "assets:sql.svg",
+                        "id": "5",
+                        "isDerived": false,
+                        "name": "PostgresDB",
+                        "tags": [
+                            "sampledb"
+                        ],
+                        "uses": 0
+                    },
+                    "id": "-LzmLb5PfTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKutdexCgwPv3VhRz\",\"uri\":\"atlas:json:i-LzmKKutdexCgwPv3VhRz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmLb8PfTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmLb8PfTAdq4stfbU2\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuudexCgwPv3VhSz\",\"uri\":\"atlas:json:i-LzmKKuudexCgwPv3VhSz\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.648240\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/body/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.928587\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"completed\",\"path\":\"/body/completed\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]},{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.467324\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKutdexCgwPv3VhRz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"task\",\"path\":\"/body/task\",\"fieldType\":\"STRING\",\"docId\":\"i-LzmKKuudexCgwPv3VhSz\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmLteyfTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "End action of Syndesis integrations that start from a provided API",
+                        "descriptor": {
+                            "componentScheme": "bean",
+                            "configuredProperties": {
+                                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                "method": "process"
+                            },
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "API response payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Response",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"body\":{\"type\":\"object\",\"description\":\"\",\"required\":[\"id\",\"task\"],\"properties\":{\"id\":{\"title\":\"Task ID\",\"description\":\"Unique task identifier\",\"type\":\"integer\"},\"task\":{\"title\":\"The task\",\"description\":\"Task line\",\"type\":\"string\"},\"completed\":{\"title\":\"Task completition status\",\"description\":\"0 - ongoing, 1 - completed\",\"maximum\":1,\"minimum\":0,\"type\":\"integer\"}}}}}"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Return Path Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "defaultResponse": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Default Response",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 0,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorHandling": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Error Handling",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorResponseCodes": {
+                                            "componentProperty": false,
+                                            "defaultValue": "{}",
+                                            "deprecated": false,
+                                            "description": "The return code to set according to different error situations",
+                                            "displayName": "Error Response Codes",
+                                            "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"200 All is good\",\"value\":\"200\"},{\"label\":\"404 No Record with this ID\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                            "javaType": "Map",
+                                            "kind": "parameter",
+                                            "order": 4,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "mapset"
+                                        },
+                                        "httpResponseCode": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The return code to set in the HTTP response",
+                                            "displayName": "Return Code",
+                                            "enum": [
+                                                {
+                                                    "label": "200 All is good",
+                                                    "value": "200"
+                                                },
+                                                {
+                                                    "label": "404 No Record with this ID",
+                                                    "value": "404"
+                                                },
+                                                {
+                                                    "label": "500 Server Error",
+                                                    "value": "500"
+                                                }
+                                            ],
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 1,
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "select"
+                                        },
+                                        "returnBody": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Include error message in the return body",
+                                            "javaType": "Boolean",
+                                            "kind": "parameter",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "ServerError",
+                                    "name": "SERVER_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-end",
+                        "name": "Provided API Return Path",
+                        "pattern": "To",
+                        "tags": [
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "errorResponseCodes": "{\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SERVER_ERROR\":\"500\"}",
+                        "httpResponseCode": "200",
+                        "returnBody": "false"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKuudexCgwPv3VhSz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                }
+            ],
+            "tags": [
+                "5",
+                "api-provider"
+            ],
+            "type": "API_PROVIDER"
+        },
+        {
+            "description": "DELETE /{id}",
+            "id": "i-LzmKKuudexCgwPv3VhWz",
+            "metadata": {
+                "default-return-code": "204",
+                "excerpt": "204 Task deleted",
+                "openapi-operationid": "delete-task",
+                "return-code-edited": "true"
+            },
+            "name": "Delete task",
+            "steps": [
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Start a Syndesis integration from a provided API",
+                        "descriptor": {
+                            "componentScheme": "direct",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "description": "API request payload",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "unified": "true"
+                                },
+                                "name": "Request",
+                                "specification": "{\"$schema\":\"http://json-schema.org/schema#\",\"type\":\"object\",\"$id\":\"io:syndesis:wrapped\",\"properties\":{\"parameters\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\",\"title\":\"id\",\"description\":\"Task identifier to delete\"}}}}}"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "name": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The operation ID as defined in the API spec",
+                                            "displayName": "Operation ID",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-start",
+                        "metadata": {
+                            "serverBasePath": "/"
+                        },
+                        "name": "Provided API",
+                        "pattern": "From",
+                        "tags": [
+                            "expose",
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "name": "delete-task"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKuudexCgwPv3VhUz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "step",
+                        "descriptor": {
+                            "inputDataShape": {
+                                "kind": "any",
+                                "name": "All preceding outputs"
+                            },
+                            "outputDataShape": {
+                                "description": "Parameters of SQL [DELETE FROM TODO WHERE ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            }
+                        }
+                    },
+                    "configuredProperties": {
+                        "atlasmapping": "{\"AtlasMapping\":{\"jsonType\":\"io.atlasmap.v2.AtlasMapping\",\"dataSource\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"i-LzmKKuudexCgwPv3VhUz\",\"uri\":\"atlas:json:i-LzmKKuudexCgwPv3VhUz\",\"dataSourceType\":\"SOURCE\"},{\"jsonType\":\"io.atlasmap.json.v2.JsonDataSource\",\"id\":\"-LzmM7T2fTAdq4stfbU2\",\"uri\":\"atlas:json:-LzmM7T2fTAdq4stfbU2\",\"dataSourceType\":\"TARGET\",\"template\":null}],\"mappings\":{\"mapping\":[{\"jsonType\":\"io.atlasmap.v2.Mapping\",\"id\":\"mapping.891997\",\"inputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/parameters/id\",\"fieldType\":\"INTEGER\",\"docId\":\"i-LzmKKuudexCgwPv3VhUz\",\"userCreated\":false}],\"outputField\":[{\"jsonType\":\"io.atlasmap.json.v2.JsonField\",\"name\":\"id\",\"path\":\"/id\",\"fieldType\":\"INTEGER\",\"docId\":\"-LzmM7T2fTAdq4stfbU2\",\"userCreated\":false}]}]},\"name\":\"UI.0\",\"lookupTables\":{\"lookupTable\":[]},\"constants\":{\"constant\":[]},\"properties\":{\"property\":[]}}}"
+                    },
+                    "id": "-LzmNqm1fTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "name": "Data Mapper",
+                    "stepKind": "mapper"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "Invoke SQL to obtain, store, update, or delete data.",
+                        "descriptor": {
+                            "componentScheme": "sql",
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "description": "Parameters of SQL [DELETE FROM TODO WHERE ID=:#id]",
+                                "kind": "json-schema",
+                                "metadata": {
+                                    "variant": "element"
+                                },
+                                "name": "SQL Parameter",
+                                "specification": "{\"type\":\"object\",\"$schema\":\"http://json-schema.org/schema#\",\"title\":\"SQL_PARAM_IN\",\"properties\":{\"id\":{\"type\":\"integer\",\"required\":true}}}",
+                                "type": "SQL_PARAM_IN"
+                            },
+                            "outputDataShape": {
+                                "kind": "none",
+                                "type": "SQL_PARAM_OUT"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                    "name": "SQL statement",
+                                    "properties": {
+                                        "batch": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Batch update",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        },
+                                        "query": {
+                                            "dataList": [
+                                                "DELETE FROM TODO WHERE ID=:#id"
+                                            ],
+                                            "defaultValue": "DELETE FROM TODO WHERE ID=:#id",
+                                            "deprecated": false,
+                                            "displayName": "SQL statement",
+                                            "group": "common",
+                                            "javaType": "java.lang.String",
+                                            "kind": "path",
+                                            "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                            "order": 1,
+                                            "placeholder": "for example ':#MYPARAMNAME'",
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "dataList"
+                                        },
+                                        "raiseErrorOnNotFound": {
+                                            "defaultValue": "false",
+                                            "deprecated": false,
+                                            "displayName": "Raise error when record not found",
+                                            "group": "common",
+                                            "javaType": "java.lang.Boolean",
+                                            "kind": "property",
+                                            "labelHint": "Error when no records are selected, updated or deleted",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "SqlDataAccessError",
+                                    "name": "SQL_DATA_ACCESS_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlEntityNotFoundError",
+                                    "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                },
+                                {
+                                    "displayName": "SqlConnectorError",
+                                    "name": "SQL_CONNECTOR_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "sql-connector",
+                        "name": "Invoke SQL",
+                        "pattern": "To",
+                        "tags": [
+                            "dynamic"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "batch": "false",
+                        "query": "DELETE FROM TODO WHERE ID=:#id",
+                        "raiseErrorOnNotFound": "true"
+                    },
+                    "connection": {
+                        "configuredProperties": {
+                            "password": "»ENC:175336e801c64fe07fb67b74a1f737b9fdf7a7056e8460855f69cf222da0c04fcd8338a803f23cdccf1648435cbfddeb",
+                            "schema": "sampledb",
+                            "url": "jdbc:postgresql://syndesis-db:5432/sampledb",
+                            "user": "sampledb"
+                        },
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke SQL to obtain, store, update, or delete data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that starts with INSERT, SELECT, UPDATE or DELETE.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "batch": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Batch update",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Use prepared statements for INSERT, UPDATE, DELETE in order to update multiple rows with batch update.",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed. Can contain input parameters prefixed by ':#'.",
+                                                        "order": 1,
+                                                        "placeholder": "for example ':#MYPARAMNAME'",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "raiseErrorOnNotFound": {
+                                                        "defaultValue": "false",
+                                                        "deprecated": false,
+                                                        "displayName": "Raise error when record not found",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "property",
+                                                        "labelHint": "Error when no records are selected, updated or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "SqlDataAccessError",
+                                                "name": "SQL_DATA_ACCESS_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlEntityNotFoundError",
+                                                "name": "SQL_ENTITY_NOT_FOUND_ERROR"
+                                            },
+                                            {
+                                                "displayName": "SqlConnectorError",
+                                                "name": "SQL_CONNECTOR_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-connector",
+                                    "name": "Invoke SQL",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke SQL to obtain data.",
+                                    "descriptor": {
+                                        "componentScheme": "sql",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Enter a SQL statement that returns results, such as SELECT.",
+                                                "name": "SQL statement",
+                                                "properties": {
+                                                    "isRaiseErrorOnNotFound": {
+                                                        "deprecated": false,
+                                                        "displayName": "Raise NotFoundError",
+                                                        "group": "consumer",
+                                                        "javaType": "java.lang.Boolean",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Raise NotFoundError if no records are inserted, updated, selected or deleted",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    },
+                                                    "query": {
+                                                        "deprecated": false,
+                                                        "displayName": "SQL statement",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "SQL statement to be executed.",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "dataList"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-start-connector",
+                                    "name": "Periodic SQL invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "common",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "property",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored procedure template to perform.",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-connector",
+                                    "name": "Invoke stored procedure",
+                                    "pattern": "To",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "Periodically invoke a stored procedure.",
+                                    "descriptor": {
+                                        "componentScheme": "sql-stored",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.sql.customizer.SqlStartStoredConnectorCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "json-schema"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "Select the stored procedure.",
+                                                "name": "Procedure name",
+                                                "properties": {
+                                                    "procedureName": {
+                                                        "componentProperty": true,
+                                                        "deprecated": false,
+                                                        "displayName": "Procedure name",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Name of the stored procedure.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "schedulerExpression": {
+                                                        "defaultValue": "60000",
+                                                        "deprecated": false,
+                                                        "displayName": "Period",
+                                                        "group": "consumer",
+                                                        "javaType": "long",
+                                                        "kind": "parameter",
+                                                        "labelHint": "Delay between scheduling (executing).",
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "duration"
+                                                    },
+                                                    "template": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Template",
+                                                        "group": "producer",
+                                                        "javaType": "java.lang.String",
+                                                        "kind": "path",
+                                                        "labelHint": "Stored Procedure template to perform.",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "hidden"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "sql-stored-start-connector",
+                                    "name": "Periodic stored procedure invocation",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "dynamic"
+                                    ]
+                                }
+                            ],
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.sql.customizer.DataSourceCustomizer"
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-sql:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "jdbc-driver",
+                                    "type": "EXTENSION_TAG"
+                                }
+                            ],
+                            "description": "Invoke SQL to obtain, store, update, or delete data.",
+                            "icon": "assets:sql.svg",
+                            "id": "sql",
+                            "name": "Database",
+                            "properties": {
+                                "password": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Password",
+                                    "group": "security",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common,security",
+                                    "labelHint": "Password for the database connection.",
+                                    "order": 3,
+                                    "required": true,
+                                    "secret": true,
+                                    "type": "string"
+                                },
+                                "schema": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Schema",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "label": "common",
+                                    "labelHint": "Database schema.",
+                                    "order": 4,
+                                    "required": false,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Connection URL",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "JDBC URL of the database.",
+                                    "order": 1,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                },
+                                "user": {
+                                    "componentProperty": true,
+                                    "deprecated": false,
+                                    "displayName": "Username",
+                                    "group": "common",
+                                    "javaType": "java.lang.String",
+                                    "kind": "property",
+                                    "labelHint": "Username for the database connection.",
+                                    "order": 2,
+                                    "required": true,
+                                    "secret": false,
+                                    "type": "string"
+                                }
+                            },
+                            "tags": [
+                                "verifier"
+                            ],
+                            "version": 1
+                        },
+                        "connectorId": "sql",
+                        "description": "Connection to SampleDB",
+                        "icon": "assets:sql.svg",
+                        "id": "5",
+                        "isDerived": false,
+                        "name": "PostgresDB",
+                        "tags": [
+                            "sampledb"
+                        ],
+                        "uses": 0
+                    },
+                    "id": "-LzmM7T2fTAdq4stfbU2",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                },
+                {
+                    "action": {
+                        "actionType": "connector",
+                        "description": "End action of Syndesis integrations that start from a provided API",
+                        "descriptor": {
+                            "componentScheme": "bean",
+                            "configuredProperties": {
+                                "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                "method": "process"
+                            },
+                            "connectorCustomizers": [
+                                "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                            ],
+                            "inputDataShape": {
+                                "kind": "none"
+                            },
+                            "outputDataShape": {
+                                "kind": "none"
+                            },
+                            "propertyDefinitionSteps": [
+                                {
+                                    "description": "API Provider Return Path Configuration",
+                                    "name": "configuration",
+                                    "properties": {
+                                        "defaultResponse": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Default Response",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 0,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorHandling": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Error Handling",
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 2,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "legend"
+                                        },
+                                        "errorResponseCodes": {
+                                            "componentProperty": false,
+                                            "defaultValue": "{}",
+                                            "deprecated": false,
+                                            "description": "The return code to set according to different error situations",
+                                            "displayName": "Error Response Codes",
+                                            "extendedProperties": "{ \"mapsetValueDefinition\": {    \"enum\" : [{\"label\":\"204 Task deleted\",\"value\":\"204\"},{\"label\":\"404 No Record found with this ID\",\"value\":\"404\"},{\"label\":\"500 Server Error\",\"value\":\"500\"}],    \"type\" : \"select\" },\"mapsetOptions\": {    \"i18nKeyColumnTitle\": \"When the error message is\",    \"i18nValueColumnTitle\": \"Return this HTTP response code\" }}",
+                                            "javaType": "Map",
+                                            "kind": "parameter",
+                                            "order": 4,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "mapset"
+                                        },
+                                        "httpResponseCode": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "description": "The return code to set in the HTTP response",
+                                            "displayName": "Return Code",
+                                            "enum": [
+                                                {
+                                                    "label": "204 Task deleted",
+                                                    "value": "204"
+                                                },
+                                                {
+                                                    "label": "404 No Record found with this ID",
+                                                    "value": "404"
+                                                },
+                                                {
+                                                    "label": "500 Server Error",
+                                                    "value": "500"
+                                                }
+                                            ],
+                                            "javaType": "String",
+                                            "kind": "parameter",
+                                            "order": 1,
+                                            "required": true,
+                                            "secret": false,
+                                            "type": "select"
+                                        },
+                                        "returnBody": {
+                                            "componentProperty": false,
+                                            "deprecated": false,
+                                            "displayName": "Include error message in the return body",
+                                            "javaType": "Boolean",
+                                            "kind": "parameter",
+                                            "order": 3,
+                                            "required": false,
+                                            "secret": false,
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ],
+                            "standardizedErrors": [
+                                {
+                                    "displayName": "ServerError",
+                                    "name": "SERVER_ERROR"
+                                }
+                            ]
+                        },
+                        "id": "io.syndesis:api-provider-end",
+                        "name": "Provided API Return Path",
+                        "pattern": "To",
+                        "tags": [
+                            "locked-action"
+                        ]
+                    },
+                    "configuredProperties": {
+                        "errorResponseCodes": "{\"SERVER_ERROR\":\"500\",\"SQL_CONNECTOR_ERROR\":\"500\",\"SQL_DATA_ACCESS_ERROR\":\"500\",\"SQL_ENTITY_NOT_FOUND_ERROR\":\"404\"}",
+                        "httpResponseCode": "204",
+                        "returnBody": "false"
+                    },
+                    "connection": {
+                        "connector": {
+                            "actions": [
+                                {
+                                    "actionType": "connector",
+                                    "description": "Start a Syndesis integration from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "direct",
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderStartEndpointCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "name": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The operation ID as defined in the API spec",
+                                                        "displayName": "Operation ID",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-start",
+                                    "name": "Provided API",
+                                    "pattern": "From",
+                                    "tags": [
+                                        "expose"
+                                    ]
+                                },
+                                {
+                                    "actionType": "connector",
+                                    "description": "End action of Syndesis integrations that start from a provided API",
+                                    "descriptor": {
+                                        "componentScheme": "bean",
+                                        "configuredProperties": {
+                                            "beanName": "io.syndesis.connector.apiprovider.NoOpBean",
+                                            "method": "process"
+                                        },
+                                        "connectorCustomizers": [
+                                            "io.syndesis.connector.apiprovider.ApiProviderReturnPathCustomizer"
+                                        ],
+                                        "inputDataShape": {
+                                            "kind": "any"
+                                        },
+                                        "outputDataShape": {
+                                            "kind": "none"
+                                        },
+                                        "propertyDefinitionSteps": [
+                                            {
+                                                "description": "API Provider Return Path Configuration",
+                                                "name": "configuration",
+                                                "properties": {
+                                                    "defaultResponse": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Default Response",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 0,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorHandling": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Error Handling",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 2,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "legend"
+                                                    },
+                                                    "errorResponseCodes": {
+                                                        "componentProperty": false,
+                                                        "defaultValue": "{}",
+                                                        "deprecated": false,
+                                                        "description": "The return code to set according to different error situations",
+                                                        "displayName": "Error Response Codes",
+                                                        "javaType": "Map",
+                                                        "kind": "parameter",
+                                                        "order": 4,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "mapset"
+                                                    },
+                                                    "httpResponseCode": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "description": "The return code to set in the HTTP response",
+                                                        "displayName": "Return Code",
+                                                        "javaType": "String",
+                                                        "kind": "parameter",
+                                                        "order": 1,
+                                                        "required": true,
+                                                        "secret": false,
+                                                        "type": "select"
+                                                    },
+                                                    "returnBody": {
+                                                        "componentProperty": false,
+                                                        "deprecated": false,
+                                                        "displayName": "Include error message in the return body",
+                                                        "javaType": "Boolean",
+                                                        "kind": "parameter",
+                                                        "order": 3,
+                                                        "required": false,
+                                                        "secret": false,
+                                                        "type": "boolean"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "standardizedErrors": [
+                                            {
+                                                "displayName": "ServerError",
+                                                "name": "SERVER_ERROR"
+                                            }
+                                        ]
+                                    },
+                                    "id": "io.syndesis:api-provider-end",
+                                    "name": "Provided API Return Path",
+                                    "pattern": "To"
+                                }
+                            ],
+                            "dependencies": [
+                                {
+                                    "id": "io.syndesis.connector:connector-api-provider:1.9.1-20200127",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-swagger-java:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                },
+                                {
+                                    "id": "org.apache.camel:camel-servlet-starter:2.23.2.fuse-760017",
+                                    "type": "MAVEN"
+                                }
+                            ],
+                            "description": "Expose Restful APIs",
+                            "icon": "assets:api-provider.svg",
+                            "id": "api-provider",
+                            "metadata": {
+                                "hide-from-connection-pages": "true"
+                            },
+                            "name": "API Provider",
+                            "version": 1
+                        },
+                        "connectorId": "api-provider",
+                        "description": "Expose Restful APIs",
+                        "icon": "assets:api-provider.svg",
+                        "id": "api-provider",
+                        "isDerived": false,
+                        "metadata": {
+                            "hide-from-connection-pages": "true"
+                        },
+                        "name": "API Provider",
+                        "uses": 0
+                    },
+                    "id": "i-LzmKKuudexCgwPv3VhVz",
+                    "metadata": {
+                        "configured": "true"
+                    },
+                    "stepKind": "endpoint"
+                }
+            ],
+            "tags": [
+                "5",
+                "api-provider"
+            ],
+            "type": "API_PROVIDER"
+        }
+    ],
+    "id": "i-LzmKylDdexCgwPv3VhYz",
+    "name": "Task API",
+    "resources": [
+        {
+            "id": "i-LzmKKvDdexCgwPv3VhXz",
+            "kind": "open-api"
+        }
+    ],
+    "tags": [
+        "api-provider",
+        "sql"
+    ],
+    "updatedAt": 1580319626623,
+    "version": 5
+}


### PR DESCRIPTION
fix(server): API provider error handling migration (4fb699c)

Adds missing migration script for API provider connector descriptor changes relating to error handling.

fix(server): set defaultValue type to String (3a3690c)

Most likely the type of `Object` in `ConfigurationProperty.defaultValue` is not correct, the type most likely should have been `String`. A proof of that should be that the `WithConfiguredProperties` holds a map of `String` values.


Ref. https://issues.redhat.com/browse/ENTESB-15543