### PR TITLE
fix(release): don't trigger on snapshot builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*.*.*'
+      - '!*.*.*-*'
 
 jobs:
   release:


### PR DESCRIPTION
Seems that release workflow is triggered on push of a snapshot tag, e.g.
for `1.12.0-20210610`[1]. We need it to run only for release tags, not
for snapshot tags.

[1] https://github.com/syndesisio/syndesis/actions/runs/924178490