### PR TITLE
chore: migrate to Husky 6 and auto-install

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn npm-run-all pre-commit:*

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+yarn npm-run-all pre-push:*

--- a/package.json
+++ b/package.json
@@ -7,17 +7,11 @@
     "lint-staged": "~11",
     "npm-run-all": "~4"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm-run-all pre-commit:*",
-      "pre-push": "npm-run-all pre-push:*",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "scripts": {
     "pre-commit:lint-staged": "lint-staged",
     "pre-commit:add-operator-assets-vfsdata": "git add install/operator/pkg/generator/assets_vfsdata.go",
     "pre-commit:ui-react": "cd app/ui-react && yarn pre-commit",
-    "pre-push:ui-react": "./tools/bin/syndesis -m ui-react --incremental"
+    "pre-push:ui-react": "./tools/bin/syndesis -m ui-react --incremental",
+    "postinstall": "husky install"
   }
 }


### PR DESCRIPTION
Seems we upgraded to v6 of Husky but did not perform the migration[1].
Also adds auto-install of Husky via postinstall script.

[1] https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v6