### PR TITLE
chore(build): enforce Java 1.8 version

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1474,6 +1474,9 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <configuration>
           <rules combine.children="append">
+            <requireJavaVersion>
+              <version>[1.8,1.9)</version>
+            </requireJavaVersion>
             <evaluateBeanshell>
               <message>Your JVM has limited cryptography, please upgrade
                 to 1.8.0_162 or newer or install Unlimited Strength


### PR DESCRIPTION
Maven compiler plugin hides certain `javac` error messages, for instance
those that are not strictly related to issues compiling Java code. This
makes it very difficult to debug issues. A common cause for `javac` to
fail is using a JVM newer than 1.8. This won't work due to how we use
and configure Errorprone. The configuration is JVM 1.8 specific.