### PR TITLE
refactor(build): set `git.commit.id` in all cases

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1433,7 +1433,6 @@
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
         <version>${dep.plugin.git-commit-id.version}</version>
-        <inherited>false</inherited>
         <executions>
           <execution>
             <id>basepom.default</id>


### PR DESCRIPTION
When building/running a subset of modules without `syndesis-parent`
module `git.commit.id` will not be set and will trigger enforcer
failure. This removes `<inherited>false</inherited>` so that the
`git-commit-id` plugin is run in all modules not just in parent.

Previously we have seen performance issues with running the
`git-commit-id` plugin, and confined the execution just to the parent
module. With 4.0.4 it seems those performance are not present, so we can
run it in all modules.