### PR TITLE
ENTESB-16464: NullpointerException when creating SOAP Client Connector

### DIFF
--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -271,6 +271,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.atlasmap</groupId>
+      <artifactId>atlas-xml-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.apache.ws.xmlschema</groupId>
       <artifactId>xmlschema-core</artifactId>
-      <version>2.2.3</version>
+      <version>2.2.5</version>
     </dependency>
 
     <dependency>

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/BindingHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/BindingHelper.java
@@ -74,8 +74,32 @@ import static javax.jws.soap.SOAPBinding.Use.ENCODED;
 public class BindingHelper {
 
     private static final String SCHEMA_SET_XML =
-        "<d:SchemaSet xmlns:d=\"http://atlasmap.io/xml/schemaset/v2\">" +
-            "<d:AdditionalSchemas/>" +
+        "<d:SchemaSet xmlns:d=\"http://atlasmap.io/xml/schemaset/v2\" xmlns:xml=\"http://www.w3.org/XML/1998/namespace\">" +
+            "<d:AdditionalSchemas>" +
+                "<xsd:schema targetNamespace=\"http://www.w3.org/XML/1998/namespace\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" +
+                    "<xsd:attribute name=\"lang\">" +
+                        "<xsd:simpleType>" +
+                            "<xsd:union memberTypes=\"xsd:language\">" +
+                                "<xsd:simpleType>" +
+                                    "<xsd:restriction base=\"xsd:string\">" +
+                                        "<xsd:enumeration value=\"\"/>" +
+                                    "</xsd:restriction>" +
+                                "</xsd:simpleType>" +
+                            "</xsd:union>" +
+                        "</xsd:simpleType>" +
+                    "</xsd:attribute>" +
+                    "<xsd:attribute name=\"space\">" +
+                        "<xsd:simpleType>" +
+                            "<xsd:restriction base=\"xsd:NCName\">" +
+                                "<xsd:enumeration value=\"default\"/>" +
+                                "<xsd:enumeration value=\"preserve\"/>" +
+                            "</xsd:restriction>" +
+                        "</xsd:simpleType>" +
+                    "</xsd:attribute>" +
+                    "<xsd:attribute name=\"base\" type=\"xsd:anyURI\"/>" +
+                    "<xsd:attribute name=\"id\" type=\"xsd:ID\"/>" +
+                "</xsd:schema>" +
+            "</d:AdditionalSchemas>" +
         "</d:SchemaSet>";
 
     private static final SchemaCollection SOAP_SCHEMAS;

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/BindingHelper.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/BindingHelper.java
@@ -426,7 +426,7 @@ public class BindingHelper {
             final XmlSchemaAnnotated annotated = part.getXmlSchema() != null ? part.getXmlSchema() :
                 schemaCollection.getTypeByQName(part.getTypeQName());
 
-            final QName name = part.getConcreteName();
+            final QName name = part.getName();
             final XmlSchemaElement element;
             if (annotated instanceof XmlSchemaElement) {
                 // extract element

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaExtractor.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/XmlSchemaExtractor.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -67,6 +69,7 @@ import org.apache.ws.commons.schema.XmlSchemaSimpleTypeRestriction;
 import org.apache.ws.commons.schema.XmlSchemaSimpleTypeUnion;
 import org.apache.ws.commons.schema.XmlSchemaType;
 import org.apache.ws.commons.schema.constants.Constants;
+import org.apache.ws.commons.schema.utils.NamespaceMap;
 import org.apache.ws.commons.schema.utils.XmlSchemaNamed;
 import org.apache.ws.commons.schema.utils.XmlSchemaNamedWithForm;
 import org.apache.ws.commons.schema.utils.XmlSchemaObjectBase;
@@ -224,6 +227,14 @@ class XmlSchemaExtractor {
         XmlSchema targetSchema = targetSchemas.getSchemaByTargetNamespace(namespaceURI);
         if (targetSchema == null) {
             targetSchema = targetSchemas.newXmlSchemaInCollection(namespaceURI);
+            final NamespaceMap namespaceContext = new NamespaceMap();
+
+            // add the usual suspects, for some reason these seem to be missing from the
+            // generated SchemaSet
+            namespaceContext.add("xsd", XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            namespaceContext.add(XMLConstants.XML_NS_PREFIX, XMLConstants.XML_NS_URI);
+
+            targetSchema.setNamespaceContext(namespaceContext);
 
             final XmlSchema sourceSchema = sourceSchemas.getSchemaByTargetNamespace(namespaceURI);
             if (sourceSchema != null) {

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/AbstractSoapExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/AbstractSoapExampleTest.java
@@ -69,7 +69,8 @@ public abstract class AbstractSoapExampleTest {
             load("/soap/Integrations.wsdl"),
             load("/soap/Resource_Management.wsdl"),
             load("/soap/Workday_Connect.wsdl"),
-            load("/soap/Workday_Extensibility.wsdl")
+            load("/soap/Workday_Extensibility.wsdl"),
+            load("/soap/suitecrm_rpc_literal.wsdl")
         );
     }
 

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import io.atlasmap.xml.inspect.XmlInspectionException;
+import io.atlasmap.xml.inspect.XmlInspectionService;
 import io.syndesis.common.model.DataShape;
 import io.syndesis.common.model.DataShapeKinds;
 import io.syndesis.common.model.action.Action;
@@ -58,6 +60,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(SoapApiConnectorGeneratorExampleTest.class);
+
+    static final XmlInspectionService XML_INSPECTION_SVC = new XmlInspectionService();
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("parameters")
@@ -98,7 +102,7 @@ public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTes
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("parameters")
-    public void shouldGenerateConnector(final String path, final String specification) throws IOException, SAXException {
+    public void shouldGenerateConnector(final String path, final String specification) throws IOException, SAXException, XmlInspectionException {
 
         final Connector connector = connectorGenerator.generate(SoapConnectorTemplate.SOAP_TEMPLATE, getConnectorSettings(specification));
 
@@ -162,7 +166,7 @@ public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTes
         }
     }
 
-    private static void validateDataShape(DataShape inputDataShape) throws SAXException, IOException {
+    private static void validateDataShape(DataShape inputDataShape) throws SAXException, IOException, XmlInspectionException {
         // check whether the shape is not none
         if (inputDataShape.getKind() != DataShapeKinds.NONE) {
             assertThat(inputDataShape.getName()).isNotEmpty();
@@ -174,6 +178,8 @@ public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTes
 
             // validate schemaset
             XmlSchemaTestHelper.validateSchemaSet(specification);
+
+            XML_INSPECTION_SVC.inspectSchema(specification);
         }
     }
 

--- a/app/server/api-generator/src/test/resources/soap/StockQuote.wsdl
+++ b/app/server/api-generator/src/test/resources/soap/StockQuote.wsdl
@@ -26,7 +26,7 @@
 
     <message name="GetTradePriceInput">
         <part name="tickerSymbol" type="xsd:string"/>
-        <part name="time" type="xsd:timeInstant"/>
+        <part name="time" type="xsd:dateTime"/>
     </message>
 
     <message name="GetTradePriceOutput">

--- a/app/server/api-generator/src/test/resources/soap/suitecrm_rpc_literal.wsdl
+++ b/app/server/api-generator/src/test/resources/soap/suitecrm_rpc_literal.wsdl
@@ -1,0 +1,842 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<definitions xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://www.sugarcrm.com/sugarcrm" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://www.sugarcrm.com/sugarcrm">
+<types>
+<xsd:schema targetNamespace="http://www.sugarcrm.com/sugarcrm"
+>
+ <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/" schemaLocation="http://schemas.xmlsoap.org/soap/encoding/"/>
+ <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/" schemaLocation="http://schemas.xmlsoap.org/wsdl/"/>
+ <xsd:complexType name="new_note_attachment">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="filename" type="xsd:string"/>
+   <xsd:element name="file" type="xsd:string"/>
+   <xsd:element name="related_module_id" type="xsd:string"/>
+   <xsd:element name="related_module_name" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="new_return_note_attachment">
+  <xsd:all>
+   <xsd:element name="note_attachment" type="tns:new_note_attachment"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="user_auth">
+  <xsd:all>
+   <xsd:element name="user_name" type="xsd:string"/>
+   <xsd:element name="password" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="field">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="type" type="xsd:string"/>
+   <xsd:element name="group" type="xsd:string"/>
+   <xsd:element name="label" type="xsd:string"/>
+   <xsd:element name="required" type="xsd:int"/>
+   <xsd:element name="options" type="tns:name_value_list"/>
+   <xsd:element name="default_value" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="field_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:field[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="link_field">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="type" type="xsd:string"/>
+   <xsd:element name="relationship" type="xsd:string"/>
+   <xsd:element name="module" type="xsd:string"/>
+   <xsd:element name="bean_name" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_field_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_field[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="name_value">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="value" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="name_value_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:name_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="name_value_lists">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:name_value_list[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="select_fields">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="xsd:string[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="deleted_array">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="xsd:int[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="new_module_fields">
+  <xsd:all>
+   <xsd:element name="module_name" type="xsd:string"/>
+   <xsd:element name="table_name" type="xsd:string"/>
+   <xsd:element name="module_fields" type="tns:field_list"/>
+   <xsd:element name="link_fields" type="tns:link_field_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="entry_value">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="module_name" type="xsd:string"/>
+   <xsd:element name="name_value_list" type="tns:name_value_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="entry_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:entry_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="set_entries_detail_result">
+  <xsd:all>
+   <xsd:element name="name_value_lists" type="tns:name_value_lists"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_names_to_fields_array">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_name_to_fields_array[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="link_name_to_fields_array">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="value" type="tns:select_fields"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_value">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:name_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="link_array_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_value2[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="link_name_value">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="records" type="tns:link_array_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_name_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="link_lists">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_list2[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="get_entry_result_version2">
+  <xsd:all>
+   <xsd:element name="entry_list" type="tns:entry_list"/>
+   <xsd:element name="relationship_list" type="tns:link_lists"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="return_search_result">
+  <xsd:all>
+   <xsd:element name="entry_list" type="tns:search_link_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="get_entry_list_result_version2">
+  <xsd:all>
+   <xsd:element name="result_count" type="xsd:int"/>
+   <xsd:element name="total_count" type="xsd:int"/>
+   <xsd:element name="next_offset" type="xsd:int"/>
+   <xsd:element name="entry_list" type="tns:entry_list"/>
+   <xsd:element name="relationship_list" type="tns:link_lists"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="get_server_info_result">
+  <xsd:all>
+   <xsd:element name="flavor" type="xsd:string"/>
+   <xsd:element name="version" type="xsd:string"/>
+   <xsd:element name="gmt_time" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="new_set_entry_result">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="new_set_entries_result">
+  <xsd:all>
+   <xsd:element name="ids" type="tns:select_fields"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="new_set_relationhip_ids">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:select_fields[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="new_set_relationship_list_result">
+  <xsd:all>
+   <xsd:element name="created" type="xsd:int"/>
+   <xsd:element name="failed" type="xsd:int"/>
+   <xsd:element name="deleted" type="xsd:int"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="document_revision">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="document_name" type="xsd:string"/>
+   <xsd:element name="revision" type="xsd:string"/>
+   <xsd:element name="filename" type="xsd:string"/>
+   <xsd:element name="file" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="new_return_document_revision">
+  <xsd:all>
+   <xsd:element name="document_revision" type="tns:document_revision"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="module_list">
+  <xsd:all>
+   <xsd:element name="modules" type="tns:module_list_array"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="get_entries_count_result">
+  <xsd:all>
+   <xsd:element name="result_count" type="xsd:int"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="md5_results">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="xsd:string[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="module_names">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="xsd:string[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="upcoming_activities_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:upcoming_activity_entry[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="upcoming_activity_entry">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="module" type="xsd:string"/>
+   <xsd:element name="date_due" type="xsd:string"/>
+   <xsd:element name="summary" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="last_viewed_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:last_viewed_entry[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="last_viewed_entry">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="item_id" type="xsd:string"/>
+   <xsd:element name="item_summary" type="xsd:string"/>
+   <xsd:element name="module_name" type="xsd:string"/>
+   <xsd:element name="monitor_id" type="xsd:string"/>
+   <xsd:element name="date_modified" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="module_list_array">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:module_list_entry[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="module_list_entry">
+  <xsd:all>
+   <xsd:element name="module_key" type="xsd:string"/>
+   <xsd:element name="module_label" type="xsd:string"/>
+   <xsd:element name="favorite_enabled" type="xsd:boolean"/>
+   <xsd:element name="acls" type="tns:acl_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="acl_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:acl_list_entry[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="acl_list_entry">
+  <xsd:all>
+   <xsd:element name="action" type="xsd:string"/>
+   <xsd:element name="access" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_list2">
+  <xsd:all>
+   <xsd:element name="link_list" type="tns:link_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="link_value2">
+  <xsd:all>
+   <xsd:element name="link_value" type="tns:link_value"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="report_field_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:field_list2[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="field_list2">
+  <xsd:all>
+   <xsd:element name="field_list" type="tns:field_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="report_entry_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:entry_list2[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="entry_list2">
+  <xsd:all>
+   <xsd:element name="entry_list" type="tns:entry_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="search_link_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:search_link_name_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="search_link_name_value">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="records" type="tns:search_link_array_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="search_link_array_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:link_value[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="error_value">
+  <xsd:all>
+   <xsd:element name="number" type="xsd:string"/>
+   <xsd:element name="name" type="xsd:string"/>
+   <xsd:element name="description" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="modified_relationship_entry_list">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:modified_relationship_entry[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
+ <xsd:complexType name="modified_relationship_entry">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:string"/>
+   <xsd:element name="module_name" type="xsd:string"/>
+   <xsd:element name="name_value_list" type="tns:name_value_list"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="modified_relationship_result">
+  <xsd:all>
+   <xsd:element name="result_count" type="xsd:int"/>
+   <xsd:element name="next_offset" type="xsd:int"/>
+   <xsd:element name="entry_list" type="tns:modified_relationship_entry_list"/>
+   <xsd:element name="error" type="tns:error_value"/>
+  </xsd:all>
+ </xsd:complexType>
+</xsd:schema>
+</types>
+<message name="loginRequest">
+  <part name="user_auth" type="tns:user_auth" />
+  <part name="application_name" type="xsd:string" />
+  <part name="name_value_list" type="tns:name_value_list" /></message>
+<message name="loginResponse">
+  <part name="return" type="tns:entry_value" /></message>
+<message name="logoutRequest">
+  <part name="session" type="xsd:string" /></message>
+<message name="logoutResponse"></message>
+<message name="get_entryRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="id" type="xsd:string" />
+  <part name="select_fields" type="tns:select_fields" />
+  <part name="link_name_to_fields_array" type="tns:link_names_to_fields_array" />
+  <part name="track_view" type="xsd:boolean" /></message>
+<message name="get_entryResponse">
+  <part name="return" type="tns:get_entry_result_version2" /></message>
+<message name="get_entriesRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="ids" type="tns:select_fields" />
+  <part name="select_fields" type="tns:select_fields" />
+  <part name="link_name_to_fields_array" type="tns:link_names_to_fields_array" />
+  <part name="track_view" type="xsd:boolean" /></message>
+<message name="get_entriesResponse">
+  <part name="return" type="tns:get_entry_result_version2" /></message>
+<message name="get_entry_listRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="query" type="xsd:string" />
+  <part name="order_by" type="xsd:string" />
+  <part name="offset" type="xsd:int" />
+  <part name="select_fields" type="tns:select_fields" />
+  <part name="link_name_to_fields_array" type="tns:link_names_to_fields_array" />
+  <part name="max_results" type="xsd:int" />
+  <part name="deleted" type="xsd:int" />
+  <part name="favorites" type="xsd:boolean" /></message>
+<message name="get_entry_listResponse">
+  <part name="return" type="tns:get_entry_list_result_version2" /></message>
+<message name="set_relationshipRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="module_id" type="xsd:string" />
+  <part name="link_field_name" type="xsd:string" />
+  <part name="related_ids" type="tns:select_fields" />
+  <part name="name_value_list" type="tns:name_value_list" />
+  <part name="delete" type="xsd:int" /></message>
+<message name="set_relationshipResponse">
+  <part name="return" type="tns:new_set_relationship_list_result" /></message>
+<message name="set_relationshipsRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_names" type="tns:select_fields" />
+  <part name="module_ids" type="tns:select_fields" />
+  <part name="link_field_names" type="tns:select_fields" />
+  <part name="related_ids" type="tns:new_set_relationhip_ids" />
+  <part name="name_value_lists" type="tns:name_value_lists" />
+  <part name="delete_array" type="tns:deleted_array" /></message>
+<message name="set_relationshipsResponse">
+  <part name="return" type="tns:new_set_relationship_list_result" /></message>
+<message name="get_relationshipsRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="module_id" type="xsd:string" />
+  <part name="link_field_name" type="xsd:string" />
+  <part name="related_module_query" type="xsd:string" />
+  <part name="related_fields" type="tns:select_fields" />
+  <part name="related_module_link_name_to_fields_array" type="tns:link_names_to_fields_array" />
+  <part name="deleted" type="xsd:int" />
+  <part name="order_by" type="xsd:string" />
+  <part name="offset" type="xsd:int" />
+  <part name="limit" type="xsd:int" /></message>
+<message name="get_relationshipsResponse">
+  <part name="return" type="tns:get_entry_result_version2" /></message>
+<message name="set_entryRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="name_value_list" type="tns:name_value_list" /></message>
+<message name="set_entryResponse">
+  <part name="return" type="tns:new_set_entry_result" /></message>
+<message name="set_entriesRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="name_value_lists" type="tns:name_value_lists" /></message>
+<message name="set_entriesResponse">
+  <part name="return" type="tns:new_set_entries_result" /></message>
+<message name="get_server_infoRequest"></message>
+<message name="get_server_infoResponse">
+  <part name="return" type="tns:get_server_info_result" /></message>
+<message name="get_user_idRequest">
+  <part name="session" type="xsd:string" /></message>
+<message name="get_user_idResponse">
+  <part name="return" type="xsd:string" /></message>
+<message name="get_module_fieldsRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="fields" type="tns:select_fields" /></message>
+<message name="get_module_fieldsResponse">
+  <part name="return" type="tns:new_module_fields" /></message>
+<message name="seamless_loginRequest">
+  <part name="session" type="xsd:string" /></message>
+<message name="seamless_loginResponse">
+  <part name="return" type="xsd:int" /></message>
+<message name="set_note_attachmentRequest">
+  <part name="session" type="xsd:string" />
+  <part name="note" type="tns:new_note_attachment" /></message>
+<message name="set_note_attachmentResponse">
+  <part name="return" type="tns:new_set_entry_result" /></message>
+<message name="get_note_attachmentRequest">
+  <part name="session" type="xsd:string" />
+  <part name="id" type="xsd:string" /></message>
+<message name="get_note_attachmentResponse">
+  <part name="return" type="tns:new_return_note_attachment" /></message>
+<message name="set_document_revisionRequest">
+  <part name="session" type="xsd:string" />
+  <part name="note" type="tns:document_revision" /></message>
+<message name="set_document_revisionResponse">
+  <part name="return" type="tns:new_set_entry_result" /></message>
+<message name="get_document_revisionRequest">
+  <part name="session" type="xsd:string" />
+  <part name="i" type="xsd:string" /></message>
+<message name="get_document_revisionResponse">
+  <part name="return" type="tns:new_return_document_revision" /></message>
+<message name="search_by_moduleRequest">
+  <part name="session" type="xsd:string" />
+  <part name="search_string" type="xsd:string" />
+  <part name="modules" type="tns:select_fields" />
+  <part name="offset" type="xsd:int" />
+  <part name="max_results" type="xsd:int" />
+  <part name="assigned_user_id" type="xsd:string" />
+  <part name="select_fields" type="tns:select_fields" />
+  <part name="unified_search_only" type="xsd:boolean" />
+  <part name="favorites" type="xsd:boolean" /></message>
+<message name="search_by_moduleResponse">
+  <part name="return" type="tns:return_search_result" /></message>
+<message name="get_available_modulesRequest">
+  <part name="session" type="xsd:string" />
+  <part name="filter" type="xsd:string" /></message>
+<message name="get_available_modulesResponse">
+  <part name="return" type="tns:module_list" /></message>
+<message name="get_user_team_idRequest">
+  <part name="session" type="xsd:string" /></message>
+<message name="get_user_team_idResponse">
+  <part name="return" type="xsd:string" /></message>
+<message name="set_campaign_mergeRequest">
+  <part name="session" type="xsd:string" />
+  <part name="targets" type="tns:select_fields" />
+  <part name="campaign_id" type="xsd:string" /></message>
+<message name="set_campaign_mergeResponse"></message>
+<message name="get_entries_countRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="query" type="xsd:string" />
+  <part name="deleted" type="xsd:int" /></message>
+<message name="get_entries_countResponse">
+  <part name="return" type="tns:get_entries_count_result" /></message>
+<message name="get_module_fields_md5Request">
+  <part name="session" type="xsd:string" />
+  <part name="module_names" type="tns:select_fields" /></message>
+<message name="get_module_fields_md5Response">
+  <part name="return" type="tns:md5_results" /></message>
+<message name="get_last_viewedRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_names" type="tns:module_names" /></message>
+<message name="get_last_viewedResponse">
+  <part name="return" type="tns:last_viewed_list" /></message>
+<message name="get_upcoming_activitiesRequest">
+  <part name="session" type="xsd:string" /></message>
+<message name="get_upcoming_activitiesResponse">
+  <part name="return" type="tns:upcoming_activities_list" /></message>
+<message name="get_modified_relationshipsRequest">
+  <part name="session" type="xsd:string" />
+  <part name="module_name" type="xsd:string" />
+  <part name="related_module" type="xsd:string" />
+  <part name="from_date" type="xsd:string" />
+  <part name="to_date" type="xsd:string" />
+  <part name="offset" type="xsd:int" />
+  <part name="max_results" type="xsd:int" />
+  <part name="deleted" type="xsd:int" />
+  <part name="module_user_id" type="xsd:string" />
+  <part name="select_fields" type="tns:select_fields" />
+  <part name="relationship_name" type="xsd:string" />
+  <part name="deletion_date" type="xsd:string" /></message>
+<message name="get_modified_relationshipsResponse">
+  <part name="return" type="tns:modified_relationship_result" /></message>
+<portType name="sugarsoapPortType">
+  <operation name="login">
+    <input message="tns:loginRequest"/>
+    <output message="tns:loginResponse"/>
+  </operation>
+  <operation name="logout">
+    <input message="tns:logoutRequest"/>
+    <output message="tns:logoutResponse"/>
+  </operation>
+  <operation name="get_entry">
+    <input message="tns:get_entryRequest"/>
+    <output message="tns:get_entryResponse"/>
+  </operation>
+  <operation name="get_entries">
+    <input message="tns:get_entriesRequest"/>
+    <output message="tns:get_entriesResponse"/>
+  </operation>
+  <operation name="get_entry_list">
+    <input message="tns:get_entry_listRequest"/>
+    <output message="tns:get_entry_listResponse"/>
+  </operation>
+  <operation name="set_relationship">
+    <input message="tns:set_relationshipRequest"/>
+    <output message="tns:set_relationshipResponse"/>
+  </operation>
+  <operation name="set_relationships">
+    <input message="tns:set_relationshipsRequest"/>
+    <output message="tns:set_relationshipsResponse"/>
+  </operation>
+  <operation name="get_relationships">
+    <input message="tns:get_relationshipsRequest"/>
+    <output message="tns:get_relationshipsResponse"/>
+  </operation>
+  <operation name="set_entry">
+    <input message="tns:set_entryRequest"/>
+    <output message="tns:set_entryResponse"/>
+  </operation>
+  <operation name="set_entries">
+    <input message="tns:set_entriesRequest"/>
+    <output message="tns:set_entriesResponse"/>
+  </operation>
+  <operation name="get_server_info">
+    <input message="tns:get_server_infoRequest"/>
+    <output message="tns:get_server_infoResponse"/>
+  </operation>
+  <operation name="get_user_id">
+    <input message="tns:get_user_idRequest"/>
+    <output message="tns:get_user_idResponse"/>
+  </operation>
+  <operation name="get_module_fields">
+    <input message="tns:get_module_fieldsRequest"/>
+    <output message="tns:get_module_fieldsResponse"/>
+  </operation>
+  <operation name="seamless_login">
+    <input message="tns:seamless_loginRequest"/>
+    <output message="tns:seamless_loginResponse"/>
+  </operation>
+  <operation name="set_note_attachment">
+    <input message="tns:set_note_attachmentRequest"/>
+    <output message="tns:set_note_attachmentResponse"/>
+  </operation>
+  <operation name="get_note_attachment">
+    <input message="tns:get_note_attachmentRequest"/>
+    <output message="tns:get_note_attachmentResponse"/>
+  </operation>
+  <operation name="set_document_revision">
+    <input message="tns:set_document_revisionRequest"/>
+    <output message="tns:set_document_revisionResponse"/>
+  </operation>
+  <operation name="get_document_revision">
+    <input message="tns:get_document_revisionRequest"/>
+    <output message="tns:get_document_revisionResponse"/>
+  </operation>
+  <operation name="search_by_module">
+    <input message="tns:search_by_moduleRequest"/>
+    <output message="tns:search_by_moduleResponse"/>
+  </operation>
+  <operation name="get_available_modules">
+    <input message="tns:get_available_modulesRequest"/>
+    <output message="tns:get_available_modulesResponse"/>
+  </operation>
+  <operation name="get_user_team_id">
+    <input message="tns:get_user_team_idRequest"/>
+    <output message="tns:get_user_team_idResponse"/>
+  </operation>
+  <operation name="set_campaign_merge">
+    <input message="tns:set_campaign_mergeRequest"/>
+    <output message="tns:set_campaign_mergeResponse"/>
+  </operation>
+  <operation name="get_entries_count">
+    <input message="tns:get_entries_countRequest"/>
+    <output message="tns:get_entries_countResponse"/>
+  </operation>
+  <operation name="get_module_fields_md5">
+    <input message="tns:get_module_fields_md5Request"/>
+    <output message="tns:get_module_fields_md5Response"/>
+  </operation>
+  <operation name="get_last_viewed">
+    <input message="tns:get_last_viewedRequest"/>
+    <output message="tns:get_last_viewedResponse"/>
+  </operation>
+  <operation name="get_upcoming_activities">
+    <input message="tns:get_upcoming_activitiesRequest"/>
+    <output message="tns:get_upcoming_activitiesResponse"/>
+  </operation>
+  <operation name="get_modified_relationships">
+    <input message="tns:get_modified_relationshipsRequest"/>
+    <output message="tns:get_modified_relationshipsResponse"/>
+  </operation>
+</portType>
+<binding name="sugarsoapBinding" type="tns:sugarsoapPortType">
+  <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+  <operation name="login">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/login" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="logout">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/logout" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_entry">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_entry" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_entries">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_entries" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_entry_list">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_entry_list" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_relationship">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_relationship" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_relationships">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_relationships" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_relationships">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_relationships" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_entry">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_entry" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_entries">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_entries" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_server_info">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_server_info" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_user_id">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_user_id" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_module_fields">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_module_fields" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="seamless_login">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/seamless_login" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_note_attachment">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_note_attachment" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_note_attachment">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_note_attachment" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_document_revision">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_document_revision" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_document_revision">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_document_revision" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="search_by_module">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/search_by_module" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_available_modules">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_available_modules" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_user_team_id">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_user_team_id" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="set_campaign_merge">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/set_campaign_merge" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_entries_count">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_entries_count" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_module_fields_md5">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_module_fields_md5" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_last_viewed">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_last_viewed" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_upcoming_activities">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_upcoming_activities" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+  <operation name="get_modified_relationships">
+    <soap:operation soapAction="https://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php/get_modified_relationships" style="rpc"/>
+    <input><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></input>
+    <output><soap:body use="literal" namespace="http://www.sugarcrm.com/sugarcrm"/></output>
+  </operation>
+</binding>
+<service name="sugarsoap">
+  <port name="sugarsoapPort" binding="tns:sugarsoapBinding">
+    <soap:address location="http://my-release-suitecrm-suitecrm.apps.cluster-5d8d.5d8d.sandbox1044.opentlc.com/service/v4_1/soap.php"/>
+  </port>
+</service>
+</definitions>


### PR DESCRIPTION
Split the work to address the issue in several commits to ease reviewing:

chore(deps): upgrade xmlschema-core 2.2.5 (b7cfa9c)

Makes sense to use a newer, currently latest, version.

chore(c/soap): test data shape with AtlasMap (10dbcec)

This makes sure that any data shape produced by the SOAP API generator
will be accepted by AtlasMap inspection by running the inspection as a
part of the example tests.

fix(c/soap): change xsd:timeInstant to xsd:dateTime (0cac7b4)

SOAP 1.2 renamed `xsd:timeInstant` to `xsd:dateTime` see[1]. Using
`xsd:timeInstant` was breaking the tests with AtlasMap as the XML Schema
data types no longer define `xsd:timeInstant`.

Might be a slight concern with regards to legacy SOAP 1.1 or earlier,
this was an easier fix and it's fairly safe that most deployments are
using SOAP 1.2 these days.

[1] https://w3.org/2000/xp/Group/1/10/11/soap12-part1.html#schemachanges

fix(c/soap): NPE in XmlSchemaSerializer (b402730)

This fixes the `NullPointerException` in `XmlSchemaSerializer` reported
in ENTESB-16464[1]. The namespace context in the target schema was not
initialized and defaulted to `null`, leading to the
`NullPointerException`.

In addition to setting the namespace context to an instance of
`NamespaceMap`, this instance was populated with prefixes for XML Schema
and XML namespaces, as these were not set by default.

[1] https://issues.redhat.com/browse/ENTESB-16464

fix(c/soap): use name instead of concrete name (db434b4)

For an unknown reason the code was using concrete name instead of name
to extract a schema for a SOAP message part, this lead to
`NullPointerException`s when concrete name was not set.

fix(c/soap): add definition of XML schema namespace (0107b48)

XML namespace is an odd one, it's implicitly defined in a XML schema
document, but not in non-XML schema documents. So in the schema sets
created by the SOAP API generator and expected by AtlasMap in the data
shape it needs to be declared and included. Otherwise attributes with
type of `xml:*` can't be unreferenced and the inspection of the data
shape fails.

To circumvent this, XML namespace schema is added automatically to all
schema sets. This might seem unwarranted, but considering that most SOAP
APIs will declare a SOAP fault, and that the `reasonText` is defined
with `xml:lang` attribute inclusion seems warranted.

fix(c/soap): test with SugarCRM WSDL file (fb9e399)

This adds an example test with the WSDL from SugarCRM, being that it's
reported in ENTESB-16464[1], now we can make sure that this WSDL passes
generation and AtlasMap inspection.

[1] https://issues.redhat.com/browse/ENTESB-16464

