### PR TITLE
fix(c/soap): custom SOAP client error handling

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGenerator.java
@@ -158,6 +158,13 @@ public class SoapApiConnectorGenerator extends ConnectorGenerator {
     private APISummary getApiSummary(ConnectorTemplate connectorTemplate, ConnectorSettings connectorSettings,
                                      SoapApiModelInfo modelInfo) {
 
+        if (!modelInfo.getResolvedSpecification().isPresent()) {
+            return new APISummary.Builder()
+                .errors(modelInfo.getErrors())
+                .warnings(modelInfo.getWarnings())
+                .build();
+        }
+
         final Map<String, String> configuredProperties = connectorSettings.getConfiguredProperties();
 
         // create connector from template and connectorSettings, and add connector properties and parse warnings and errors

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -163,10 +163,24 @@ public final class SoapApiModelParser {
         } catch (WSDLException | BusException e) {
             addError(builder, "Error parsing WSDL: " + e.getMessage(), e);
         } catch (TransformerException e) {
-            addError(builder, "Error condensing WSDL: " + e.getMessage(), e);
+            addError(builder, "Error parsing WSDL: " + messageFrom(e), e);
         }
 
         return builder.build();
+    }
+
+    private static String messageFrom(final TransformerException e) {
+        TransformerException last = e;
+        while (last.getCause() instanceof TransformerException) {
+            last = (TransformerException) e.getCause();
+        }
+
+        final Throwable lastCause = last.getCause();
+        if (lastCause != null) {
+            return lastCause.getMessage();
+        }
+
+        return last.getMessage();
     }
 
     public static String getAddress(Definition definition, QName service, String port) {

--- a/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
+++ b/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
@@ -1,5 +1,6 @@
-import { IApiSummarySoap } from '@syndesis/models';
 import * as React from 'react';
+
+import { IApiSummarySoap } from '@syndesis/models';
 import { ApiContext } from './ApiContext';
 import { callFetch } from './callFetch';
 
@@ -55,17 +56,10 @@ export function useApiConnectorSummary(
         if (summary.errorCode) {
           throw new Error(summary.userMsg);
         }
-        if (!summary.actionsSummary) {
-          let errorMessage = '';
-          // we should be getting an array of error objects
-          if (Array.isArray(summary.errors)) {
-            errorMessage = summary.errors
+        if (Array.isArray(summary.errors) && summary.errors.length > 0) {
+          const errorMessage = summary.errors
               .map((e: string | any) => (e.message ? e.message : e))
               .join('\n');
-          } else {
-            // but in case we don't, let's show what we got and hope for the best
-            errorMessage = JSON.stringify(summary);
-          }
           throw new Error(errorMessage);
         }
         setApiSummary(summary as IApiSummarySoap);
@@ -78,5 +72,5 @@ export function useApiConnectorSummary(
     fetchSummary();
   }, [specification, apiContext, setLoading, setApiSummary, setError]);
 
-  return { apiSummary, loading, error };
+  return { apiSummary, loading, error, setError };
 }

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
@@ -1,4 +1,5 @@
-import { useApiConnectorSummary } from '@syndesis/api';
+import * as React from 'react';
+
 import {
   ApiConnectorCreatorBreadcrumb,
   ApiConnectorCreatorBreadSteps,
@@ -9,9 +10,11 @@ import {
   PageLoader,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
-import * as React from 'react';
-import { Translation } from 'react-i18next';
 import { ApiError, PageTitle } from '../../../../shared';
+
+import { useApiConnectorSummary } from '@syndesis/api';
+import { Translation } from 'react-i18next';
+import { UIContext } from '../../../../app';
 import resolvers from '../../resolvers';
 
 export const SelectMethodPage: React.FunctionComponent = () => {
@@ -20,10 +23,22 @@ export const SelectMethodPage: React.FunctionComponent = () => {
   const [spec, setSpec] = React.useState('');
   const [showSoapConfig, setShowSoapConfig] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
-  const { apiSummary, error, loading } = useApiConnectorSummary(
+  const { apiSummary, error, loading, setError } = useApiConnectorSummary(
     spec,
     connectorTemplateId
   );
+  const uiContext = React.useContext(UIContext);
+
+  React.useEffect(() => {
+    if (error) {
+      uiContext.pushNotification((error as Error).message, 'error');
+      setError(false);
+      setShowSoapConfig(false);
+      setIsLoading(false);
+      setSpec('');
+      setConnectorTemplateId('');
+    }
+  }, [error, uiContext, history, setError]);
 
   /**
    * Only use the loader state from useApiConnectorSummary


### PR DESCRIPTION
This adds error handling to custom SOAP client creation. On the server
side this also cleans up the error message when parsing WSDL so that the
message doesn't show Java internals.

Ref. https://issues.redhat.com/browse/ENTESB-14078