### PR TITLE
fix(c/sql): pass schema to legacy parser

### DIFF
--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementLegacyParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementLegacyParser.java
@@ -52,12 +52,7 @@ class SqlStatementLegacyParser {
     private final List<String> sqlArrayUpperCase = new ArrayList<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlStatementParser.class);
 
-    public SqlStatementLegacyParser(Connection connection, String sql) throws SQLException {
-        this(connection, null, sql);
-    }
-
     public SqlStatementLegacyParser(Connection connection, String schema, String sql) throws SQLException {
-        super();
         statementInfo = new SqlStatementMetaData(sql.trim(), schema);
         this.connection = connection;
         dbHelper = new DbMetaDataHelper(connection);

--- a/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
+++ b/app/connector/sql/src/main/java/io/syndesis/connector/sql/common/SqlStatementParser.java
@@ -231,7 +231,7 @@ public final class SqlStatementParser {
         } catch (final JSQLParserException e) {
             // if we failed we try to parse with the legacy parser
             // if that fails as well we throw the original exception
-            final SqlStatementLegacyParser legacyParser = new SqlStatementLegacyParser(helper.connection, sql);
+            final SqlStatementLegacyParser legacyParser = new SqlStatementLegacyParser(helper.connection, schema, sql);
             try {
                 return legacyParser.parse();
             } catch (SQLException fromLegacyParser) {


### PR DESCRIPTION
Legacy parser could fail if the database object is in a different schema
than the default schema provided by the connection.

Ref. https://issues.redhat.com/browse/ENTESB-16608