### PR TITLE
chore(ui): upgrade prettier and add JSON sort

### DIFF
--- a/app/ui-react/package.json
+++ b/app/ui-react/package.json
@@ -46,7 +46,8 @@
     "lerna": "^3.13.1",
     "lint-staged": "^10.0.7",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.16.4",
+    "prettier": "^2.3.1",
+    "prettier-plugin-sort-json": "^0.0.2",
     "rxjs": "^6.4.0",
     "tslint": "^5.13.0",
     "tslint-config-prettier": "^1.18.0",
@@ -66,8 +67,9 @@
     ]
   },
   "prettier": {
-    "trailingComma": "es5",
+    "jsonRecursiveSort": true,
+    "semi": true,
     "singleQuote": true,
-    "semi": true
+    "trailingComma": "es5"
   }
 }

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -1,34 +1,2470 @@
 {
-  "openapi": "3.0.1",
+  "components": {
+    "schemas": {
+      "APIFormData": {
+        "properties": {
+          "specification": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "APISummary": {
+        "properties": {
+          "actionsSummary": {
+            "$ref": "#/components/schemas/ActionsSummary"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/Violation"
+            },
+            "type": "array"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/Violation"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "AcquisitionMethod": {
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "enum": ["OAUTH1", "OAUTH2"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AcquisitionRequest": {
+        "properties": {
+          "returnUrl": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Action": {
+        "discriminator": {
+          "propertyName": "actionType"
+        },
+        "properties": {
+          "actionType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "descriptor": {
+            "$ref": "#/components/schemas/ActionDescriptor"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "enum": ["From", "Pipe", "To", "PollEnrich"],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ActionDescriptor": {
+        "properties": {
+          "inputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "outputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "propertyDefinitionSteps": {
+            "items": {
+              "$ref": "#/components/schemas/ActionDescriptorStep"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ActionDescriptorStep": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ActionsSummary": {
+        "properties": {
+          "actionCountByTags": {
+            "additionalProperties": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "totalActions": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ConfigurationProperty": {
+        "properties": {
+          "componentProperty": {
+            "type": "boolean"
+          },
+          "connectorValue": {
+            "type": "string"
+          },
+          "controlHint": {
+            "type": "string"
+          },
+          "dataList": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultValue": {
+            "type": "string"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/PropertyValue"
+            },
+            "type": "array"
+          },
+          "extendedProperties": {
+            "type": "string"
+          },
+          "generator": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "javaType": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "labelHint": {
+            "type": "string"
+          },
+          "multiple": {
+            "type": "boolean"
+          },
+          "order": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "raw": {
+            "type": "boolean"
+          },
+          "relation": {
+            "items": {
+              "$ref": "#/components/schemas/PropertyRelation"
+            },
+            "type": "array"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "secret": {
+            "type": "boolean"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Connection": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connector": {
+            "$ref": "#/components/schemas/Connector"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "createdDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "options": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "userId": {
+            "type": "string"
+          },
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectionBulletinBoard": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "errors": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/LeveledMessage"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "notices": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "targetResourceId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "warnings": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectionOverview": {
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/ConnectionBulletinBoard"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connector": {
+            "$ref": "#/components/schemas/Connector"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "createdDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "options": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "userId": {
+            "type": "string"
+          },
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Connector": {
+        "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorAction"
+            },
+            "type": "array"
+          },
+          "actionsSummary": {
+            "$ref": "#/components/schemas/ActionsSummary"
+          },
+          "componentScheme": {
+            "type": "string"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorCustomizers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "connectorFactory": {
+            "type": "string"
+          },
+          "connectorGroup": {
+            "$ref": "#/components/schemas/ConnectorGroup"
+          },
+          "connectorGroupId": {
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "exceptionHandler": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "uses": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "readOnly": true,
+            "type": "object"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["actions", "name"],
+        "type": "object"
+      },
+      "ConnectorAction": {
+        "properties": {
+          "actionType": {
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "descriptor": {
+            "$ref": "#/components/schemas/ConnectorDescriptor"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "enum": ["From", "Pipe", "To", "PollEnrich"],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectorDescriptor": {
+        "properties": {
+          "camelConnectorGAV": {
+            "type": "string"
+          },
+          "camelConnectorPrefix": {
+            "type": "string"
+          },
+          "componentScheme": {
+            "type": "string"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorCustomizers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "connectorFactory": {
+            "type": "string"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "exceptionHandler": {
+            "type": "string"
+          },
+          "inputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "outputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "propertyDefinitionSteps": {
+            "items": {
+              "$ref": "#/components/schemas/ActionDescriptorStep"
+            },
+            "type": "array"
+          },
+          "standardizedErrors": {
+            "items": {
+              "$ref": "#/components/schemas/StandardizedError"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectorFormData": {
+        "properties": {
+          "connector": {
+            "$ref": "#/components/schemas/Connector"
+          },
+          "iconInputStream": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectorGroup": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectorSettings": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorTemplateId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectorTemplate": {
+        "properties": {
+          "componentScheme": {
+            "type": "string"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorGroup": {
+            "$ref": "#/components/schemas/ConnectorGroup"
+          },
+          "connectorProperties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ContinuousDeliveryEnvironment": {
+        "properties": {
+          "environmentId": {
+            "type": "string"
+          },
+          "lastExportedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastImportedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastTaggedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "releaseTag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CustomConnectorFormData": {
+        "properties": {
+          "connectorSettings": {
+            "$ref": "#/components/schemas/ConnectorSettings"
+          },
+          "iconInputStream": {
+            "type": "object"
+          },
+          "specification": {
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "DataShape": {
+        "properties": {
+          "collectionClassName": {
+            "type": "string"
+          },
+          "collectionType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "exemplar": {
+            "items": {
+              "format": "byte",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "kind": {
+            "enum": [
+              "any",
+              "java",
+              "json-schema",
+              "json-instance",
+              "xml-schema",
+              "xml-schema-inspected",
+              "xml-instance",
+              "none"
+            ],
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "specification": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "variants": {
+            "items": {
+              "$ref": "#/components/schemas/DataShape"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Dependency": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": ["MAVEN", "EXTENSION", "EXTENSION_TAG", "ICON"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DynamicConnectionPropertiesMetadata": {
+        "type": "object"
+      },
+      "Environment": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "EventMessage": {
+        "properties": {
+          "data": {
+            "type": "object"
+          },
+          "event": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Extension": {
+        "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/Action"
+            },
+            "type": "array"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "createdDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extensionId": {
+            "type": "string"
+          },
+          "extensionType": {
+            "enum": ["Steps", "Connectors", "Libraries"],
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "status": {
+            "enum": ["Draft", "Installed", "Deleted"],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "userId": {
+            "type": "string"
+          },
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": ["actions", "extensionType", "name", "schemaVersion"],
+        "type": "object"
+      },
+      "FilterOptions": {
+        "properties": {
+          "ops": {
+            "items": {
+              "$ref": "#/components/schemas/Op"
+            },
+            "type": "array"
+          },
+          "paths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Flow": {
+        "properties": {
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "scheduler": {
+            "$ref": "#/components/schemas/Scheduler"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "type": {
+            "enum": ["PRIMARY", "API_PROVIDER", "ALTERNATE"],
+            "type": "string"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ImmutableConnectorAction": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Action"
+          },
+          {
+            "properties": {
+              "dependencies": {
+                "items": {
+                  "$ref": "#/components/schemas/Dependency"
+                },
+                "type": "array"
+              },
+              "descriptor": {
+                "$ref": "#/components/schemas/ConnectorDescriptor"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": ["name"],
+        "type": "object"
+      },
+      "ImmutableStepAction": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Action"
+          },
+          {
+            "properties": {
+              "descriptor": {
+                "$ref": "#/components/schemas/StepDescriptor"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": ["name"],
+        "type": "object"
+      },
+      "InputPart": {
+        "properties": {
+          "bodyAsString": {
+            "type": "string"
+          },
+          "contentTypeFromMessage": {
+            "type": "boolean"
+          },
+          "headers": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "properties": {
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "mediaType": {
+            "properties": {
+              "parameters": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "subtype": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "wildcardSubtype": {
+                "type": "boolean"
+              },
+              "wildcardType": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "Integration": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
+          "continuousDeliveryState": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "exposure": {
+            "type": "string"
+          },
+          "flows": {
+            "items": {
+              "$ref": "#/components/schemas/Flow"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceIdentifier"
+            },
+            "type": "array"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "IntegrationBulletinBoard": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "errors": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/LeveledMessage"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "notices": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "targetResourceId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "warnings": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeployment": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/IntegrationDeploymentError"
+          },
+          "id": {
+            "type": "string"
+          },
+          "integrationId": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/Integration"
+          },
+          "statusMessage": {
+            "type": "string"
+          },
+          "stepsDone": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentMetrics": {
+        "properties": {
+          "errors": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "lastProcessed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "messages": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "start": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "uptimeDuration": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentOverview": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/IntegrationDeploymentError"
+          },
+          "id": {
+            "type": "string"
+          },
+          "statusMessage": {
+            "type": "string"
+          },
+          "stepsDone": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationMetricsSummary": {
+        "properties": {
+          "errors": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "integrationDeploymentMetrics": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDeploymentMetrics"
+            },
+            "type": "array"
+          },
+          "lastProcessed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "messages": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "metricsProvider": {
+            "type": "string"
+          },
+          "start": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "topIntegrations": {
+            "additionalProperties": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "uptimeDuration": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationOverview": {
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/IntegrationBulletinBoard"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
+          "continuousDeliveryState": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "deploymentVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "deployments": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDeploymentOverview"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "exposure": {
+            "type": "string"
+          },
+          "exposureMeans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "flows": {
+            "items": {
+              "$ref": "#/components/schemas/Flow"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "managementUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceIdentifier"
+            },
+            "type": "array"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "JsonNode": {
+        "properties": {
+          "array": {
+            "type": "boolean"
+          },
+          "bigDecimal": {
+            "type": "boolean"
+          },
+          "bigInteger": {
+            "type": "boolean"
+          },
+          "binary": {
+            "type": "boolean"
+          },
+          "boolean": {
+            "type": "boolean"
+          },
+          "containerNode": {
+            "type": "boolean"
+          },
+          "double": {
+            "type": "boolean"
+          },
+          "empty": {
+            "type": "boolean"
+          },
+          "float": {
+            "type": "boolean"
+          },
+          "floatingPointNumber": {
+            "type": "boolean"
+          },
+          "int": {
+            "type": "boolean"
+          },
+          "integralNumber": {
+            "type": "boolean"
+          },
+          "long": {
+            "type": "boolean"
+          },
+          "missingNode": {
+            "type": "boolean"
+          },
+          "nodeType": {
+            "enum": [
+              "ARRAY",
+              "BINARY",
+              "BOOLEAN",
+              "MISSING",
+              "NULL",
+              "NUMBER",
+              "OBJECT",
+              "POJO",
+              "STRING"
+            ],
+            "type": "string"
+          },
+          "null": {
+            "type": "boolean"
+          },
+          "number": {
+            "type": "boolean"
+          },
+          "object": {
+            "type": "boolean"
+          },
+          "pojo": {
+            "type": "boolean"
+          },
+          "short": {
+            "type": "boolean"
+          },
+          "textual": {
+            "type": "boolean"
+          },
+          "valueNode": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "LeveledMessage": {
+        "properties": {
+          "code": {
+            "enum": [
+              "SYNDESIS000",
+              "SYNDESIS001",
+              "SYNDESIS002",
+              "SYNDESIS003",
+              "SYNDESIS004",
+              "SYNDESIS005",
+              "SYNDESIS006",
+              "SYNDESIS007",
+              "SYNDESIS008",
+              "SYNDESIS009",
+              "SYNDESIS010",
+              "SYNDESIS011",
+              "SYNDESIS012"
+            ],
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "level": {
+            "enum": ["INFO", "WARN", "ERROR"],
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultConnectionOverview": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectionOverview"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultConnector": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Connector"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultConnectorAction": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorAction"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultConnectorGroup": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorGroup"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultConnectorTemplate": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorTemplate"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultExtension": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultIntegrationDeployment": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDeployment"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultIntegrationOverview": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationOverview"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultOAuthApp": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OAuthApp"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultOrganization": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Organization"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultPermission": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultRole": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Role"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultString": {
+        "properties": {
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultUser": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/User"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ModelDataObject": {
+        "properties": {
+          "condition": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "action",
+              "connection",
+              "connection-overview",
+              "connector",
+              "connector-action",
+              "connector-group",
+              "connector-template",
+              "icon",
+              "environment",
+              "environment-type",
+              "extension",
+              "step-action",
+              "organization",
+              "integration",
+              "integration-overview",
+              "integration-deployment",
+              "integration-deployment-state-details",
+              "integration-metrics-summary",
+              "integration-runtime",
+              "integration-endpoint",
+              "step",
+              "permission",
+              "role",
+              "user",
+              "connection-bulletin-board",
+              "integration-bulletin-board",
+              "open-api"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MultipartFormDataInput": {
+        "properties": {
+          "formDataMap": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/InputPart"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
+          "parts": {
+            "items": {
+              "$ref": "#/components/schemas/InputPart"
+            },
+            "type": "array"
+          },
+          "preamble": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "OAuthApp": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Op": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Organization": {
+        "properties": {
+          "environments": {
+            "items": {
+              "$ref": "#/components/schemas/Environment"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Permission": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "PropertyRelation": {
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "when": {
+            "items": {
+              "$ref": "#/components/schemas/When"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "PropertyValue": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Quota": {
+        "properties": {
+          "maxDeploymentsPerUser": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "maxIntegrationsPerUser": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "usedDeploymentsPerUser": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "usedIntegrationsPerUser": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ResourceIdentifier": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "action",
+              "connection",
+              "connection-overview",
+              "connector",
+              "connector-action",
+              "connector-group",
+              "connector-template",
+              "icon",
+              "environment",
+              "environment-type",
+              "extension",
+              "step-action",
+              "organization",
+              "integration",
+              "integration-overview",
+              "integration-deployment",
+              "integration-deployment-state-details",
+              "integration-metrics-summary",
+              "integration-runtime",
+              "integration-endpoint",
+              "step",
+              "permission",
+              "role",
+              "user",
+              "connection-bulletin-board",
+              "integration-bulletin-board",
+              "open-api"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "Result": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/VerifierError"
+            },
+            "type": "array"
+          },
+          "scope": {
+            "enum": ["PARAMETERS", "CONNECTIVITY"],
+            "type": "string"
+          },
+          "status": {
+            "enum": ["OK", "ERROR", "UNSUPPORTED"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Role": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "permissions": {
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Scheduler": {
+        "properties": {
+          "expression": {
+            "type": "string"
+          },
+          "type": {
+            "enum": ["timer", "cron"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StandardizedError": {
+        "type": "object"
+      },
+      "Step": {
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/Action"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/Connection"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "extension": {
+            "$ref": "#/components/schemas/Extension"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "stepKind": {
+            "enum": [
+              "endpoint",
+              "connector",
+              "expressionFilter",
+              "ruleFilter",
+              "extension",
+              "mapper",
+              "choice",
+              "split",
+              "aggregate",
+              "log",
+              "headers",
+              "template"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StepDescriptor": {
+        "properties": {
+          "entrypoint": {
+            "type": "string"
+          },
+          "inputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "kind": {
+            "enum": ["STEP", "BEAN", "ENDPOINT"],
+            "type": "string"
+          },
+          "outputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "propertyDefinitionSteps": {
+            "items": {
+              "$ref": "#/components/schemas/ActionDescriptorStep"
+            },
+            "type": "array"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TargetStateRequest": {
+        "properties": {
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "integrations": {
+            "items": {
+              "$ref": "#/components/schemas/Integration"
+            },
+            "type": "array"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "roleId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "VerifierError": {
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "code": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "parameters": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Violation": {
+        "type": "object"
+      },
+      "When": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WithResourceId": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
   "info": {
-    "title": "Syndesis Internal API",
-    "description": "The Syndesis REST API connects to back-end services on the\nSyndesis and provides a single entry point for the Syndesis UI.\n",
     "contact": {
-      "url": "https://syndesis.io/",
-      "email": "syndesis@googlegroups.com"
+      "email": "syndesis@googlegroups.com",
+      "url": "https://syndesis.io/"
     },
+    "description": "The Syndesis REST API connects to back-end services on the\nSyndesis and provides a single entry point for the Syndesis UI.\n",
     "license": {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
+    "title": "Syndesis Internal API",
     "version": "v1-2.0-SNAPSHOT"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Development server"
-    }
-  ],
+  "openapi": "3.0.1",
   "paths": {
-    "/connections/{id}/bulletins": {
+    "/connections": {
       "get": {
-        "tags": ["connections"],
-        "operationId": "getBulletins",
+        "operationId": "list",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
             "schema": {
               "type": "string"
             }
@@ -36,58 +2472,20 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConnectionBulletinBoard"
+                  "$ref": "#/components/schemas/ListResultConnectionOverview"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
-      }
-    },
-    "/connections/{id}": {
-      "get": {
-        "tags": ["connections"],
-        "operationId": "get_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConnectionOverview"
-                }
-              }
-            }
-          }
-        }
+        },
+        "tags": ["connections"]
       },
-      "put": {
-        "tags": ["connections"],
-        "operationId": "update",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+      "post": {
+        "operationId": "create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -100,20 +2498,60 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "*/*": {}
-            }
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            },
+            "description": "default response"
           }
-        }
-      },
+        },
+        "tags": ["connections"]
+      }
+    },
+    "/connections/validation": {
+      "post": {
+        "operationId": "validate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Connection"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "All validations pass"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["connections"]
+      }
+    },
+    "/connections/{id}": {
       "delete": {
-        "tags": ["connections"],
         "operationId": "delete",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -122,20 +2560,46 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connections"]
+      },
+      "get": {
+        "operationId": "get_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionOverview"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connections"]
       },
       "patch": {
-        "tags": ["connections"],
         "operationId": "patch",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -154,81 +2618,26 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
+            },
+            "description": "default response"
           }
-        }
-      }
-    },
-    "/connections": {
-      "get": {
-        "tags": ["connections"],
-        "operationId": "list",
+        },
+        "tags": ["connections"]
+      },
+      "put": {
+        "operationId": "update",
         "parameters": [
           {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
+            "in": "path",
+            "name": "id",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
         ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultConnectionOverview"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["connections"],
-        "operationId": "create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -241,149 +2650,74 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Connection"
-                }
-              }
-            }
+              "*/*": {}
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["connections"]
       }
     },
     "/connections/{id}/actions/{actionId}": {
       "post": {
-        "tags": ["actions", "connections"],
         "description": "Retrieves enriched action definition, that is an action definition that has input/output data shapes and property enums defined with respect to the given action properties",
         "operationId": "enrichWithMetadata",
         "parameters": [
           {
-            "name": "actionId",
+            "example": "io.syndesis:salesforce-create-or-update:latest",
             "in": "path",
+            "name": "actionId",
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "example": "io.syndesis:salesforce-create-or-update:latest"
+            }
           },
           {
-            "name": "id",
+            "example": "my-connection",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "example": "my-connection"
+            }
           }
         ],
         "requestBody": {
           "content": {
             "*/*": {
               "schema": {
-                "type": "object",
                 "additionalProperties": {
                   "type": "object"
-                }
+                },
+                "type": "object"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "A map of zero or more action property suggestions keyed by the property name",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ConnectorDescriptor"
                 }
               }
-            }
+            },
+            "description": "A map of zero or more action property suggestions keyed by the property name"
           }
-        }
-      }
-    },
-    "/connections/validation": {
-      "post": {
-        "tags": ["connections"],
-        "operationId": "validate",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Connection"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "204": {
-            "description": "All validations pass"
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
+        "tags": ["actions", "connections"]
       }
     },
-    "/connectorgroups": {
+    "/connections/{id}/bulletins": {
       "get": {
-        "tags": ["connectorgroups"],
-        "operationId": "list_1",
+        "operationId": "getBulletins",
         "parameters": [
           {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
+            "in": "path",
+            "name": "id",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -391,26 +2725,184 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionBulletinBoard"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connections"]
+      }
+    },
+    "/connector-templates": {
+      "get": {
+        "operationId": "list_4",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultConnectorTemplate"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connector-template"]
+      }
+    },
+    "/connector-templates/{id}": {
+      "get": {
+        "operationId": "get_7",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorTemplate"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connector-template"]
+      }
+    },
+    "/connectorgroups": {
+      "get": {
+        "operationId": "list_1",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResultConnectorGroup"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["connectorgroups"]
       }
     },
     "/connectorgroups/{id}": {
       "get": {
-        "tags": ["connectorgroups"],
         "operationId": "get",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -419,26 +2911,185 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ConnectorGroup"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["connectorgroups"]
       }
     },
-    "/connectors/{id}/icon": {
+    "/connectors": {
       "get": {
-        "tags": ["connector", "connector-icon", "connectors"],
-        "operationId": "get_2",
+        "operationId": "list_2",
         "parameters": [
           {
-            "name": "id",
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultConnector"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      }
+    },
+    "/connectors/custom": {
+      "post": {
+        "description": "Creates a new Connector based on the ConnectorTemplate identified by the provided `id` and the data given in `connectorSettings` multipart part, plus optional `icon` file",
+        "operationId": "create_4",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomConnectorFormData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Newly created Connector"
+          }
+        },
+        "tags": ["custom-connector", "connector-template", "connectors"]
+      }
+    },
+    "/connectors/custom/info": {
+      "post": {
+        "description": "Provides a summary of the connector as it would be built using a ConnectorTemplate identified by the provided `connector-template-id` and the data given in `connectorSettings`",
+        "operationId": "info_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectorSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APISummary"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["custom-connector", "connector-template", "connectors"]
+      }
+    },
+    "/connectors/{connectorId}/actions": {
+      "get": {
+        "operationId": "list_3",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "in": "path",
+            "name": "connectorId",
             "required": true,
             "schema": {
               "type": "string"
@@ -447,21 +3098,295 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "*/*": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultConnectorAction"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["actions", "connectors"]
+      }
+    },
+    "/connectors/{connectorId}/actions/{id}": {
+      "get": {
+        "operationId": "get_6",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "connectorId",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorAction"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["actions", "connectors"]
+      }
+    },
+    "/connectors/{id}": {
+      "delete": {
+        "operationId": "delete_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      },
+      "get": {
+        "operationId": "get_5",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connector"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      },
+      "patch": {
+        "operationId": "patch_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonNode"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      },
+      "put": {
+        "operationId": "update_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Connector"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      }
+    },
+    "/connectors/{id}/actions/{actionId}/filters/options": {
+      "get": {
+        "operationId": "getFilterOptions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "actionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterOptions"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      }
+    },
+    "/connectors/{id}/credentials": {
+      "get": {
+        "operationId": "get_3",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionMethod"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["credentials", "connectors"]
       },
       "post": {
-        "tags": ["connector", "connector-icon", "connectors"],
+        "operationId": "create_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["credentials", "connectors"]
+      }
+    },
+    "/connectors/{id}/icon": {
+      "get": {
+        "operationId": "get_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connector", "connector-icon", "connectors"]
+      },
+      "post": {
         "description": "Updates the connector icon for the specified connector and returns the updated connector",
         "operationId": "create_1",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -481,77 +3406,17 @@
           "200": {
             "description": "Updated Connector icon"
           }
-        }
-      }
-    },
-    "/connectors/{id}/credentials": {
-      "get": {
-        "tags": ["credentials", "connectors"],
-        "operationId": "get_3",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcquisitionMethod"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["credentials", "connectors"],
-        "operationId": "create_2",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AcquisitionRequest"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {}
-            }
-          }
-        }
+        "tags": ["connector", "connector-icon", "connectors"]
       }
     },
     "/connectors/{id}/properties": {
       "post": {
-        "tags": ["properties", "connectors"],
         "operationId": "dynamicConnectionProperties",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -560,350 +3425,26 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DynamicConnectionPropertiesMetadata"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
-      }
-    },
-    "/connectors/{id}": {
-      "get": {
-        "tags": ["connectors"],
-        "operationId": "get_5",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Connector"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["connectors"],
-        "operationId": "update_2",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Connector"
-              }
-            }
-          },
-          "required": true
         },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["connectors"],
-        "operationId": "delete_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": ["connectors"],
-        "operationId": "patch_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/JsonNode"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/connectors": {
-      "get": {
-        "tags": ["connectors"],
-        "operationId": "list_2",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultConnector"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/connectors/{connectorId}/actions/{id}": {
-      "get": {
-        "tags": ["actions", "connectors"],
-        "operationId": "get_6",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectorId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConnectorAction"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/connectors/{connectorId}/actions": {
-      "get": {
-        "tags": ["actions", "connectors"],
-        "operationId": "list_3",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectorId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultConnectorAction"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/connectors/{id}/actions/{actionId}/filters/options": {
-      "get": {
-        "tags": ["connectors"],
-        "operationId": "getFilterOptions",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "actionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilterOptions"
-                }
-              }
-            }
-          }
-        }
+        "tags": ["properties", "connectors"]
       }
     },
     "/connectors/{id}/verifier": {
       "post": {
-        "tags": ["connectors"],
         "operationId": "verifyConnectionParameters",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -914,183 +3455,64 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
                 "additionalProperties": {
                   "type": "string"
-                }
+                },
+                "type": "object"
               }
             }
           }
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Result"
-                  }
+                  },
+                  "type": "array"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "/connectors/custom/info": {
-      "post": {
-        "tags": ["custom-connector", "connector-template", "connectors"],
-        "description": "Provides a summary of the connector as it would be built using a ConnectorTemplate identified by the provided `connector-template-id` and the data given in `connectorSettings`",
-        "operationId": "info_1",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ConnectorSettings"
-              }
-            }
+            },
+            "description": "default response"
           }
         },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APISummary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/connectors/custom": {
-      "post": {
-        "tags": ["custom-connector", "connector-template", "connectors"],
-        "description": "Creates a new Connector based on the ConnectorTemplate identified by the provided `id` and the data given in `connectorSettings` multipart part, plus optional `icon` file",
-        "operationId": "create_4",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/CustomConnectorFormData"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Newly created Connector"
-          }
-        }
-      }
-    },
-    "/connector-templates/{id}": {
-      "get": {
-        "tags": ["connector-template"],
-        "operationId": "get_7",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConnectorTemplate"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/connector-templates": {
-      "get": {
-        "tags": ["connector-template"],
-        "operationId": "list_4",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultConnectorTemplate"
-                }
-              }
-            }
-          }
-        }
+        "tags": ["connectors"]
       }
     },
     "/credentials/callback": {
       "get": {
-        "tags": ["credentials"],
         "operationId": "callback",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["credentials"]
+      }
+    },
+    "/environments": {
+      "get": {
+        "operationId": "getReleaseEnvironments",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "withUses",
+            "schema": {
+              "type": "boolean"
             }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "default response"
           }
         }
       }
@@ -1100,8 +3522,8 @@
         "operationId": "getReleaseTags",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1110,58 +3532,17 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
                   "additionalProperties": {
                     "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
+                  },
+                  "type": "object"
                 }
               }
-            }
-          }
-        }
-      },
-      "put": {
-        "operationId": "putTagsForRelease",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
-                }
-              }
-            }
+            },
+            "description": "default response"
           }
         }
       },
@@ -1169,8 +3550,8 @@
         "operationId": "patchTagsForRelease",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1181,10 +3562,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "type": "array"
               }
             }
           },
@@ -1192,50 +3573,142 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
                   "additionalProperties": {
                     "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
+                  },
+                  "type": "object"
                 }
               }
+            },
+            "description": "default response"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putTagsForRelease",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
           }
         }
       }
     },
-    "/environments": {
-      "get": {
-        "operationId": "getReleaseEnvironments",
+    "/environments/integrations/{id}/{env}": {
+      "delete": {
+        "operationId": "deleteReleaseTag",
         "parameters": [
           {
-            "name": "withUses",
-            "in": "query",
+            "in": "path",
+            "name": "id",
+            "required": true,
             "schema": {
-              "type": "boolean"
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "application/json": {}
-            }
+              "*/*": {}
+            },
+            "description": "default response"
           }
         }
       }
     },
     "/environments/{env}": {
+      "delete": {
+        "operationId": "deleteEnvironment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        }
+      },
+      "post": {
+        "operationId": "addNewEnvironment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        }
+      },
       "put": {
         "operationId": "renameEnvironment",
         "parameters": [
           {
-            "name": "env",
             "in": "path",
+            "name": "env",
             "required": true,
             "schema": {
               "type": "string"
@@ -1254,249 +3727,84 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "addNewEnvironment",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "deleteEnvironment",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/environments/integrations/{id}/{env}": {
-      "delete": {
-        "operationId": "deleteReleaseTag",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/organizations": {
-      "get": {
-        "operationId": "list_5",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultOrganization"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/organizations/{id}": {
-      "get": {
-        "operationId": "get_4",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Organization"
-                }
-              }
-            }
+            },
+            "description": "default response"
           }
         }
       }
     },
     "/event/reservations": {
       "post": {
-        "tags": ["events"],
         "operationId": "reserveEventStream",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/EventMessage"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["events"]
       }
     },
     "/extensions": {
       "get": {
-        "tags": ["extensions"],
         "operationId": "list_6",
         "parameters": [
           {
-            "name": "sort",
-            "in": "query",
             "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "direction",
-            "in": "query",
             "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
             "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": ["asc", "desc"],
+              "type": "string"
             }
           },
           {
-            "name": "page",
-            "in": "query",
             "description": "Page number to return",
+            "in": "query",
+            "name": "page",
             "schema": {
-              "type": "integer",
+              "default": 1,
               "format": "int64",
-              "default": 1
+              "type": "integer"
             }
           },
           {
-            "name": "per_page",
-            "in": "query",
             "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
             "schema": {
-              "type": "integer",
+              "default": 20,
               "format": "int64",
-              "default": 20
+              "type": "integer"
             }
           },
           {
-            "name": "query",
-            "in": "query",
             "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "extensionType",
             "in": "query",
+            "name": "extensionType",
             "schema": {
               "type": "string"
             }
@@ -1504,24 +3812,24 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResultExtension"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["extensions"]
       },
       "post": {
-        "tags": ["extensions"],
         "operationId": "upload",
         "parameters": [
           {
-            "name": "updatedId",
             "in": "query",
+            "name": "updatedId",
             "schema": {
               "type": "string"
             }
@@ -1538,115 +3846,21 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Extension"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
-      }
-    },
-    "/extensions/{id}": {
-      "get": {
-        "tags": ["extensions"],
-        "operationId": "get_8",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Extension"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["extensions"],
-        "operationId": "delete_2",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}/validation": {
-      "post": {
-        "tags": ["extensions"],
-        "operationId": "validate_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "All blocking validations pass",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
+        },
+        "tags": ["extensions"]
       }
     },
     "/extensions/validation": {
       "post": {
-        "tags": ["extensions"],
         "operationId": "validate_2",
         "requestBody": {
           "content": {
@@ -1660,42 +3874,92 @@
         },
         "responses": {
           "200": {
-            "description": "All blocking validations pass",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Violation"
-                  }
+                  },
+                  "type": "array"
                 }
               }
-            }
+            },
+            "description": "All blocking validations pass"
           },
           "400": {
-            "description": "Found violations in validation",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Violation"
-                  }
+                  },
+                  "type": "array"
                 }
               }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}": {
+      "delete": {
+        "operationId": "delete_2",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      },
+      "get": {
+        "operationId": "get_8",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Extension"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
       }
     },
     "/extensions/{id}/install": {
       "post": {
-        "tags": ["extensions"],
         "operationId": "install",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1704,42 +3968,42 @@
         ],
         "responses": {
           "200": {
-            "description": "Installed",
             "content": {
               "*/*": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Violation"
-                  }
+                  },
+                  "type": "array"
                 }
               }
-            }
+            },
+            "description": "Installed"
           },
           "400": {
-            "description": "Found violations in validation",
             "content": {
               "*/*": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/Violation"
-                  }
+                  },
+                  "type": "array"
                 }
               }
-            }
+            },
+            "description": "Found violations in validation"
           }
-        }
+        },
+        "tags": ["extensions"]
       }
     },
     "/extensions/{id}/integrations": {
       "get": {
-        "tags": ["extensions"],
         "operationId": "integrations",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1748,30 +4012,30 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {
                 "schema": {
-                  "uniqueItems": true,
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/ResourceIdentifier"
-                  }
+                  },
+                  "type": "array",
+                  "uniqueItems": true
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["extensions"]
       }
     },
     "/extensions/{id}/stepIcon": {
       "get": {
-        "tags": ["extensions"],
         "operationId": "getStepIcon",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1780,157 +4044,213 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["extensions"]
       }
     },
-    "/integrations/{id}/deployments/{version}": {
-      "get": {
-        "tags": ["integration-deployments"],
-        "operationId": "get_9",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "version",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationDeployment"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integrations/{id}/deployments": {
-      "get": {
-        "tags": ["integration-deployments"],
-        "operationId": "list_7",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultIntegrationDeployment"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["integration-deployments"],
-        "operationId": "update_1",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationDeployment"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integrations/{id}/deployments/{version}/targetState": {
+    "/extensions/{id}/validation": {
       "post": {
-        "tags": ["integration-deployments"],
-        "operationId": "updateTargetState",
+        "operationId": "validate_1",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "All blocking validations pass"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/integration-support/export.zip": {
+      "get": {
+        "operationId": "export",
+        "parameters": [
           {
-            "name": "version",
-            "in": "path",
+            "in": "query",
+            "name": "id",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           }
         ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/octet-stream": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integration-support/generate/pom.xml": {
+      "post": {
+        "operationId": "projectPom",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Integration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "byte",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integration-support/import": {
+      "post": {
+        "operationId": "importIntegration",
         "requestBody": {
           "content": {
             "*/*": {
               "schema": {
-                "$ref": "#/components/schemas/TargetStateRequest"
+                "type": "object"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "application/json": {}
-            }
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/WithResourceId"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["integration-support"]
       }
     },
-    "/integrations/{id}": {
+    "/integration-support/overviews": {
       "get": {
-        "tags": ["integrations"],
-        "operationId": "get_11",
+        "operationId": "getOverviews",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integrations": {
+      "get": {
+        "operationId": "list_8",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
-            "required": true,
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
             "schema": {
               "type": "string"
             }
@@ -1938,30 +4258,20 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntegrationOverview"
+                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["integrations"]
       },
-      "put": {
-        "tags": ["integrations"],
-        "operationId": "update_3",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+      "post": {
+        "operationId": "create_3",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1974,20 +4284,103 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "*/*": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integrations"]
+      }
+    },
+    "/integrations/filters/options": {
+      "get": {
+        "operationId": "getGlobalFilterOptions",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterOptions"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integrations"]
+      },
+      "post": {
+        "operationId": "getFilterOptions_1",
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/DataShape"
+              }
             }
           }
-        }
-      },
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterOptions"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integrations"]
+      }
+    },
+    "/integrations/validation": {
+      "post": {
+        "operationId": "validate_3",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Integration"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "All validations pass"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["integrations"]
+      }
+    },
+    "/integrations/{id}": {
       "delete": {
-        "tags": ["integrations"],
         "operationId": "delete_3",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -1996,20 +4389,46 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integrations"]
+      },
+      "get": {
+        "operationId": "get_11",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationOverview"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integrations"]
       },
       "patch": {
-        "tags": ["integrations"],
         "operationId": "patch_2",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -2028,81 +4447,26 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
+            },
+            "description": "default response"
           }
-        }
-      }
-    },
-    "/integrations": {
-      "get": {
-        "tags": ["integrations"],
-        "operationId": "list_8",
+        },
+        "tags": ["integrations"]
+      },
+      "put": {
+        "operationId": "update_3",
         "parameters": [
           {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
+            "in": "path",
+            "name": "id",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
         ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["integrations"],
-        "operationId": "create_3",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2115,26 +4479,22 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Integration"
-                }
-              }
-            }
+              "*/*": {}
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["integrations"]
       }
     },
-    "/integrations/{id}/overview": {
+    "/integrations/{id}/deployments": {
       "get": {
-        "tags": ["integrations"],
-        "operationId": "getOverview",
+        "operationId": "list_7",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -2143,119 +4503,170 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultIntegrationDeployment"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-deployments"]
+      },
+      "put": {
+        "operationId": "update_1",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDeployment"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-deployments"]
+      }
+    },
+    "/integrations/{id}/deployments/{version}": {
+      "get": {
+        "operationId": "get_9",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDeployment"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-deployments"]
+      }
+    },
+    "/integrations/{id}/deployments/{version}/targetState": {
+      "post": {
+        "operationId": "updateTargetState",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "$ref": "#/components/schemas/TargetStateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-deployments"]
+      }
+    },
+    "/integrations/{id}/overview": {
+      "get": {
+        "operationId": "getOverview",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IntegrationOverview"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "/integrations/filters/options": {
-      "get": {
-        "tags": ["integrations"],
-        "operationId": "getGlobalFilterOptions",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilterOptions"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["integrations"],
-        "operationId": "getFilterOptions_1",
-        "requestBody": {
-          "content": {
-            "*/*": {
-              "schema": {
-                "$ref": "#/components/schemas/DataShape"
-              }
-            }
+            },
+            "description": "default response"
           }
         },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilterOptions"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integrations/validation": {
-      "post": {
-        "tags": ["integrations"],
-        "operationId": "validate_3",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Integration"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "All validations pass"
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
+        "tags": ["integrations"]
       }
     },
     "/integrations/{id}/specification": {
       "get": {
-        "tags": ["integrations"],
         "description": "Responds with specification that defines this integration",
         "operationId": "fetch",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "The ID of the integration",
+            "example": "integration-id",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "example": "integration-id"
+            }
           }
         ],
         "responses": {
-          "404": {
-            "description": "No specification resource defines this integration"
-          },
-          "204": {
-            "description": "Empty specification provided when definining this integration"
-          },
           "200": {
             "description": "Specification resource follows",
             "headers": {
@@ -2268,181 +4679,78 @@
                 "style": "simple"
               }
             }
+          },
+          "204": {
+            "description": "Empty specification provided when definining this integration"
+          },
+          "404": {
+            "description": "No specification resource defines this integration"
           }
-        }
+        },
+        "tags": ["integrations"]
       },
       "put": {
-        "tags": ["integrations"],
         "description": "For an integration that is generated from a specification updates it so it conforms to the updated specification",
         "operationId": "update_4",
         "parameters": [
           {
-            "name": "id",
-            "in": "path",
             "description": "The ID of the integration",
+            "example": "integration-id",
+            "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
-            },
-            "example": "integration-id"
+            }
           }
         ],
         "requestBody": {
-          "description": "Next revision of the specification",
           "content": {
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/APIFormData"
               }
             }
-          }
+          },
+          "description": "Next revision of the specification"
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/export.zip": {
-      "get": {
-        "tags": ["integration-support"],
-        "operationId": "export",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/octet-stream": {}
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/overviews": {
-      "get": {
-        "tags": ["integration-support"],
-        "operationId": "getOverviews",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/generate/pom.xml": {
-      "post": {
-        "tags": ["integration-support"],
-        "operationId": "projectPom",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Integration"
-              }
-            }
+            },
+            "description": "default response"
           }
         },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "byte"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/import": {
-      "post": {
-        "tags": ["integration-support"],
-        "operationId": "importIntegration",
-        "requestBody": {
-          "content": {
-            "*/*": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/WithResourceId"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        "tags": ["integrations"]
       }
     },
     "/metrics/integrations": {
       "get": {
-        "tags": ["integration-metrics"],
         "description": "Retrieves a rolled up metrics summary for all integrations over their lifetime",
         "operationId": "get_10",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IntegrationMetricsSummary"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["integration-metrics"]
       }
     },
     "/metrics/integrations/{integrationId}": {
       "get": {
-        "tags": ["integration-metrics"],
         "operationId": "get_12",
         "parameters": [
           {
-            "name": "integrationId",
             "in": "path",
+            "name": "integrationId",
             "required": true,
             "schema": {
               "type": "string"
@@ -2451,29 +4759,212 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IntegrationMetricsSummary"
                 }
               }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-metrics"]
+      }
+    },
+    "/organizations": {
+      "get": {
+        "operationId": "list_5",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
             }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultOrganization"
+                }
+              }
+            },
+            "description": "default response"
           }
         }
       }
     },
+    "/organizations/{id}": {
+      "get": {
+        "operationId": "get_4",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        }
+      }
+    },
+    "/permissions": {
+      "get": {
+        "operationId": "list_10",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultPermission"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["permissions"]
+      }
+    },
+    "/permissions/{id}": {
+      "get": {
+        "operationId": "get_15",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Permission"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["permissions"]
+      }
+    },
     "/resources/{kind}/{id}": {
       "get": {
-        "tags": ["resources"],
         "operationId": "get_13",
         "parameters": [
           {
-            "name": "kind",
             "in": "path",
+            "name": "kind",
             "required": true,
             "schema": {
-              "type": "string",
               "enum": [
                 "action",
                 "connection",
@@ -2502,12 +4993,13 @@
                 "connection-bulletin-board",
                 "integration-bulletin-board",
                 "open-api"
-              ]
+              ],
+              "type": "string"
             }
           },
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -2516,22 +5008,180 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["resources"]
+      }
+    },
+    "/roles": {
+      "get": {
+        "operationId": "list_11",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultRole"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["roles"]
+      }
+    },
+    "/roles/{id}": {
+      "get": {
+        "operationId": "get_16",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Role"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["roles"]
+      }
+    },
+    "/setup/oauth-apps": {
+      "get": {
+        "operationId": "list_9",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultOAuthApp"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["oauth-apps"]
       }
     },
     "/setup/oauth-apps/{id}": {
-      "get": {
-        "tags": ["oauth-apps"],
-        "operationId": "get_14",
+      "delete": {
+        "operationId": "delete_4",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -2540,24 +5190,46 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["oauth-apps"]
+      },
+      "get": {
+        "operationId": "get_14",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OAuthApp"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["oauth-apps"]
       },
       "put": {
-        "tags": ["oauth-apps"],
         "operationId": "update_5",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -2576,115 +5248,42 @@
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
+            },
+            "description": "default response"
           }
-        }
-      },
-      "delete": {
-        "tags": ["oauth-apps"],
-        "operationId": "delete_4",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/setup/oauth-apps": {
-      "get": {
-        "tags": ["oauth-apps"],
-        "operationId": "list_9",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultOAuthApp"
-                }
-              }
-            }
-          }
-        }
+        },
+        "tags": ["oauth-apps"]
       }
     },
     "/tags": {
       "get": {
-        "tags": ["tags"],
         "operationId": "listTags",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResultString"
                 }
               }
-            }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["tags"]
+      }
+    },
+    "/test-support/delete-deployments": {
+      "get": {
+        "operationId": "deleteDeployments",
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
           }
         }
       }
@@ -2694,10 +5293,10 @@
         "operationId": "resetDBToDefault",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
+            },
+            "description": "default response"
           }
         }
       }
@@ -2709,33 +5308,20 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/ModelDataObject"
-                }
+                },
+                "type": "array"
               }
             }
           }
         },
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/test-support/delete-deployments": {
-      "get": {
-        "operationId": "deleteDeployments",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
+            },
+            "description": "default response"
           }
         }
       }
@@ -2745,289 +5331,66 @@
         "operationId": "snapshotDB",
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/ModelDataObject"
-                  }
+                  },
+                  "type": "array"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "/permissions": {
-      "get": {
-        "tags": ["permissions"],
-        "operationId": "list_10",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultPermission"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/permissions/{id}": {
-      "get": {
-        "tags": ["permissions"],
-        "operationId": "get_15",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Permission"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/roles": {
-      "get": {
-        "tags": ["roles"],
-        "operationId": "list_11",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultRole"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/roles/{id}": {
-      "get": {
-        "tags": ["roles"],
-        "operationId": "get_16",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Role"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/users/~": {
-      "get": {
-        "tags": ["users"],
-        "operationId": "whoAmI",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/users/~/quota": {
-      "get": {
-        "tags": ["users"],
-        "operationId": "quota",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Quota"
-                }
-              }
-            }
+            },
+            "description": "default response"
           }
         }
       }
     },
     "/users": {
       "get": {
-        "tags": ["users"],
         "operationId": "list_12",
         "parameters": [
           {
-            "name": "sort",
-            "in": "query",
             "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "direction",
-            "in": "query",
             "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
             "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": ["asc", "desc"],
+              "type": "string"
             }
           },
           {
-            "name": "page",
-            "in": "query",
             "description": "Page number to return",
+            "in": "query",
+            "name": "page",
             "schema": {
-              "type": "integer",
+              "default": 1,
               "format": "int64",
-              "default": 1
+              "type": "integer"
             }
           },
           {
-            "name": "per_page",
-            "in": "query",
             "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
             "schema": {
-              "type": "integer",
+              "default": 20,
               "format": "int64",
-              "default": 20
+              "type": "integer"
             }
           },
           {
-            "name": "query",
-            "in": "query",
             "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
             "schema": {
               "type": "string"
             }
@@ -3035,26 +5398,26 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListResultUser"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["users"]
       }
     },
     "/users/{id}": {
       "get": {
-        "tags": ["users"],
         "operationId": "get_17",
         "parameters": [
           {
-            "name": "id",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
@@ -3063,2423 +5426,60 @@
         ],
         "responses": {
           "default": {
-            "description": "default response",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/User"
                 }
               }
-            }
+            },
+            "description": "default response"
           }
-        }
+        },
+        "tags": ["users"]
+      }
+    },
+    "/users/~": {
+      "get": {
+        "operationId": "whoAmI",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["users"]
+      }
+    },
+    "/users/~/quota": {
+      "get": {
+        "operationId": "quota",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Quota"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["users"]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "ConnectionBulletinBoard": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "errors": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "warnings": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "notices": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "targetResourceId": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LeveledMessage"
-            }
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "LeveledMessage": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "level": {
-            "type": "string",
-            "enum": ["INFO", "WARN", "ERROR"]
-          },
-          "detail": {
-            "type": "string"
-          },
-          "code": {
-            "type": "string",
-            "enum": [
-              "SYNDESIS000",
-              "SYNDESIS001",
-              "SYNDESIS002",
-              "SYNDESIS003",
-              "SYNDESIS004",
-              "SYNDESIS005",
-              "SYNDESIS006",
-              "SYNDESIS007",
-              "SYNDESIS008",
-              "SYNDESIS009",
-              "SYNDESIS010",
-              "SYNDESIS011",
-              "SYNDESIS012"
-            ]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "Action": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "descriptor": {
-            "$ref": "#/components/schemas/ActionDescriptor"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "actionType": {
-            "type": "string"
-          },
-          "pattern": {
-            "type": "string",
-            "enum": ["From", "Pipe", "To", "PollEnrich"]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        },
-        "discriminator": {
-          "propertyName": "actionType"
-        }
-      },
-      "ActionDescriptor": {
-        "type": "object",
-        "properties": {
-          "inputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "outputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "propertyDefinitionSteps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
-          }
-        }
-      },
-      "ActionDescriptorStep": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ActionsSummary": {
-        "type": "object",
-        "properties": {
-          "actionCountByTags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "totalActions": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "ConfigurationProperty": {
-        "type": "object",
-        "properties": {
-          "generator": {
-            "type": "string"
-          },
-          "secret": {
-            "type": "boolean"
-          },
-          "raw": {
-            "type": "boolean"
-          },
-          "type": {
-            "type": "string"
-          },
-          "defaultValue": {
-            "type": "string"
-          },
-          "displayName": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "deprecated": {
-            "type": "boolean"
-          },
-          "group": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "enum": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PropertyValue"
-            }
-          },
-          "javaType": {
-            "type": "string"
-          },
-          "required": {
-            "type": "boolean"
-          },
-          "componentProperty": {
-            "type": "boolean"
-          },
-          "controlHint": {
-            "type": "string"
-          },
-          "dataList": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "labelHint": {
-            "type": "string"
-          },
-          "placeholder": {
-            "type": "string"
-          },
-          "relation": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PropertyRelation"
-            }
-          },
-          "multiple": {
-            "type": "boolean"
-          },
-          "connectorValue": {
-            "type": "string"
-          },
-          "extendedProperties": {
-            "type": "string"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "order": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          }
-        }
-      },
-      "Connection": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "options": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "organization": {
-            "$ref": "#/components/schemas/Organization"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "connector": {
-            "$ref": "#/components/schemas/Connector"
-          },
-          "connectorId": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "derived": {
-            "type": "boolean"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        }
-      },
-      "ConnectionOverview": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "board": {
-            "$ref": "#/components/schemas/ConnectionBulletinBoard"
-          },
-          "id": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "options": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "organization": {
-            "$ref": "#/components/schemas/Organization"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "connector": {
-            "$ref": "#/components/schemas/Connector"
-          },
-          "connectorId": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "derived": {
-            "type": "boolean"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        }
-      },
-      "Connector": {
-        "required": ["actions", "name"],
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connectorCustomizers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "exceptionHandler": {
-            "type": "string"
-          },
-          "connectorGroup": {
-            "$ref": "#/components/schemas/ConnectorGroup"
-          },
-          "connectorGroupId": {
-            "type": "string"
-          },
-          "componentScheme": {
-            "type": "string"
-          },
-          "connectorFactory": {
-            "type": "string"
-          },
-          "uses": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            "readOnly": true
-          },
-          "actionsSummary": {
-            "$ref": "#/components/schemas/ActionsSummary"
-          },
-          "id": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "actions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectorAction"
-            }
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ConnectorAction": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "descriptor": {
-            "$ref": "#/components/schemas/ConnectorDescriptor"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "actionType": {
-            "type": "string"
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "pattern": {
-            "type": "string",
-            "enum": ["From", "Pipe", "To", "PollEnrich"]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ConnectorDescriptor": {
-        "type": "object",
-        "properties": {
-          "connectorCustomizers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "exceptionHandler": {
-            "type": "string"
-          },
-          "componentScheme": {
-            "type": "string"
-          },
-          "connectorFactory": {
-            "type": "string"
-          },
-          "camelConnectorGAV": {
-            "type": "string"
-          },
-          "connectorId": {
-            "type": "string"
-          },
-          "camelConnectorPrefix": {
-            "type": "string"
-          },
-          "standardizedErrors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StandardizedError"
-            }
-          },
-          "inputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "outputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "propertyDefinitionSteps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ConnectorGroup": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "ContinuousDeliveryEnvironment": {
-        "type": "object",
-        "properties": {
-          "releaseTag": {
-            "type": "string"
-          },
-          "lastExportedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "lastImportedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "environmentId": {
-            "type": "string"
-          },
-          "lastTaggedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "DataShape": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataShape"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "any",
-              "java",
-              "json-schema",
-              "json-instance",
-              "xml-schema",
-              "xml-schema-inspected",
-              "xml-instance",
-              "none"
-            ]
-          },
-          "specification": {
-            "type": "string"
-          },
-          "exemplar": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "byte"
-            }
-          },
-          "collectionClassName": {
-            "type": "string"
-          },
-          "collectionType": {
-            "type": "string"
-          }
-        }
-      },
-      "Dependency": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["MAVEN", "EXTENSION", "EXTENSION_TAG", "ICON"]
-          }
-        }
-      },
-      "Environment": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "Extension": {
-        "required": ["actions", "extensionType", "name", "schemaVersion"],
-        "type": "object",
-        "properties": {
-          "schemaVersion": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "extensionId": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "actions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Action"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": ["Draft", "Installed", "Deleted"]
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "extensionType": {
-            "type": "string",
-            "enum": ["Steps", "Connectors", "Libraries"]
-          },
-          "id": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        }
-      },
-      "Flow": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "scheduler": {
-            "$ref": "#/components/schemas/Scheduler"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["PRIMARY", "API_PROVIDER", "ALTERNATE"]
-          },
-          "description": {
-            "type": "string"
-          },
-          "connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connection"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "ImmutableConnectorAction": {
-        "required": ["name"],
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Action"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "descriptor": {
-                "$ref": "#/components/schemas/ConnectorDescriptor"
-              },
-              "dependencies": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Dependency"
-                }
-              }
-            }
-          }
-        ]
-      },
-      "ImmutableStepAction": {
-        "required": ["name"],
-        "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Action"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "descriptor": {
-                "$ref": "#/components/schemas/StepDescriptor"
-              }
-            }
-          }
-        ]
-      },
-      "Integration": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connection"
-            }
-          },
-          "continuousDeliveryState": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-            }
-          },
-          "exposure": {
-            "type": "string"
-          },
-          "flows": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Flow"
-            }
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "resources": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResourceIdentifier"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "Organization": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "environments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Environment"
-            }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/User"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "PropertyRelation": {
-        "type": "object",
-        "properties": {
-          "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/When"
-            }
-          },
-          "action": {
-            "type": "string"
-          }
-        }
-      },
-      "PropertyValue": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          }
-        }
-      },
-      "ResourceIdentifier": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "action",
-              "connection",
-              "connection-overview",
-              "connector",
-              "connector-action",
-              "connector-group",
-              "connector-template",
-              "icon",
-              "environment",
-              "environment-type",
-              "extension",
-              "step-action",
-              "organization",
-              "integration",
-              "integration-overview",
-              "integration-deployment",
-              "integration-deployment-state-details",
-              "integration-metrics-summary",
-              "integration-runtime",
-              "integration-endpoint",
-              "step",
-              "permission",
-              "role",
-              "user",
-              "connection-bulletin-board",
-              "integration-bulletin-board",
-              "open-api"
-            ]
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "Scheduler": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["timer", "cron"]
-          },
-          "expression": {
-            "type": "string"
-          }
-        }
-      },
-      "StandardizedError": {
-        "type": "object"
-      },
-      "Step": {
-        "type": "object",
-        "properties": {
-          "connection": {
-            "$ref": "#/components/schemas/Connection"
-          },
-          "name": {
-            "type": "string"
-          },
-          "extension": {
-            "$ref": "#/components/schemas/Extension"
-          },
-          "stepKind": {
-            "type": "string",
-            "enum": [
-              "endpoint",
-              "connector",
-              "expressionFilter",
-              "ruleFilter",
-              "extension",
-              "mapper",
-              "choice",
-              "split",
-              "aggregate",
-              "log",
-              "headers",
-              "template"
-            ]
-          },
-          "action": {
-            "$ref": "#/components/schemas/Action"
-          },
-          "id": {
-            "type": "string"
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "StepDescriptor": {
-        "type": "object",
-        "properties": {
-          "entrypoint": {
-            "type": "string"
-          },
-          "resource": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string",
-            "enum": ["STEP", "BEAN", "ENDPOINT"]
-          },
-          "inputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "outputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "propertyDefinitionSteps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
-          }
-        }
-      },
-      "User": {
-        "type": "object",
-        "properties": {
-          "fullName": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "username": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "lastName": {
-            "type": "string"
-          },
-          "integrations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Integration"
-            }
-          },
-          "roleId": {
-            "type": "string"
-          },
-          "firstName": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "When": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "ListResultConnectionOverview": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectionOverview"
-            }
-          }
-        }
-      },
-      "JsonNode": {
-        "type": "object",
-        "properties": {
-          "float": {
-            "type": "boolean"
-          },
-          "nodeType": {
-            "type": "string",
-            "enum": [
-              "ARRAY",
-              "BINARY",
-              "BOOLEAN",
-              "MISSING",
-              "NULL",
-              "NUMBER",
-              "OBJECT",
-              "POJO",
-              "STRING"
-            ]
-          },
-          "array": {
-            "type": "boolean"
-          },
-          "empty": {
-            "type": "boolean"
-          },
-          "null": {
-            "type": "boolean"
-          },
-          "number": {
-            "type": "boolean"
-          },
-          "double": {
-            "type": "boolean"
-          },
-          "int": {
-            "type": "boolean"
-          },
-          "boolean": {
-            "type": "boolean"
-          },
-          "short": {
-            "type": "boolean"
-          },
-          "long": {
-            "type": "boolean"
-          },
-          "missingNode": {
-            "type": "boolean"
-          },
-          "containerNode": {
-            "type": "boolean"
-          },
-          "valueNode": {
-            "type": "boolean"
-          },
-          "object": {
-            "type": "boolean"
-          },
-          "pojo": {
-            "type": "boolean"
-          },
-          "integralNumber": {
-            "type": "boolean"
-          },
-          "floatingPointNumber": {
-            "type": "boolean"
-          },
-          "bigDecimal": {
-            "type": "boolean"
-          },
-          "bigInteger": {
-            "type": "boolean"
-          },
-          "textual": {
-            "type": "boolean"
-          },
-          "binary": {
-            "type": "boolean"
-          }
-        }
-      },
-      "Violation": {
-        "type": "object"
-      },
-      "ListResultConnectorGroup": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectorGroup"
-            }
-          }
-        }
-      },
-      "InputPart": {
-        "type": "object",
-        "properties": {
-          "contentTypeFromMessage": {
-            "type": "boolean"
-          },
-          "bodyAsString": {
-            "type": "string"
-          },
-          "headers": {
-            "type": "object",
-            "properties": {
-              "empty": {
-                "type": "boolean"
-              }
-            },
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "mediaType": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "subtype": {
-                "type": "string"
-              },
-              "parameters": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "wildcardType": {
-                "type": "boolean"
-              },
-              "wildcardSubtype": {
-                "type": "boolean"
-              }
-            }
-          }
-        }
-      },
-      "MultipartFormDataInput": {
-        "type": "object",
-        "properties": {
-          "formDataMap": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/InputPart"
-              }
-            }
-          },
-          "preamble": {
-            "type": "string"
-          },
-          "parts": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InputPart"
-            }
-          }
-        }
-      },
-      "AcquisitionMethod": {
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["OAUTH1", "OAUTH2"]
-          },
-          "label": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "configured": {
-            "type": "boolean"
-          }
-        }
-      },
-      "AcquisitionRequest": {
-        "type": "object",
-        "properties": {
-          "returnUrl": {
-            "type": "string",
-            "format": "uri"
-          }
-        }
-      },
-      "DynamicConnectionPropertiesMetadata": {
-        "type": "object"
-      },
-      "ConnectorFormData": {
-        "type": "object",
-        "properties": {
-          "connector": {
-            "$ref": "#/components/schemas/Connector"
-          },
-          "iconInputStream": {
-            "type": "object"
-          }
-        }
-      },
-      "ListResultConnector": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connector"
-            }
-          }
-        }
-      },
-      "ListResultConnectorAction": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectorAction"
-            }
-          }
-        }
-      },
-      "FilterOptions": {
-        "type": "object",
-        "properties": {
-          "ops": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Op"
-            }
-          },
-          "paths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "Op": {
-        "type": "object",
-        "properties": {
-          "label": {
-            "type": "string"
-          },
-          "operator": {
-            "type": "string"
-          }
-        }
-      },
-      "Result": {
-        "type": "object",
-        "properties": {
-          "errors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VerifierError"
-            }
-          },
-          "scope": {
-            "type": "string",
-            "enum": ["PARAMETERS", "CONNECTIVITY"]
-          },
-          "status": {
-            "type": "string",
-            "enum": ["OK", "ERROR", "UNSUPPORTED"]
-          }
-        }
-      },
-      "VerifierError": {
-        "type": "object",
-        "properties": {
-          "parameters": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "attributes": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "code": {
-            "type": "string"
-          }
-        }
-      },
-      "APISummary": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "errors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Violation"
-            }
-          },
-          "warnings": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Violation"
-            }
-          },
-          "actionsSummary": {
-            "$ref": "#/components/schemas/ActionsSummary"
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ConnectorSettings": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "connectorTemplateId": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "CustomConnectorFormData": {
-        "type": "object",
-        "properties": {
-          "connectorSettings": {
-            "$ref": "#/components/schemas/ConnectorSettings"
-          },
-          "iconInputStream": {
-            "type": "object"
-          },
-          "specification": {
-            "type": "object"
-          }
-        }
-      },
-      "ConnectorTemplate": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connectorGroup": {
-            "$ref": "#/components/schemas/ConnectorGroup"
-          },
-          "componentScheme": {
-            "type": "string"
-          },
-          "connectorProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ListResultConnectorTemplate": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectorTemplate"
-            }
-          }
-        }
-      },
-      "ListResultOrganization": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Organization"
-            }
-          }
-        }
-      },
-      "EventMessage": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object"
-          },
-          "event": {
-            "type": "string"
-          }
-        }
-      },
-      "ListResultExtension": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Extension"
-            }
-          }
-        }
-      },
-      "IntegrationDeployment": {
-        "type": "object",
-        "properties": {
-          "spec": {
-            "$ref": "#/components/schemas/Integration"
-          },
-          "integrationId": {
-            "type": "string"
-          },
-          "error": {
-            "$ref": "#/components/schemas/IntegrationDeploymentError"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "stepsDone": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "statusMessage": {
-            "type": "string"
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "id": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationDeploymentError": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string"
-          }
-        }
-      },
-      "ListResultIntegrationDeployment": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationDeployment"
-            }
-          }
-        }
-      },
-      "TargetStateRequest": {
-        "type": "object",
-        "properties": {
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          }
-        }
-      },
-      "IntegrationBulletinBoard": {
-        "type": "object",
-        "properties": {
-          "errors": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "warnings": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "notices": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "targetResourceId": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LeveledMessage"
-            }
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationDeploymentOverview": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "$ref": "#/components/schemas/IntegrationDeploymentError"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "stepsDone": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "statusMessage": {
-            "type": "string"
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "id": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationOverview": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string"
-          },
-          "board": {
-            "$ref": "#/components/schemas/IntegrationBulletinBoard"
-          },
-          "draft": {
-            "type": "boolean"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "deploymentVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "exposureMeans": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "deployments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationDeploymentOverview"
-            }
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "managementUrl": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connection"
-            }
-          },
-          "continuousDeliveryState": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-            }
-          },
-          "exposure": {
-            "type": "string"
-          },
-          "flows": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Flow"
-            }
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "resources": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResourceIdentifier"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "ListResultIntegrationOverview": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationOverview"
-            }
-          }
-        }
-      },
-      "APIFormData": {
-        "type": "object",
-        "properties": {
-          "specification": {
-            "type": "object"
-          }
-        }
-      },
-      "WithResourceId": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "IntegrationDeploymentMetrics": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "type": "string"
-          },
-          "errors": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "messages": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "lastProcessed": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "start": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "uptimeDuration": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationMetricsSummary": {
-        "type": "object",
-        "properties": {
-          "errors": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "messages": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "lastProcessed": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "integrationDeploymentMetrics": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationDeploymentMetrics"
-            }
-          },
-          "start": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "topIntegrations": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          "uptimeDuration": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "metricsProvider": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "OAuthApp": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "derived": {
-            "type": "boolean"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ListResultOAuthApp": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OAuthApp"
-            }
-          }
-        }
-      },
-      "ListResultString": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ModelDataObject": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string",
-            "enum": [
-              "action",
-              "connection",
-              "connection-overview",
-              "connector",
-              "connector-action",
-              "connector-group",
-              "connector-template",
-              "icon",
-              "environment",
-              "environment-type",
-              "extension",
-              "step-action",
-              "organization",
-              "integration",
-              "integration-overview",
-              "integration-deployment",
-              "integration-deployment-state-details",
-              "integration-metrics-summary",
-              "integration-runtime",
-              "integration-endpoint",
-              "step",
-              "permission",
-              "role",
-              "user",
-              "connection-bulletin-board",
-              "integration-bulletin-board",
-              "open-api"
-            ]
-          },
-          "condition": {
-            "type": "string"
-          },
-          "data": {
-            "type": "string"
-          }
-        }
-      },
-      "ListResultPermission": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Permission"
-            }
-          }
-        }
-      },
-      "Permission": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "ListResultRole": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Role"
-            }
-          }
-        }
-      },
-      "Role": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "permissions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Permission"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "Quota": {
-        "type": "object",
-        "properties": {
-          "maxIntegrationsPerUser": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "usedIntegrationsPerUser": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "usedDeploymentsPerUser": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "maxDeploymentsPerUser": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "ListResultUser": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/User"
-            }
-          }
-        }
-      }
+  "servers": [
+    {
+      "description": "Development server",
+      "url": "http://localhost:8080"
     }
-  }
+  ]
 }

--- a/app/ui-react/packages/models/openapi.json
+++ b/app/ui-react/packages/models/openapi.json
@@ -1,932 +1,12 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "Syndesis Supported API",
-    "description": "The Syndesis Supported REST API connects to back-end services on\nthe Syndesis and provides a single entry point for the 3rd party\nclients.\n",
-    "contact": {
-      "url": "https://syndesis.io/",
-      "email": "syndesis@googlegroups.com"
-    },
-    "license": {
-      "name": "Apache 2.0",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
-    },
-    "version": "v1-2.0-SNAPSHOT"
-  },
-  "servers": [
-    {
-      "url": "http://localhost:8080",
-      "description": "Development server"
-    }
-  ],
-  "paths": {
-    "/extensions": {
-      "get": {
-        "tags": ["extensions"],
-        "operationId": "list",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "Sort the result list according to the given field value",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "direction",
-            "in": "query",
-            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
-            "schema": {
-              "type": "string",
-              "enum": ["asc", "desc"]
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to return",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 1
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of records per page",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "default": 20
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "description": "The search query to filter results on",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "extensionType",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultExtension"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["extensions"],
-        "operationId": "upload",
-        "parameters": [
-          {
-            "name": "updatedId",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/MultipartFormDataInput"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Extension"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}": {
-      "get": {
-        "tags": ["extensions"],
-        "operationId": "get",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Extension"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["extensions"],
-        "operationId": "delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}/validation": {
-      "post": {
-        "tags": ["extensions"],
-        "operationId": "validate",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "All blocking validations pass",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/extensions/validation": {
-      "post": {
-        "tags": ["extensions"],
-        "operationId": "validate_1",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Extension"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "All blocking validations pass",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}/install": {
-      "post": {
-        "tags": ["extensions"],
-        "operationId": "install",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Installed",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Found violations in validation",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Violation"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}/integrations": {
-      "get": {
-        "tags": ["extensions"],
-        "operationId": "integrations",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "uniqueItems": true,
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ResourceIdentifier"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/extensions/{id}/stepIcon": {
-      "get": {
-        "tags": ["extensions"],
-        "operationId": "getStepIcon",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations": {
-      "post": {
-        "tags": ["public-api"],
-        "operationId": "importResources",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/ImportFormDataInput"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ContinuousDeliveryImportResults"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/public/connections/{id}/properties": {
-      "post": {
-        "tags": ["public-api"],
-        "operationId": "configureConnection",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "refreshIntegrations",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConnectionOverview"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{id}/state": {
-      "get": {
-        "tags": ["public-api"],
-        "operationId": "getIntegrationState",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationState"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{id}/deployments": {
-      "post": {
-        "tags": ["public-api"],
-        "operationId": "publishIntegration",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IntegrationDeployment"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{id}/deployments/stop": {
-      "put": {
-        "tags": ["public-api"],
-        "operationId": "stopIntegration",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {}
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{env}/export.zip": {
-      "get": {
-        "tags": ["public-api"],
-        "operationId": "exportResources",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "all",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ignoreTimestamp",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/octet-stream": {}
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{id}/tags": {
-      "get": {
-        "tags": ["public-api"],
-        "operationId": "getReleaseTags",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["public-api"],
-        "operationId": "putTagsForRelease",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": ["public-api"],
-        "operationId": "patchTagsForRelease",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/public/environments": {
-      "get": {
-        "tags": ["public-api"],
-        "operationId": "getReleaseEnvironments",
-        "parameters": [
-          {
-            "name": "withUses",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {}
-            }
-          }
-        }
-      }
-    },
-    "/public/environments/{env}": {
-      "put": {
-        "tags": ["public-api"],
-        "operationId": "renameEnvironment",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "string"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["public-api"],
-        "operationId": "addNewEnvironment",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["public-api"],
-        "operationId": "deleteEnvironment",
-        "parameters": [
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/public/integrations/{id}/tags/{env}": {
-      "delete": {
-        "tags": ["public-api"],
-        "operationId": "deleteReleaseTag",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "env",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "*/*": {}
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/export.zip": {
-      "get": {
-        "tags": ["integration-support"],
-        "operationId": "export",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/octet-stream": {}
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/overviews": {
-      "get": {
-        "tags": ["integration-support"],
-        "operationId": "getOverviews",
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/generate/pom.xml": {
-      "post": {
-        "tags": ["integration-support"],
-        "operationId": "projectPom",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Integration"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "byte"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/integration-support/import": {
-      "post": {
-        "tags": ["integration-support"],
-        "operationId": "importIntegration",
-        "requestBody": {
-          "content": {
-            "*/*": {
-              "schema": {
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "default response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/WithResourceId"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "components": {
     "schemas": {
       "Action": {
-        "required": ["name"],
-        "type": "object",
+        "discriminator": {
+          "propertyName": "actionType"
+        },
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
+          "actionType": {
             "type": "string"
           },
           "description": {
@@ -935,33 +15,34 @@
           "descriptor": {
             "$ref": "#/components/schemas/ActionDescriptor"
           },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "id": {
+            "type": "string"
           },
-          "actionType": {
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
             "type": "string"
           },
           "pattern": {
-            "type": "string",
-            "enum": ["From", "Pipe", "To", "PollEnrich"]
+            "enum": ["From", "Pipe", "To", "PollEnrich"],
+            "type": "string"
           },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
+          "tags": {
+            "items": {
               "type": "string"
-            }
+            },
+            "type": "array",
+            "uniqueItems": true
           }
         },
-        "discriminator": {
-          "propertyName": "actionType"
-        }
+        "required": ["name"],
+        "type": "object"
       },
       "ActionDescriptor": {
-        "type": "object",
         "properties": {
           "inputDataShape": {
             "$ref": "#/components/schemas/DataShape"
@@ -970,17 +51,22 @@
             "$ref": "#/components/schemas/DataShape"
           },
           "propertyDefinitionSteps": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
+            },
+            "type": "array"
           }
-        }
+        },
+        "type": "object"
       },
       "ActionDescriptorStep": {
-        "required": ["name"],
-        "type": "object",
         "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "description": {
             "type": "string"
           },
@@ -988,153 +74,522 @@
             "type": "string"
           },
           "properties": {
-            "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            },
+            "type": "object"
           }
-        }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ActionsSummary": {
+        "properties": {
+          "actionCountByTags": {
+            "additionalProperties": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "object"
+          },
+          "totalActions": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
       },
       "ConfigurationProperty": {
-        "type": "object",
         "properties": {
-          "generator": {
-            "type": "string"
-          },
-          "secret": {
-            "type": "boolean"
-          },
-          "raw": {
-            "type": "boolean"
-          },
-          "type": {
-            "type": "string"
-          },
-          "defaultValue": {
-            "type": "string"
-          },
-          "displayName": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "deprecated": {
-            "type": "boolean"
-          },
-          "group": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "enum": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PropertyValue"
-            }
-          },
-          "javaType": {
-            "type": "string"
-          },
-          "required": {
-            "type": "boolean"
-          },
           "componentProperty": {
-            "type": "boolean"
-          },
-          "controlHint": {
-            "type": "string"
-          },
-          "dataList": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "labelHint": {
-            "type": "string"
-          },
-          "placeholder": {
-            "type": "string"
-          },
-          "relation": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PropertyRelation"
-            }
-          },
-          "multiple": {
             "type": "boolean"
           },
           "connectorValue": {
             "type": "string"
           },
+          "controlHint": {
+            "type": "string"
+          },
+          "dataList": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultValue": {
+            "type": "string"
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "enum": {
+            "items": {
+              "$ref": "#/components/schemas/PropertyValue"
+            },
+            "type": "array"
+          },
           "extendedProperties": {
             "type": "string"
           },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "generator": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string"
+          },
+          "javaType": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "labelHint": {
+            "type": "string"
+          },
+          "multiple": {
+            "type": "boolean"
           },
           "order": {
-            "type": "object",
             "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
               "present": {
                 "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
               }
-            }
-          }
-        }
-      },
-      "ConnectorDescriptor": {
-        "type": "object",
-        "properties": {
-          "connectorCustomizers": {
-            "type": "array",
+            },
+            "type": "object"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "raw": {
+            "type": "boolean"
+          },
+          "relation": {
+            "items": {
+              "$ref": "#/components/schemas/PropertyRelation"
+            },
+            "type": "array"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "secret": {
+            "type": "boolean"
+          },
+          "tags": {
             "items": {
               "type": "string"
-            }
+            },
+            "type": "array",
+            "uniqueItems": true
           },
-          "exceptionHandler": {
+          "type": {
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Connection": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connector": {
+            "$ref": "#/components/schemas/Connector"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "createdDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "options": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "userId": {
+            "type": "string"
+          },
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectionBulletinBoard": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "errors": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/LeveledMessage"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "notices": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "targetResourceId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "warnings": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectionOverview": {
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/ConnectionBulletinBoard"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connector": {
+            "$ref": "#/components/schemas/Connector"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "createdDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "options": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "organizationId": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "userId": {
+            "type": "string"
+          },
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Connector": {
+        "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorAction"
+            },
+            "type": "array"
+          },
+          "actionsSummary": {
+            "$ref": "#/components/schemas/ActionsSummary"
           },
           "componentScheme": {
             "type": "string"
           },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorCustomizers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "connectorFactory": {
             "type": "string"
           },
-          "camelConnectorGAV": {
+          "connectorGroup": {
+            "$ref": "#/components/schemas/ConnectorGroup"
+          },
+          "connectorGroupId": {
             "type": "string"
           },
-          "connectorId": {
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "exceptionHandler": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "uses": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "readOnly": true,
+            "type": "object"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["actions", "name"],
+        "type": "object"
+      },
+      "ConnectorAction": {
+        "properties": {
+          "actionType": {
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "descriptor": {
+            "$ref": "#/components/schemas/ConnectorDescriptor"
+          },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "enum": ["From", "Pipe", "To", "PollEnrich"],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ConnectorDescriptor": {
+        "properties": {
+          "camelConnectorGAV": {
             "type": "string"
           },
           "camelConnectorPrefix": {
             "type": "string"
           },
-          "standardizedErrors": {
-            "type": "array",
+          "componentScheme": {
+            "type": "string"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connectorCustomizers": {
             "items": {
-              "$ref": "#/components/schemas/StandardizedError"
-            }
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "connectorFactory": {
+            "type": "string"
+          },
+          "connectorId": {
+            "type": "string"
+          },
+          "exceptionHandler": {
+            "type": "string"
           },
           "inputDataShape": {
             "$ref": "#/components/schemas/DataShape"
@@ -1143,46 +598,89 @@
             "$ref": "#/components/schemas/DataShape"
           },
           "propertyDefinitionSteps": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
+            },
+            "type": "array"
           },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+          "standardizedErrors": {
+            "items": {
+              "$ref": "#/components/schemas/StandardizedError"
+            },
+            "type": "array"
           }
-        }
+        },
+        "type": "object"
       },
-      "DataShape": {
-        "required": ["name"],
-        "type": "object",
+      "ConnectorGroup": {
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
-          },
-          "type": {
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "ContinuousDeliveryEnvironment": {
+        "properties": {
+          "environmentId": {
             "type": "string"
           },
-          "variants": {
-            "type": "array",
+          "lastExportedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastImportedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastTaggedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "releaseTag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ContinuousDeliveryImportResults": {
+        "properties": {
+          "lastImportedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "results": {
             "items": {
-              "$ref": "#/components/schemas/DataShape"
-            }
+              "$ref": "#/components/schemas/WithResourceId"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DataShape": {
+        "properties": {
+          "collectionClassName": {
+            "type": "string"
+          },
+          "collectionType": {
+            "type": "string"
           },
           "description": {
             "type": "string"
           },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
+          "exemplar": {
+            "items": {
+              "format": "byte",
               "type": "string"
-            }
+            },
+            "type": "array"
           },
           "kind": {
-            "type": "string",
             "enum": [
               "any",
               "java",
@@ -1192,330 +690,866 @@
               "xml-schema-inspected",
               "xml-instance",
               "none"
-            ]
+            ],
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
           },
           "specification": {
             "type": "string"
           },
-          "exemplar": {
-            "type": "array",
+          "type": {
+            "type": "string"
+          },
+          "variants": {
             "items": {
-              "type": "string",
-              "format": "byte"
-            }
-          },
-          "collectionClassName": {
-            "type": "string"
-          },
-          "collectionType": {
-            "type": "string"
+              "$ref": "#/components/schemas/DataShape"
+            },
+            "type": "array"
           }
-        }
+        },
+        "required": ["name"],
+        "type": "object"
       },
       "Dependency": {
-        "type": "object",
         "properties": {
           "id": {
             "type": "string"
           },
           "type": {
-            "type": "string",
-            "enum": ["MAVEN", "EXTENSION", "EXTENSION_TAG", "ICON"]
+            "enum": ["MAVEN", "EXTENSION", "EXTENSION_TAG", "ICON"],
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
-      "Extension": {
-        "required": ["actions", "extensionType", "name", "schemaVersion"],
-        "type": "object",
+      "Environment": {
         "properties": {
-          "schemaVersion": {
+          "id": {
             "type": "string"
           },
           "name": {
             "type": "string"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "Extension": {
+        "properties": {
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/Action"
+            },
+            "type": "array"
           },
-          "description": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "createdDate": {
+            "format": "date-time",
             "type": "string"
           },
-          "icon": {
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
             "type": "string"
           },
           "extensionId": {
             "type": "string"
           },
-          "version": {
+          "extensionType": {
+            "enum": ["Steps", "Connectors", "Libraries"],
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "status": {
+            "enum": ["Draft", "Installed", "Deleted"],
             "type": "string"
           },
           "tags": {
-            "uniqueItems": true,
-            "type": "array",
             "items": {
               "type": "string"
-            }
-          },
-          "actions": {
+            },
             "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Action"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "status": {
-            "type": "string",
-            "enum": ["Draft", "Installed", "Deleted"]
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
+            "uniqueItems": true
           },
           "userId": {
             "type": "string"
           },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
+          "uses": {
+            "format": "int32",
+            "readOnly": true,
+            "type": "integer"
           },
-          "extensionType": {
-            "type": "string",
-            "enum": ["Steps", "Connectors", "Libraries"]
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": ["actions", "extensionType", "name", "schemaVersion"],
+        "type": "object"
+      },
+      "Flow": {
+        "properties": {
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
           },
           "id": {
             "type": "string"
           },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
           "metadata": {
-            "type": "object",
             "additionalProperties": {
               "type": "string"
-            }
+            },
+            "type": "object"
           },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
+          "name": {
+            "type": "string"
+          },
+          "scheduler": {
+            "$ref": "#/components/schemas/Scheduler"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "type": {
+            "enum": ["PRIMARY", "API_PROVIDER", "ALTERNATE"],
+            "type": "string"
           }
-        }
+        },
+        "required": ["name"],
+        "type": "object"
       },
       "ImmutableConnectorAction": {
-        "required": ["name"],
-        "type": "object",
         "allOf": [
           {
             "$ref": "#/components/schemas/Action"
           },
           {
-            "type": "object",
             "properties": {
-              "descriptor": {
-                "$ref": "#/components/schemas/ConnectorDescriptor"
-              },
               "dependencies": {
-                "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Dependency"
-                }
+                },
+                "type": "array"
+              },
+              "descriptor": {
+                "$ref": "#/components/schemas/ConnectorDescriptor"
               }
-            }
+            },
+            "type": "object"
           }
-        ]
+        ],
+        "required": ["name"],
+        "type": "object"
       },
       "ImmutableStepAction": {
-        "required": ["name"],
-        "type": "object",
         "allOf": [
           {
             "$ref": "#/components/schemas/Action"
           },
           {
-            "type": "object",
             "properties": {
               "descriptor": {
                 "$ref": "#/components/schemas/StepDescriptor"
               }
-            }
+            },
+            "type": "object"
           }
-        ]
-      },
-      "ListResultExtension": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Extension"
-            }
-          }
-        }
-      },
-      "PropertyRelation": {
-        "type": "object",
-        "properties": {
-          "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/When"
-            }
-          },
-          "action": {
-            "type": "string"
-          }
-        }
-      },
-      "PropertyValue": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          }
-        }
-      },
-      "StandardizedError": {
+        ],
+        "required": ["name"],
         "type": "object"
       },
-      "StepDescriptor": {
-        "type": "object",
+      "ImportFormDataInput": {
         "properties": {
-          "entrypoint": {
+          "data": {
+            "type": "object"
+          },
+          "deploy": {
+            "type": "boolean"
+          },
+          "environment": {
             "type": "string"
           },
-          "resource": {
-            "type": "string"
+          "properties": {
+            "type": "object"
           },
-          "kind": {
-            "type": "string",
-            "enum": ["STEP", "BEAN", "ENDPOINT"]
-          },
-          "inputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "outputDataShape": {
-            "$ref": "#/components/schemas/DataShape"
-          },
-          "propertyDefinitionSteps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ActionDescriptorStep"
-            }
+          "refreshIntegrations": {
+            "type": "boolean"
           }
-        }
-      },
-      "When": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "Violation": {
+        },
         "type": "object"
       },
       "InputPart": {
-        "type": "object",
         "properties": {
-          "contentTypeFromMessage": {
-            "type": "boolean"
-          },
           "bodyAsString": {
             "type": "string"
           },
+          "contentTypeFromMessage": {
+            "type": "boolean"
+          },
           "headers": {
-            "type": "object",
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "properties": {
               "empty": {
                 "type": "boolean"
               }
             },
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            "type": "object"
           },
           "mediaType": {
-            "type": "object",
             "properties": {
-              "type": {
-                "type": "string"
+              "parameters": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
               },
               "subtype": {
                 "type": "string"
               },
-              "parameters": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "wildcardType": {
-                "type": "boolean"
+              "type": {
+                "type": "string"
               },
               "wildcardSubtype": {
                 "type": "boolean"
+              },
+              "wildcardType": {
+                "type": "boolean"
               }
-            }
+            },
+            "type": "object"
           }
-        }
+        },
+        "type": "object"
+      },
+      "Integration": {
+        "properties": {
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
+          "continuousDeliveryState": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "exposure": {
+            "type": "string"
+          },
+          "flows": {
+            "items": {
+              "$ref": "#/components/schemas/Flow"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceIdentifier"
+            },
+            "type": "array"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "IntegrationBulletinBoard": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "errors": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/LeveledMessage"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "notices": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "targetResourceId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "warnings": {
+            "properties": {
+              "asInt": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "present": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeployment": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/IntegrationDeploymentError"
+          },
+          "id": {
+            "type": "string"
+          },
+          "integrationId": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/Integration"
+          },
+          "statusMessage": {
+            "type": "string"
+          },
+          "stepsDone": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentOverview": {
+        "properties": {
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/IntegrationDeploymentError"
+          },
+          "id": {
+            "type": "string"
+          },
+          "statusMessage": {
+            "type": "string"
+          },
+          "stepsDone": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationDeploymentStateDetails": {
+        "properties": {
+          "deploymentVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "detailedState": {
+            "enum": ["ASSEMBLING", "BUILDING", "DEPLOYING", "STARTING"],
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "integrationId": {
+            "type": "string"
+          },
+          "linkType": {
+            "enum": ["EVENTS", "LOGS"],
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "podName": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationOverview": {
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/IntegrationBulletinBoard"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
+          "continuousDeliveryState": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+            },
+            "type": "object"
+          },
+          "createdAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
+          },
+          "deploymentVersion": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "deployments": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationDeploymentOverview"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "exposure": {
+            "type": "string"
+          },
+          "exposureMeans": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "flows": {
+            "items": {
+              "$ref": "#/components/schemas/Flow"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "managementUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigurationProperty"
+            },
+            "type": "object"
+          },
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/ResourceIdentifier"
+            },
+            "type": "array"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/Step"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "targetState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "IntegrationState": {
+        "properties": {
+          "currentState": {
+            "enum": ["Published", "Unpublished", "Error", "Pending"],
+            "type": "string"
+          },
+          "stateDetails": {
+            "$ref": "#/components/schemas/IntegrationDeploymentStateDetails"
+          }
+        },
+        "type": "object"
+      },
+      "LeveledMessage": {
+        "properties": {
+          "code": {
+            "enum": [
+              "SYNDESIS000",
+              "SYNDESIS001",
+              "SYNDESIS002",
+              "SYNDESIS003",
+              "SYNDESIS004",
+              "SYNDESIS005",
+              "SYNDESIS006",
+              "SYNDESIS007",
+              "SYNDESIS008",
+              "SYNDESIS009",
+              "SYNDESIS010",
+              "SYNDESIS011",
+              "SYNDESIS012"
+            ],
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "level": {
+            "enum": ["INFO", "WARN", "ERROR"],
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultExtension": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ListResultIntegrationOverview": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationOverview"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
       },
       "MultipartFormDataInput": {
-        "type": "object",
         "properties": {
           "formDataMap": {
-            "type": "object",
             "additionalProperties": {
-              "type": "array",
               "items": {
                 "$ref": "#/components/schemas/InputPart"
-              }
-            }
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
+          "parts": {
+            "items": {
+              "$ref": "#/components/schemas/InputPart"
+            },
+            "type": "array"
           },
           "preamble": {
             "type": "string"
-          },
-          "parts": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/InputPart"
-            }
           }
-        }
+        },
+        "type": "object"
+      },
+      "Organization": {
+        "properties": {
+          "environments": {
+            "items": {
+              "$ref": "#/components/schemas/Environment"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": ["name"],
+        "type": "object"
+      },
+      "PropertyRelation": {
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "when": {
+            "items": {
+              "$ref": "#/components/schemas/When"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "PropertyValue": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "ResourceIdentifier": {
-        "type": "object",
         "properties": {
-          "version": {
-            "type": "integer",
-            "format": "int32"
+          "id": {
+            "type": "string"
           },
           "kind": {
-            "type": "string",
             "enum": [
               "action",
               "connection",
@@ -1544,698 +1578,67 @@
               "connection-bulletin-board",
               "integration-bulletin-board",
               "open-api"
-            ]
-          },
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "ContinuousDeliveryImportResults": {
-        "type": "object",
-        "properties": {
-          "lastImportedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "results": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/WithResourceId"
-            }
-          }
-        }
-      },
-      "WithResourceId": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          }
-        }
-      },
-      "ImportFormDataInput": {
-        "type": "object",
-        "properties": {
-          "data": {
-            "type": "object"
-          },
-          "properties": {
-            "type": "object"
-          },
-          "refreshIntegrations": {
-            "type": "boolean"
-          },
-          "environment": {
-            "type": "string"
-          },
-          "deploy": {
-            "type": "boolean"
-          }
-        }
-      },
-      "ActionsSummary": {
-        "type": "object",
-        "properties": {
-          "actionCountByTags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "totalActions": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "Connection": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "options": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "organization": {
-            "$ref": "#/components/schemas/Organization"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "connector": {
-            "$ref": "#/components/schemas/Connector"
-          },
-          "connectorId": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "derived": {
-            "type": "boolean"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        }
-      },
-      "ConnectionBulletinBoard": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "errors": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "warnings": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "notices": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "targetResourceId": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LeveledMessage"
-            }
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "ConnectionOverview": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "board": {
-            "$ref": "#/components/schemas/ConnectionBulletinBoard"
-          },
-          "id": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "options": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "description": {
-            "type": "string"
-          },
-          "lastUpdated": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "organization": {
-            "$ref": "#/components/schemas/Organization"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "organizationId": {
-            "type": "string"
-          },
-          "connector": {
-            "$ref": "#/components/schemas/Connector"
-          },
-          "connectorId": {
-            "type": "string"
-          },
-          "createdDate": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "derived": {
-            "type": "boolean"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "uses": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          }
-        }
-      },
-      "Connector": {
-        "required": ["actions", "name"],
-        "type": "object",
-        "properties": {
-          "icon": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connectorCustomizers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "exceptionHandler": {
-            "type": "string"
-          },
-          "connectorGroup": {
-            "$ref": "#/components/schemas/ConnectorGroup"
-          },
-          "connectorGroupId": {
-            "type": "string"
-          },
-          "componentScheme": {
-            "type": "string"
-          },
-          "connectorFactory": {
-            "type": "string"
-          },
-          "uses": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            },
-            "readOnly": true
-          },
-          "actionsSummary": {
-            "$ref": "#/components/schemas/ActionsSummary"
-          },
-          "id": {
+            ],
             "type": "string"
           },
           "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "actions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConnectorAction"
-            }
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "format": "int32",
+            "type": "integer"
           }
-        }
-      },
-      "ConnectorAction": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "descriptor": {
-            "$ref": "#/components/schemas/ConnectorDescriptor"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "actionType": {
-            "type": "string"
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          },
-          "pattern": {
-            "type": "string",
-            "enum": ["From", "Pipe", "To", "PollEnrich"]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "ConnectorGroup": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "ContinuousDeliveryEnvironment": {
-        "type": "object",
-        "properties": {
-          "releaseTag": {
-            "type": "string"
-          },
-          "lastExportedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "lastImportedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "environmentId": {
-            "type": "string"
-          },
-          "lastTaggedAt": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "Environment": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "Flow": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "scheduler": {
-            "$ref": "#/components/schemas/Scheduler"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["PRIMARY", "API_PROVIDER", "ALTERNATE"]
-          },
-          "description": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "Integration": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connection"
-            }
-          },
-          "continuousDeliveryState": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-            }
-          },
-          "exposure": {
-            "type": "string"
-          },
-          "flows": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Flow"
-            }
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "resources": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResourceIdentifier"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "LeveledMessage": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "level": {
-            "type": "string",
-            "enum": ["INFO", "WARN", "ERROR"]
-          },
-          "detail": {
-            "type": "string"
-          },
-          "code": {
-            "type": "string",
-            "enum": [
-              "SYNDESIS000",
-              "SYNDESIS001",
-              "SYNDESIS002",
-              "SYNDESIS003",
-              "SYNDESIS004",
-              "SYNDESIS005",
-              "SYNDESIS006",
-              "SYNDESIS007",
-              "SYNDESIS008",
-              "SYNDESIS009",
-              "SYNDESIS010",
-              "SYNDESIS011",
-              "SYNDESIS012"
-            ]
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "Organization": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "environments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Environment"
-            }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/User"
-            }
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        }
+        },
+        "type": "object"
       },
       "Scheduler": {
-        "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["timer", "cron"]
-          },
           "expression": {
             "type": "string"
+          },
+          "type": {
+            "enum": ["timer", "cron"],
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
+      },
+      "StandardizedError": {
+        "type": "object"
       },
       "Step": {
-        "type": "object",
         "properties": {
+          "action": {
+            "$ref": "#/components/schemas/Action"
+          },
+          "configuredProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "connection": {
             "$ref": "#/components/schemas/Connection"
           },
-          "name": {
-            "type": "string"
+          "dependencies": {
+            "items": {
+              "$ref": "#/components/schemas/Dependency"
+            },
+            "type": "array"
           },
           "extension": {
             "$ref": "#/components/schemas/Extension"
           },
+          "id": {
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
           "stepKind": {
-            "type": "string",
             "enum": [
               "endpoint",
               "connector",
@@ -2249,417 +1652,1014 @@
               "log",
               "headers",
               "template"
-            ]
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StepDescriptor": {
+        "properties": {
+          "entrypoint": {
+            "type": "string"
           },
-          "action": {
-            "$ref": "#/components/schemas/Action"
+          "inputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "kind": {
+            "enum": ["STEP", "BEAN", "ENDPOINT"],
+            "type": "string"
+          },
+          "outputDataShape": {
+            "$ref": "#/components/schemas/DataShape"
+          },
+          "propertyDefinitionSteps": {
+            "items": {
+              "$ref": "#/components/schemas/ActionDescriptorStep"
+            },
+            "type": "array"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "firstName": {
+            "type": "string"
+          },
+          "fullName": {
+            "type": "string"
           },
           "id": {
             "type": "string"
           },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "dependencies": {
-            "type": "array",
+          "integrations": {
             "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
+              "$ref": "#/components/schemas/Integration"
+            },
+            "type": "array"
           },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "User": {
-        "type": "object",
-        "properties": {
-          "fullName": {
+          "lastName": {
             "type": "string"
           },
           "name": {
-            "type": "string"
-          },
-          "username": {
             "type": "string"
           },
           "organizationId": {
             "type": "string"
           },
-          "lastName": {
-            "type": "string"
-          },
-          "integrations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Integration"
-            }
-          },
           "roleId": {
             "type": "string"
           },
-          "firstName": {
-            "type": "string"
-          },
-          "id": {
+          "username": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
-      "IntegrationDeploymentStateDetails": {
-        "type": "object",
-        "properties": {
-          "namespace": {
-            "type": "string"
-          },
-          "deploymentVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "integrationId": {
-            "type": "string"
-          },
-          "linkType": {
-            "type": "string",
-            "enum": ["EVENTS", "LOGS"]
-          },
-          "detailedState": {
-            "type": "string",
-            "enum": ["ASSEMBLING", "BUILDING", "DEPLOYING", "STARTING"]
-          },
-          "podName": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        }
+      "Violation": {
+        "type": "object"
       },
-      "IntegrationState": {
-        "type": "object",
+      "When": {
         "properties": {
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "stateDetails": {
-            "$ref": "#/components/schemas/IntegrationDeploymentStateDetails"
-          }
-        }
-      },
-      "IntegrationDeployment": {
-        "type": "object",
-        "properties": {
-          "spec": {
-            "$ref": "#/components/schemas/Integration"
-          },
-          "integrationId": {
-            "type": "string"
-          },
-          "error": {
-            "$ref": "#/components/schemas/IntegrationDeploymentError"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "stepsDone": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "statusMessage": {
-            "type": "string"
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
           "id": {
             "type": "string"
           },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationDeploymentError": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "type": {
+          "value": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
-      "IntegrationBulletinBoard": {
-        "type": "object",
+      "WithResourceId": {
         "properties": {
-          "errors": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "warnings": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "notices": {
-            "type": "object",
-            "properties": {
-              "present": {
-                "type": "boolean"
-              },
-              "asInt": {
-                "type": "integer",
-                "format": "int32"
-              }
-            }
-          },
-          "targetResourceId": {
-            "type": "string"
-          },
           "id": {
             "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LeveledMessage"
-            }
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
           }
-        }
-      },
-      "IntegrationDeploymentOverview": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "$ref": "#/components/schemas/IntegrationDeploymentError"
-          },
-          "userId": {
-            "type": "string"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "stepsDone": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "statusMessage": {
-            "type": "string"
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "id": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "IntegrationOverview": {
-        "required": ["name"],
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string"
-          },
-          "board": {
-            "$ref": "#/components/schemas/IntegrationBulletinBoard"
-          },
-          "draft": {
-            "type": "boolean"
-          },
-          "currentState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "deploymentVersion": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "exposureMeans": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "deployments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationDeploymentOverview"
-            }
-          },
-          "targetState": {
-            "type": "string",
-            "enum": ["Published", "Unpublished", "Error", "Pending"]
-          },
-          "managementUrl": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "connections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Connection"
-            }
-          },
-          "continuousDeliveryState": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
-            }
-          },
-          "exposure": {
-            "type": "string"
-          },
-          "flows": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Flow"
-            }
-          },
-          "properties": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ConfigurationProperty"
-            }
-          },
-          "configuredProperties": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "createdAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "tags": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Step"
-            }
-          },
-          "resources": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResourceIdentifier"
-            }
-          },
-          "dependencies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Dependency"
-            }
-          }
-        }
-      },
-      "ListResultIntegrationOverview": {
-        "type": "object",
-        "properties": {
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IntegrationOverview"
-            }
-          }
-        }
+        },
+        "type": "object"
       }
     }
-  }
+  },
+  "info": {
+    "contact": {
+      "email": "syndesis@googlegroups.com",
+      "url": "https://syndesis.io/"
+    },
+    "description": "The Syndesis Supported REST API connects to back-end services on\nthe Syndesis and provides a single entry point for the 3rd party\nclients.\n",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "title": "Syndesis Supported API",
+    "version": "v1-2.0-SNAPSHOT"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/extensions": {
+      "get": {
+        "operationId": "list",
+        "parameters": [
+          {
+            "description": "Sort the result list according to the given field value",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sorting direction when a 'sort' field is provided. Can be 'asc' (ascending) or 'desc' (descending)",
+            "in": "query",
+            "name": "direction",
+            "schema": {
+              "enum": ["asc", "desc"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The search query to filter results on",
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "extensionType",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultExtension"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      },
+      "post": {
+        "operationId": "upload",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "updatedId",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/MultipartFormDataInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Extension"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/validation": {
+      "post": {
+        "operationId": "validate_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Extension"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "All blocking validations pass"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}": {
+      "delete": {
+        "operationId": "delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      },
+      "get": {
+        "operationId": "get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Extension"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}/install": {
+      "post": {
+        "operationId": "install",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Installed"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}/integrations": {
+      "get": {
+        "operationId": "integrations",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ResourceIdentifier"
+                  },
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}/stepIcon": {
+      "get": {
+        "operationId": "getStepIcon",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/extensions/{id}/validation": {
+      "post": {
+        "operationId": "validate",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "All blocking validations pass"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Violation"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Found violations in validation"
+          }
+        },
+        "tags": ["extensions"]
+      }
+    },
+    "/integration-support/export.zip": {
+      "get": {
+        "operationId": "export",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/octet-stream": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integration-support/generate/pom.xml": {
+      "post": {
+        "operationId": "projectPom",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Integration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "items": {
+                    "format": "byte",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integration-support/import": {
+      "post": {
+        "operationId": "importIntegration",
+        "requestBody": {
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/WithResourceId"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/integration-support/overviews": {
+      "get": {
+        "operationId": "getOverviews",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultIntegrationOverview"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["integration-support"]
+      }
+    },
+    "/public/connections/{id}/properties": {
+      "post": {
+        "operationId": "configureConnection",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "refreshIntegrations",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionOverview"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/environments": {
+      "get": {
+        "operationId": "getReleaseEnvironments",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "withUses",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/environments/{env}": {
+      "delete": {
+        "operationId": "deleteEnvironment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      },
+      "post": {
+        "operationId": "addNewEnvironment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      },
+      "put": {
+        "operationId": "renameEnvironment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations": {
+      "post": {
+        "operationId": "importResources",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportFormDataInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContinuousDeliveryImportResults"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{env}/export.zip": {
+      "get": {
+        "operationId": "exportResources",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ignoreTimestamp",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/octet-stream": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{id}/deployments": {
+      "post": {
+        "operationId": "publishIntegration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationDeployment"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{id}/deployments/stop": {
+      "put": {
+        "operationId": "stopIntegration",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{id}/state": {
+      "get": {
+        "operationId": "getIntegrationState",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationState"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{id}/tags": {
+      "get": {
+        "operationId": "getReleaseTags",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      },
+      "patch": {
+        "operationId": "patchTagsForRelease",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      },
+      "put": {
+        "operationId": "putTagsForRelease",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/ContinuousDeliveryEnvironment"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    },
+    "/public/integrations/{id}/tags/{env}": {
+      "delete": {
+        "operationId": "deleteReleaseTag",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "env",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "*/*": {}
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["public-api"]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Development server",
+      "url": "http://localhost:8080"
+    }
+  ]
 }

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -4146,6 +4146,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/prettier@^2.2.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.0.tgz#2e8332cc7363f887d32ec5496b207d26ba8052bb"
+  integrity sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -18552,10 +18557,17 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.16.4:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier-plugin-sort-json@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-sort-json/-/prettier-plugin-sort-json-0.0.2.tgz#e2aa58829d1b895ed8d9e762860b3e3b84607245"
+  integrity sha512-St9zu6Alb+cA+FmnIFmjFOrTmBFWohYPReVjcMAI2y9mE0YJcW+RIchjLuOeXkLdh+eQlQtXy+3/6W6ZgyllQw==
+  dependencies:
+    "@types/prettier" "^2.2.0"
+
+prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
 
 pretty-bytes@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
I wanted to update the openapi.internal.json with a trivial change I
made in the server API. The diff for that was too great to be of any
value, so I found a way to add JSON sorting to prettier. Now the JSON
files are sorted so when changes are made only the lines affected by the
change are in the diff.

I've also formatted `openapi.*.json` files, to build the change on
later.