### PR TITLE
fix(release): remove m2e processing instructions

### DIFF
--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -499,7 +499,6 @@
             </goals>
           </execution>
           <execution>
-            <?m2e ignore ?>
             <id>default-cli</id>
             <goals>
               <goal>run</goal>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -175,7 +175,6 @@
             </goals>
           </execution>
           <execution>
-            <?m2e ignore ?>
             <id>default-cli</id>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
A recent release of 1.12.0[1] failed with:

```
2021-06-22T09:44:31.0147694Z [ERROR] Rule failure while trying to close staging repository with ID "iosyndesis-1289".
2021-06-22T09:44:31.0176443Z [ERROR]
2021-06-22T09:44:31.0177865Z [ERROR] Nexus Staging Rules Failure Report
2021-06-22T09:44:31.0179523Z [ERROR] ==================================
2021-06-22T09:44:31.0181276Z [ERROR]
2021-06-22T09:44:31.0183416Z [ERROR] Repository "iosyndesis-1289" failures
2021-06-22T09:44:31.0185655Z [ERROR]   Rule "sources-staging" failures
2021-06-22T09:44:31.0189161Z [ERROR]     * Rule evaluation unexpectedly failed: org.sonatype.nexus.proxy.walker.WalkerException: Aborted walking on repository ID='iosyndesis-1289' from path='/'.
2021-06-22T09:44:31.0192564Z [ERROR]   Rule "pom-staging" failures
2021-06-22T09:44:31.0196020Z [ERROR]     * Rule evaluation unexpectedly failed: org.sonatype.nexus.proxy.walker.WalkerException: Aborted walking on repository ID='iosyndesis-1289' from path='/'.
2021-06-22T09:44:31.0201981Z [ERROR]   Rule "javadoc-staging" failures
2021-06-22T09:44:31.0205093Z [ERROR]     * Rule evaluation unexpectedly failed: org.sonatype.nexus.proxy.walker.WalkerException: Aborted walking on repository ID='iosyndesis-1289' from path='/'.
2021-06-22T09:44:31.0207646Z [ERROR]
2021-06-22T09:44:31.0208867Z [ERROR]
2021-06-22T09:44:31.0211074Z [ERROR] Cleaning up local stage directory after a Rule failure during close of staging repositories: [iosyndesis-1289]
2021-06-22T09:44:31.0213243Z [ERROR]  * Deleting context 61015c63f807ce.properties
2021-06-22T09:44:31.0215934Z [ERROR] Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [iosyndesis-1289]
2021-06-22T09:44:31.0219149Z [ERROR]  * Dropping failed staging repository with ID "iosyndesis-1289" (Rule failure during close of staging repositories: [iosyndesis-1289]).
2021-06-22T09:44:31.0357507Z
2021-06-22T09:44:31.0359591Z Waiting for operation to complete...
2021-06-22T09:44:46.5549809Z .....
2021-06-22T09:44:46.5551200Z
2021-06-22T09:44:46.5553387Z [ERROR] Remote staging finished with a failure: Staging rules failure!
```

An issue OSSRH-56004[2] points to M2E processing instructions causing
issues similar to this one. As a solution this removes those processing
instructions.

[skip ci]

[1] https://github.com/syndesisio/syndesis/runs/2883233152
[2] https://issues.sonatype.org/browse/OSSRH-56004