### PR TITLE
chore(release): moving tag for snapshot release

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -75,6 +75,10 @@ release::run() {
     local moving_tag=$(extract_minor_version $release_version)
     check_error $moving_tag
 
+    if [[ $(hasflag --snapshot-release) ]]; then
+      moving_tag+='-prerelease'
+    fi
+
     # Write to logfile if requested
     if [ $(readopt --log) ]; then
         local logfile=$(readopt --log)
@@ -108,7 +112,7 @@ release::run() {
     create_upgrade_container_image "$topdir" "$release_version"
 
     # Create the operator image binaries
-    update_image_versions "$topdir" "$release_version" "$moving_tag"
+    update_image_versions "$topdir" "$release_version"
     "$topdir/install/operator/build.sh" --operator-build docker --image-build docker --image-name "syndesis/syndesis-operator" --image-tag "$release_version"
 
     # For a test run, we are done

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -328,17 +328,28 @@ publish_artifacts() {
     fi
 
     local upload_url
+    # create or update a GitHub release, the daily builds will create a release
+    # while a proper release will be initiaded by creating a GitHub release first
     upload_url=$(curl -q -s -S --fail \
       -X POST \
       -u "${github_username}:${github_token}" \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Content-Type: application/json" \
       -d "$data" \
-      "${github_api_url}/releases" | jq -r '.upload_url | sub("{.*"; "")'
-    )
+      "${github_api_url}/releases" 2> /dev/null | jq -r '.upload_url | sub("{.*"; "")' \
+    || curl -q -s -S --fail \
+      -X PATCH \
+      -u "${github_username}:${github_token}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Content-Type: application/json" \
+      -d "$data" \
+      "$(curl -q -s -S --fail \
+         -u "${github_username}:${github_token}" \
+         -H "Accept: application/vnd.github.v3+json" \
+         "${github_api_url}/releases/tags/${tag}" | jq -r .url)" | jq -r '.upload_url | sub("{.*"; "")')
 
     if [[ ! $upload_url == http* ]]; then
-        echo "ERROR: Cannot create release on remote github repository. Check if a release with the same tag already exists."
+        echo "ERROR: Cannot create release on remote github repository."
         return 1
     fi
 


### PR DESCRIPTION
Instead of stomping the release's moving tag this makes the snapshot
releases (daily releases) have the moving tag with the `-prerelease`
suffix.

Say we just released a version 1.2.3, with it a moving tag 1.2 will be
created. The idea of the moving tag is that we can create minor releases
and have environments auto-update to them. With snapshot (daily)
releases we used to use the same moving tag, so a snapshot release would
stomp over the 'proper' release's moving tag. This prevents that by
using a suffix on the snapshot release's moving tag.