### PR TITLE
chore(ui): upgrade to the latest API documentation

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/connection/ConfigurationProperty.java
@@ -116,9 +116,9 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
     String getExtendedProperties();
 
-   Optional<ConfigurationProperty.ArrayDefinition> getArrayDefinition();
+    Optional<ConfigurationProperty.ArrayDefinition> getArrayDefinition();
 
-   Optional<ConfigurationProperty.ArrayDefinitionOptions> getArrayDefinitionOptions();
+    Optional<ConfigurationProperty.ArrayDefinitionOptions> getArrayDefinitionOptions();
 
     @Value.Immutable
     @JsonDeserialize(builder = ConfigurationProperty.ArrayDefinition.Builder.class)
@@ -132,9 +132,9 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
             }
         }
 
-        ArrayDefinitionElement key();
+        ArrayDefinitionElement getKey();
 
-        ArrayDefinitionElement value();
+        ArrayDefinitionElement getValue();
     }
 
     @Value.Immutable
@@ -143,15 +143,15 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
         final class Builder extends ImmutableArrayDefinitionElement.Builder {
             public static ConfigurationProperty.ArrayDefinitionElement of(final String displayName,
-                                                                   final String type) {
+                                                                          final String type) {
                 return new ConfigurationProperty.ArrayDefinitionElement.Builder()
                            .displayName(displayName).type(type).build();
             }
         }
 
-        String displayName();
+        String getDisplayName();
 
-        String type();
+        String getType();
     }
 
     @Value.Immutable
@@ -160,16 +160,16 @@ public interface ConfigurationProperty extends WithTags, Ordered, Serializable {
 
         final class Builder extends ImmutableArrayDefinitionOptions.Builder {
             public static ConfigurationProperty.ArrayDefinitionOptions of(
-                        final String i18nAddElementText,
-                        final Integer minElements) {
+                final String i18nAddElementText,
+                final Integer minElements) {
                 return new ConfigurationProperty.ArrayDefinitionOptions.Builder()
-                           .i18nAddElementText(i18nAddElementText).minElements(minElements).build();
+                    .i18nAddElementText(i18nAddElementText).minElements(minElements).build();
             }
         }
 
-        String i18nAddElementText();
+        String getI18nAddElementText();
 
-        Integer minElements();
+        Integer getMinElements();
     }
 
     default boolean raw() {

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -71,7 +71,7 @@
 
     <okhttp3.version>3.12.1</okhttp3.version>
 
-    <swagger.version>2.1.2</swagger.version>
+    <swagger.version>2.1.9</swagger.version>
     <swagger-maven-plugin.version>3.1.8</swagger-maven-plugin.version>
 
     <activemq.version>5.15.14</activemq.version>

--- a/app/server/runtime/.prettierrc
+++ b/app/server/runtime/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "jsonRecursiveSort": true,
+}

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -97,6 +97,18 @@
       </testResource>
     </testResources>
 
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <!-- We need a newer version than in basepom, see
+            https://github.com/basepom/basepom/blob/90f18cbc66bd2e1d5f62e8af73219afe0744cef5/foundation/pom.xml#L185-L186
+          -->
+          <version>3.1.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
 
       <plugin>
@@ -248,6 +260,101 @@
               <outputPath>${apidocs.output.dir}</outputPath>
               <outputFileName>openapi</outputFileName>
               <configurationFilePath>${project.build.outputDirectory}/openapi-public.yaml</configurationFilePath>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- This makes sure that we can use the JSON sort plugin in the prettier execution below -->
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-prettier-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <!-- uncompresses prettier to target/prettier-plugin-sort-json/prettier so that the JSON plugin sort can require it -->
+                  <groupId>org.webjars.npm</groupId>
+                  <artifactId>prettier</artifactId>
+                  <version>2.3.1</version>
+                  <outputDirectory> ${project.build.directory}/prettier-plugin-sort-json/node_modules/prettier</outputDirectory>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>^.*/</pattern>
+                      <replacement>./</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <!-- the plugin to sort JSON -->
+                  <groupId>org.webjars.npm</groupId>
+                  <artifactId>prettier-plugin-sort-json</artifactId>
+                  <version>0.0.2</version>
+                  <outputDirectory> ${project.build.directory}/prettier-plugin-sort-json</outputDirectory>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>^.*/</pattern>
+                      <replacement>./</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.hubspot.maven.plugins</groupId>
+        <artifactId>prettier-maven-plugin</artifactId>
+        <version>0.14</version>
+        <configuration>
+          <prettierJavaVersion>1.3.0</prettierJavaVersion>
+          <inputGlobs>
+            <!-- inputGlob options are passed straight as command line arguments to prettier, so we take advantage of that to add specific configuration we need -->
+            <inputGlob>--config=${project.basedir}/.prettierrc</inputGlob>
+            <inputGlob>--plugin=${project.build.directory}/prettier-plugin-sort-json</inputGlob>
+            <inputGlob>${apidocs.output.dir}/internal/openapi.json</inputGlob>
+            <inputGlob>${apidocs.output.dir}/openapi.json</inputGlob>
+          </inputGlobs>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>write</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>copy-internal-openapi-documents-to-ui-model</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${apidocs.output.dir}/internal/openapi.json</sourceFile>
+              <destinationFile>${project.basedir}/../../ui-react/packages/models/openapi.internal.json</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-public-openapi-documents-to-ui-model</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${apidocs.output.dir}/openapi.json</sourceFile>
+              <destinationFile>${project.basedir}/../../ui-react/packages/models/openapi.json</destinationFile>
             </configuration>
           </execution>
         </executions>

--- a/app/server/runtime/src/main/java/io/syndesis/server/runtime/swagger/ModelConverter.java
+++ b/app/server/runtime/src/main/java/io/syndesis/server/runtime/swagger/ModelConverter.java
@@ -20,26 +20,38 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlAccessorType;
 
 import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.util.PrimitiveType;
 import io.syndesis.common.util.json.JsonUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
 public class ModelConverter extends ModelResolver {
 
     public ModelConverter() {
         super(JsonUtils.copyObjectMapperConfiguration());
+
+        // see https://github.com/swagger-api/swagger-core/issues/3443
+        PrimitiveType.customClasses().put(java.time.Instant.class.getName(), PrimitiveType.LONG);
     }
 
     @Override
     protected boolean ignore(final Annotated member, final XmlAccessorType xmlAccessorTypeAnnotation, final String propName,
         final Set<String> propertiesToIgnore) {
+        return ignoreConsideringValue(member) && super.ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore);
+    }
+
+    @Override
+    protected boolean ignore(final Annotated member, final XmlAccessorType xmlAccessorTypeAnnotation, final String propName,
+        final Set<String> propertiesToIgnore, final BeanPropertyDefinition propDef) {
+
+        return ignoreConsideringValue(member) && super.ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore, propDef);
+    }
+
+    private static boolean ignoreConsideringValue(final Annotated member) {
         final JsonIgnore ignore = member.getAnnotation(JsonIgnore.class);
 
-        if (ignore != null && !ignore.value()) {
-            return false;
-        }
-
-        return super.ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore);
+        return ignore == null || ignore.value();
     }
 }

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/swagger/ArrayDefinitionTest.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/swagger/ArrayDefinitionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.runtime.swagger;
+
+import java.util.Map;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.syndesis.common.model.connection.ConfigurationProperty;
+import io.syndesis.common.util.json.JsonUtils;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArrayDefinitionTest {
+
+    final JsonNode node = JsonUtils
+        .convertValue(ConfigurationProperty.ArrayDefinition.Builder.of(
+            ConfigurationProperty.ArrayDefinitionElement.Builder.of("key", "string"),
+            ConfigurationProperty.ArrayDefinitionElement.Builder.of("value", "string")), JsonNode.class);
+
+    @Test
+    public void generateOpenAPISchemaShouldContainTheKeyAndValueProperties() {
+        final ModelConverters converters = ModelConverters.getInstance();
+        final ResolvedSchema resolvedSchema = converters.resolveAsResolvedSchema(new AnnotatedType(ConfigurationProperty.ArrayDefinition.class));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, ?> properties = resolvedSchema.schema.getProperties();
+        assertThat(properties).containsKeys("key", "value");
+    }
+
+    @Test
+    public void serializedJSONShouldContainTheKeyAndValueProperties() {
+        assertThat(node.has("key")).isTrue();
+        assertThat(node.has("value")).isTrue();
+    }
+
+}

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -179,8 +179,48 @@
         },
         "type": "object"
       },
+      "ArrayDefinition": {
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/ArrayDefinitionElement"
+          },
+          "value": {
+            "$ref": "#/components/schemas/ArrayDefinitionElement"
+          }
+        },
+        "type": "object"
+      },
+      "ArrayDefinitionElement": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ArrayDefinitionOptions": {
+        "properties": {
+          "i18nAddElementText": {
+            "type": "string"
+          },
+          "minElements": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ConfigurationProperty": {
         "properties": {
+          "arrayDefinition": {
+            "$ref": "#/components/schemas/ArrayDefinition"
+          },
+          "arrayDefinitionOptions": {
+            "$ref": "#/components/schemas/ArrayDefinitionOptions"
+          },
           "componentProperty": {
             "type": "boolean"
           },
@@ -1614,85 +1654,6 @@
         "type": "object"
       },
       "JsonNode": {
-        "properties": {
-          "array": {
-            "type": "boolean"
-          },
-          "bigDecimal": {
-            "type": "boolean"
-          },
-          "bigInteger": {
-            "type": "boolean"
-          },
-          "binary": {
-            "type": "boolean"
-          },
-          "boolean": {
-            "type": "boolean"
-          },
-          "containerNode": {
-            "type": "boolean"
-          },
-          "double": {
-            "type": "boolean"
-          },
-          "empty": {
-            "type": "boolean"
-          },
-          "float": {
-            "type": "boolean"
-          },
-          "floatingPointNumber": {
-            "type": "boolean"
-          },
-          "int": {
-            "type": "boolean"
-          },
-          "integralNumber": {
-            "type": "boolean"
-          },
-          "long": {
-            "type": "boolean"
-          },
-          "missingNode": {
-            "type": "boolean"
-          },
-          "nodeType": {
-            "enum": [
-              "ARRAY",
-              "BINARY",
-              "BOOLEAN",
-              "MISSING",
-              "NULL",
-              "NUMBER",
-              "OBJECT",
-              "POJO",
-              "STRING"
-            ],
-            "type": "string"
-          },
-          "null": {
-            "type": "boolean"
-          },
-          "number": {
-            "type": "boolean"
-          },
-          "object": {
-            "type": "boolean"
-          },
-          "pojo": {
-            "type": "boolean"
-          },
-          "short": {
-            "type": "boolean"
-          },
-          "textual": {
-            "type": "boolean"
-          },
-          "valueNode": {
-            "type": "boolean"
-          }
-        },
         "type": "object"
       },
       "LeveledMessage": {
@@ -1945,6 +1906,49 @@
         "type": "object"
       },
       "ModelDataObject": {
+        "properties": {
+          "condition": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "action",
+              "connection",
+              "connection-overview",
+              "connector",
+              "connector-action",
+              "connector-group",
+              "connector-template",
+              "icon",
+              "environment",
+              "environment-type",
+              "extension",
+              "step-action",
+              "organization",
+              "integration",
+              "integration-overview",
+              "integration-deployment",
+              "integration-deployment-state-details",
+              "integration-metrics-summary",
+              "integration-runtime",
+              "integration-endpoint",
+              "step",
+              "permission",
+              "role",
+              "user",
+              "connection-bulletin-board",
+              "integration-bulletin-board",
+              "open-api"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ModelDataWithIdObject": {
         "properties": {
           "condition": {
             "type": "string"
@@ -2416,7 +2420,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Syndesis Internal API",
-    "version": "v1-2.0-SNAPSHOT"
+    "version": "v1-1.13-SNAPSHOT"
   },
   "openapi": "3.0.1",
   "paths": {
@@ -2569,7 +2573,7 @@
         "tags": ["connections"]
       },
       "get": {
-        "operationId": "get_1",
+        "operationId": "get",
         "parameters": [
           {
             "in": "path",
@@ -2805,7 +2809,7 @@
     },
     "/connector-templates/{id}": {
       "get": {
-        "operationId": "get_7",
+        "operationId": "get_6",
         "parameters": [
           {
             "in": "path",
@@ -2898,7 +2902,7 @@
     },
     "/connectorgroups/{id}": {
       "get": {
-        "operationId": "get",
+        "operationId": "get_1",
         "parameters": [
           {
             "in": "path",
@@ -2926,7 +2930,7 @@
     },
     "/connectors": {
       "get": {
-        "operationId": "list_2",
+        "operationId": "list_3",
         "parameters": [
           {
             "description": "Sort the result list according to the given field value",
@@ -2989,10 +2993,62 @@
         "tags": ["connectors"]
       }
     },
+    "/connectors/apiConnectors": {
+      "get": {
+        "operationId": "listApiConnectors",
+        "parameters": [
+          {
+            "description": "Filter by matching connector group ids",
+            "in": "query",
+            "name": "connectorGroupIdList",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Page number to return",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 1,
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page",
+            "in": "query",
+            "name": "per_page",
+            "schema": {
+              "default": 20,
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResultConnector"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      }
+    },
     "/connectors/custom": {
       "post": {
         "description": "Creates a new Connector based on the ConnectorTemplate identified by the provided `id` and the data given in `connectorSettings` multipart part, plus optional `icon` file",
-        "operationId": "create_4",
+        "operationId": "create_3",
         "requestBody": {
           "content": {
             "multipart/form-data": {
@@ -3016,9 +3072,9 @@
         "operationId": "info_1",
         "requestBody": {
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/ConnectorSettings"
+                "$ref": "#/components/schemas/CustomConnectorFormData"
               }
             }
           }
@@ -3040,7 +3096,7 @@
     },
     "/connectors/{connectorId}/actions": {
       "get": {
-        "operationId": "list_3",
+        "operationId": "list_2",
         "parameters": [
           {
             "description": "Sort the result list according to the given field value",
@@ -3111,9 +3167,45 @@
         "tags": ["actions", "connectors"]
       }
     },
+    "/connectors/{connectorId}/actions/{actionId}/filters/options": {
+      "get": {
+        "operationId": "getFilterOptions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connectorId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "actionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterOptions"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["connectors"]
+      }
+    },
     "/connectors/{connectorId}/actions/{id}": {
       "get": {
-        "operationId": "get_6",
+        "operationId": "get_4",
         "parameters": [
           {
             "in": "path",
@@ -3147,6 +3239,42 @@
         "tags": ["actions", "connectors"]
       }
     },
+    "/connectors/{connectorId}/properties": {
+      "post": {
+        "operationId": "dynamicConnectionProperties",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "connectorId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DynamicConnectionPropertiesMetadata"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "tags": ["properties", "connectors"]
+      }
+    },
     "/connectors/{id}": {
       "delete": {
         "operationId": "delete_1",
@@ -3171,7 +3299,7 @@
         "tags": ["connectors"]
       },
       "get": {
-        "operationId": "get_5",
+        "operationId": "get_3",
         "parameters": [
           {
             "in": "path",
@@ -3242,13 +3370,12 @@
         ],
         "requestBody": {
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Connector"
+                "$ref": "#/components/schemas/ConnectorFormData"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "default": {
@@ -3261,45 +3388,9 @@
         "tags": ["connectors"]
       }
     },
-    "/connectors/{id}/actions/{actionId}/filters/options": {
-      "get": {
-        "operationId": "getFilterOptions",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "actionId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FilterOptions"
-                }
-              }
-            },
-            "description": "default response"
-          }
-        },
-        "tags": ["connectors"]
-      }
-    },
     "/connectors/{id}/credentials": {
       "get": {
-        "operationId": "get_3",
+        "operationId": "get_2",
         "parameters": [
           {
             "in": "path",
@@ -3325,7 +3416,7 @@
         "tags": ["credentials", "connectors"]
       },
       "post": {
-        "operationId": "create_2",
+        "operationId": "create_1",
         "parameters": [
           {
             "in": "path",
@@ -3359,7 +3450,7 @@
     },
     "/connectors/{id}/icon": {
       "get": {
-        "operationId": "get_2",
+        "operationId": "get_5",
         "parameters": [
           {
             "in": "path",
@@ -3382,7 +3473,7 @@
       },
       "post": {
         "description": "Updates the connector icon for the specified connector and returns the updated connector",
-        "operationId": "create_1",
+        "operationId": "create_2",
         "parameters": [
           {
             "in": "path",
@@ -3408,34 +3499,6 @@
           }
         },
         "tags": ["connector", "connector-icon", "connectors"]
-      }
-    },
-    "/connectors/{id}/properties": {
-      "post": {
-        "operationId": "dynamicConnectionProperties",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DynamicConnectionPropertiesMetadata"
-                }
-              }
-            },
-            "description": "default response"
-          }
-        },
-        "tags": ["properties", "connectors"]
       }
     },
     "/connectors/{id}/verifier": {
@@ -3806,6 +3869,7 @@
             "in": "query",
             "name": "extensionType",
             "schema": {
+              "enum": ["Steps", "Connectors", "Libraries"],
               "type": "string"
             }
           }
@@ -3861,7 +3925,7 @@
     },
     "/extensions/validation": {
       "post": {
-        "operationId": "validate_2",
+        "operationId": "validate_1",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4055,7 +4119,7 @@
     },
     "/extensions/{id}/validation": {
       "post": {
-        "operationId": "validate_1",
+        "operationId": "validate_2",
         "parameters": [
           {
             "in": "path",
@@ -4271,7 +4335,7 @@
         "tags": ["integrations"]
       },
       "post": {
-        "operationId": "create_3",
+        "operationId": "create_4",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4398,7 +4462,7 @@
         "tags": ["integrations"]
       },
       "get": {
-        "operationId": "get_11",
+        "operationId": "get_10",
         "parameters": [
           {
             "in": "path",
@@ -4728,7 +4792,7 @@
     "/metrics/integrations": {
       "get": {
         "description": "Retrieves a rolled up metrics summary for all integrations over their lifetime",
-        "operationId": "get_10",
+        "operationId": "get_11",
         "responses": {
           "default": {
             "content": {
@@ -4838,7 +4902,7 @@
     },
     "/organizations/{id}": {
       "get": {
-        "operationId": "get_4",
+        "operationId": "get_7",
         "parameters": [
           {
             "in": "path",
@@ -5335,7 +5399,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/ModelDataObject"
+                    "$ref": "#/components/schemas/ModelDataWithIdObject"
                   },
                   "type": "array"
                 }

--- a/app/ui-react/packages/models/openapi.json
+++ b/app/ui-react/packages/models/openapi.json
@@ -99,8 +99,48 @@
         },
         "type": "object"
       },
+      "ArrayDefinition": {
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/ArrayDefinitionElement"
+          },
+          "value": {
+            "$ref": "#/components/schemas/ArrayDefinitionElement"
+          }
+        },
+        "type": "object"
+      },
+      "ArrayDefinitionElement": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ArrayDefinitionOptions": {
+        "properties": {
+          "i18nAddElementText": {
+            "type": "string"
+          },
+          "minElements": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ConfigurationProperty": {
         "properties": {
+          "arrayDefinition": {
+            "$ref": "#/components/schemas/ArrayDefinition"
+          },
+          "arrayDefinitionOptions": {
+            "$ref": "#/components/schemas/ArrayDefinitionOptions"
+          },
           "componentProperty": {
             "type": "boolean"
           },
@@ -832,6 +872,12 @@
       },
       "Flow": {
         "properties": {
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            },
+            "type": "array"
+          },
           "dependencies": {
             "items": {
               "$ref": "#/components/schemas/Dependency"
@@ -1755,7 +1801,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Syndesis Supported API",
-    "version": "v1-2.0-SNAPSHOT"
+    "version": "v1-1.13-SNAPSHOT"
   },
   "openapi": "3.0.1",
   "paths": {
@@ -1812,6 +1858,7 @@
             "in": "query",
             "name": "extensionType",
             "schema": {
+              "enum": ["Steps", "Connectors", "Libraries"],
               "type": "string"
             }
           }
@@ -1867,7 +1914,7 @@
     },
     "/extensions/validation": {
       "post": {
-        "operationId": "validate_1",
+        "operationId": "validate",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2061,7 +2108,7 @@
     },
     "/extensions/{id}/validation": {
       "post": {
-        "operationId": "validate",
+        "operationId": "validate_1",
         "parameters": [
           {
             "in": "path",

--- a/app/ui-react/packages/utils/src/autoformHelpers.ts
+++ b/app/ui-react/packages/utils/src/autoformHelpers.ts
@@ -4,6 +4,7 @@ import {
   IFormErrors,
 } from '@syndesis/auto-form';
 import {
+  ArrayDefinition,
   IConfigurationProperties,
   IConfigurationProperty,
 } from '@syndesis/models';
@@ -21,7 +22,7 @@ export function toFormDefinition(properties: IConfigurationProperties) {
     throw new Error('Undefined value passed to form definition converter');
   }
   const answer: IFormDefinition = {};
-  Object.keys(properties).forEach(key => {
+  Object.keys(properties).forEach((key) => {
     answer[key] = toFormDefinitionProperty(properties[key]);
   });
   return answer;
@@ -65,8 +66,8 @@ export function toFormDefinitionProperty(property: IConfigurationProperty) {
 export function anyFieldsRequired(properties: IConfigurationProperties) {
   return (
     Object.keys(properties)
-      .filter(key => requiredTypeMask(properties[key].type))
-      .filter(key => properties[key].required).length > 0
+      .filter((key) => requiredTypeMask(properties[key].type))
+      .filter((key) => properties[key].required).length > 0
   );
 }
 
@@ -82,10 +83,10 @@ function requiredTypeMask(type?: string) {
 }
 
 export function allFieldsRequired(properties: IConfigurationProperties) {
-  const keys = Object.keys(properties).filter(key =>
+  const keys = Object.keys(properties).filter((key) =>
     requiredTypeMask(properties[key].type)
   );
-  const allRequired = keys.filter(key => properties[key].required);
+  const allRequired = keys.filter((key) => properties[key].required);
   if (allRequired.length === 0) {
     return false;
   }
@@ -121,13 +122,13 @@ export function validateConfiguredProperties(
     return false;
   }
   const allRequired = Object.keys(properties).filter(
-    key => properties[key].required
+    (key) => properties[key].required
   );
   if (allRequired.length === 0) {
     return true;
   }
   const allRequiredSet = allRequired
-    .map(key => validateRequired(values[key]))
+    .map((key) => validateRequired(values[key]))
     .reduce((prev, curr) => curr, false);
   return allRequiredSet;
 }
@@ -155,33 +156,30 @@ function validateRequired(value?: any) {
  * @param values
  */
 export function validateRequiredProperties<T>(
-  definition: IConfigurationProperties | IFormDefinition,
+  definition: IFormDefinition | ArrayDefinition,
   getErrorString: (name: string) => string,
   values?: T,
   prefix = ''
 ): IFormErrors<T> {
   const allRequired = Object.keys(definition)
-    .filter(key => requiredTypeMask(definition[key].type))
-    .filter(key => definition[key].required);
+    .filter((key) => requiredTypeMask(definition[key].type))
+    .filter((key) => definition[key].required);
   if (allRequired.length === 0) {
     return {} as IFormErrors<T>;
   }
   const sanitizedValues = values || ({} as T);
   const validationResults = allRequired
-    .map(key => ({ key, defined: validateRequired(sanitizedValues[key]) }))
-    .reduce(
-      (acc, current) => {
-        if (!current.defined) {
-          acc[`${prefix}${current.key}`] = getErrorString(
-            definition[current.key].displayName || current.key
-          );
-        }
-        return acc;
-      },
-      {} as IFormErrors<T>
-    );
+    .map((key) => ({ key, defined: validateRequired(sanitizedValues[key]) }))
+    .reduce((acc, current) => {
+      if (!current.defined) {
+        acc[`${prefix}${current.key}`] = getErrorString(
+          definition[current.key].displayName || current.key
+        );
+      }
+      return acc;
+    }, {} as IFormErrors<T>);
   const arrayValidationResults = allRequired
-    .filter(key => definition[key].type === 'array')
+    .filter((key) => definition[key].type === 'array')
     .reduce((acc, current) => {
       const arrayValue = sanitizedValues[current] || [];
       const arrayDefinition = definition[current].arrayDefinition!;
@@ -208,7 +206,7 @@ export function validateRequiredProperties<T>(
  */
 export function coerceFormValues(values: any) {
   const updated = {};
-  Object.keys(values).forEach(key => {
+  Object.keys(values).forEach((key) => {
     updated[key] =
       typeof values[key] === 'object'
         ? JSON.stringify(values[key])


### PR DESCRIPTION
chore(deps): upgrade Swagger to 2.1.9 (230b271)

The `ModelConverter` also needed to be adjusted to override an
additional `ignore` method.

fix: make sure Array* properties are documented (3d1c9e2)

The Swagger plugin for generating the OpenAPI documents relies on the
properties having Java Bean style methods, we can't use non-Java Bean
style methods as that would end up not including those properties in the
generated OpenAPI documents.

chore(ui): upgrade to the latest API documentation (8a2c84b)

This copies over the OpenAPI documents from the current API definition,
and fixes compile issues that have occurred with now correct API
documentation.

chore(api): make OpenAPI documents in UI current (fd7764a)

Adds Maven `prepare-package` phase executions to copy and format copies
of the OpenAPI documents in the ui-react module. This way those versions
won't get stale and we'll notice incompatible changes sooner.

