### PR TITLE
chore: release using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Set version
+        id: setup
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache Maven Repository
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: release-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: release-${{ runner.os }}-m2
+      - name: Perform release
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          QUAYIO_USER: ${{ secrets.QUAYIO_USER }}
+          QUAYIO_PASSWORD: ${{ secrets.QUAYIO_PASSWORD }}
+          SYNDESISCI_TOKEN: ${{ secrets.SYNDESISCI_TOKEN }}
+          GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        run: |
+          git config --global user.email ci@syndesis.io
+          git config --global user.name 'Syndesis CI'
+          git config --global 'http.https://github.com/.extraheader' "Authorization: basic $(echo -n x-access-token:${SYNDESISCI_TOKEN}|base64 --wrap=0)"
+          gpg --batch --import <(echo "${GPG_KEY}")
+          export GPG_TTY=$(tty)
+          tools/bin/syndesis release --dry-run --settings .mvn/settings.release.xml --release-version ${{ steps.setup.outputs.version }} --git-remote origin --docker-user "${DOCKER_USER}" --docker-password "${DOCKER_PASSWORD}" --github-user syndesisci --github-token "${SYNDESISCI_TOKEN}" --quayio-user "${QUAYIO_USER}" --quayio-password "${QUAYIO_PASSWORD}" --gpg-keyname "${GPG_KEYNAME}" --gpg-passphrase "${GPG_PASSPHRASE}"

--- a/app/.mvn/settings.release.xml
+++ b/app/.mvn/settings.release.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- This settings file is used for automated release by GitHub Actions -->
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>oss-sonatype-staging</id>
+      <username>syndesis</username>
+      <password>${env.OSSRH_PASSWORD}</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>disable-apache-snapshots-repository</id>
+      <activation>
+      	<activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>apache.snapshots</id>
+          <url>http://repository.apache.org/snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>apache.snapshots</id>
+          <url>http://repository.apache.org/snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -364,6 +364,11 @@
             <version>1.6</version>
             <configuration>
               <skip>false</skip>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+                <arg>--batch</arg>
+              </gpgArguments>
             </configuration>
             <executions>
               <execution>

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -36,6 +36,8 @@ release::usage() {
     --git-remote              Name of the git remote to push to. If not given, its trying to be pushed
                               to the git remote to which the currently checked out branch is attached to.
                               Works only when on a branch, not when checked out directly.
+    --gpg-keyname             Name of the GPG key to sign with (USER-ID)
+    --gpg-passphrase          Passphrase used to unlock the GPG key
     --log <log-file>          Write full log to <log-file>, only print progress to screen
     --skip-tests              Do not run tests
     --no-strict-checksums     Do not insist on strict checksum policy for downloaded Maven artifacts
@@ -88,15 +90,9 @@ release::run() {
     # Verify that there are no modified file in git repo
     check_git_clean "$topdir"
 
-    # Temporary local repository to guarantee a clean build
-    local local_maven_repo=$(readopt --local-maven-repo)
-    if [ -z "$local_maven_repo" ]; then
-        local_maven_repo=$(mktemp -d 2>/dev/null || mktemp -d -t 'maven_repo')
-        trap "echo 'Removing temp maven repo $local_maven_repo' && rm -rf $local_maven_repo" "EXIT"
-    fi
-
     # Calculate common maven options
-    local maven_opts="$(extract_maven_opts $local_maven_repo)"
+    local maven_opts
+    maven_opts="$(extract_maven_opts "${topdir}")"
 
     # Set pom.xml version to the given release_version
     update_pom_versions "$topdir" "$release_version" "$maven_opts"
@@ -543,26 +539,40 @@ drop_staging_repo() {
 # Helper
 
 extract_maven_opts() {
-    local maven_opts="-Dmaven.repo.local=$1 --batch-mode -V -e"
+    local topdir="$1"
 
-    if [ $(hasflag --quiet -q) ]; then
+    local maven_opts
+    maven_opts="--no-transfer-progress --batch-mode -V -e"
+
+    if [ "$(hasflag --quiet -q)" ]; then
         maven_opts="$maven_opts -q"
     fi
 
-    local settings_xml=$(readopt --settings-xml --settings)
+    local settings_xml
+    settings_xml=$(readopt --settings-xml --settings)
     if [ -n "${settings_xml}" ]; then
         maven_opts="$maven_opts -s $settings_xml"
     fi
 
-    if [ $(hasflag --skip-tests) ]; then
+    if [ "$(hasflag --skip-tests)" ]; then
         maven_opts="$maven_opts -DskipTests -DskipITs"
     fi
 
-    if [ ! $(hasflag --no-strict-checksums) ]; then
+    if [ ! "$(hasflag --no-strict-checksums)" ]; then
         maven_opts="$maven_opts -C"
     fi
 
-    echo $maven_opts
+    local gpg_keyname
+    gpg_keyname=$(readopt --gpg-keyname)
+
+    local gpg_passphrase
+    gpg_passphrase=$(readopt --gpg-passphrase)
+
+    if [ -n "${gpg_keyname}" ] && [ -n "${gpg_passphrase}" ]; then
+        maven_opts+=" -Dgpg.keyname=${gpg_keyname} -Dgpg.passphrase=${gpg_passphrase}"
+    fi
+
+    echo "${maven_opts}"
 }
 
 git_commit() {


### PR DESCRIPTION
This adds a GitHub Actions workflow to release Syndesis. To trigger a
release one needs to push a tag with name `major.minor.patch`, e.g.
`1.17.0`. Use of a local repository cache in a temporary directory was
removed, as we need to rely on the caching provided by GitHub Actions.
We also use strict checksums in release so that makes it even safer.

Ref. https://issues.redhat.com/browse/ENTESB-15939