### PR TITLE
chore(deps): upgrade RESTEasy to 4.6.0.Final

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -151,8 +151,8 @@
     <mockito.version>3.8.0</mockito.version>
     <mongodb.version>3.9.0</mongodb.version>
 
-    <resteasy.version>4.5.12.Final</resteasy.version>
-    <resteasy-spring-boot-starter.version>4.6.4.Final</resteasy-spring-boot-starter.version>
+    <resteasy.version>4.6.0.Final</resteasy.version>
+    <resteasy-spring-boot-starter.version>4.8.0.Final</resteasy-spring-boot-starter.version>
 
     <immutables.version>2.8.8</immutables.version>
 


### PR DESCRIPTION
Also upgrades the RESTEasy Spring Boot starter to the version utilizing
4.6.0.Final