### PR TITLE
fix(ui): additional step for SOAP service and port

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/action/ActionsSummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/action/ActionsSummary.java
@@ -28,6 +28,10 @@ public interface ActionsSummary {
 
     final class Builder extends ImmutableActionsSummary.Builder {
         // make ImmutableActionsSummary.Builder accessible
+
+        public static ActionsSummary empty() {
+            return new Builder().build();
+        }
     }
 
     Map<String, Integer> getActionCountByTags();

--- a/app/common/model/src/main/java/io/syndesis/common/model/api/APISummary.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/api/APISummary.java
@@ -40,8 +40,8 @@ public interface APISummary extends WithName, WithConfigurationProperties, WithC
         // make ImmutableAPISummary.Builder accessible
 
         public static Builder createFrom(final Connector connector) {
-            final ActionsSummary actionsSummary = new ActionsSummary.Builder()//
-                .totalActions(connector.getActions().size())//
+            final ActionsSummary actionsSummary = new ActionsSummary.Builder()
+                .totalActions(connector.getActions().size())
                 .actionCountByTags(
                     connector.getActions().stream()
                         .flatMap(s -> s.getTags().stream().distinct())
@@ -54,17 +54,24 @@ public interface APISummary extends WithName, WithConfigurationProperties, WithC
                 )
                 .build();
 
-            return new Builder().createFrom((WithConfigurationProperties) connector)//
-                .name(connector.getName())//
-                .description(connector.getDescription())//
+            final Builder builder = new Builder().createFrom((WithConfigurationProperties) connector)
+                .name(connector.getName())
+                .description(connector.getDescription())
                 .icon(Optional.ofNullable(connector.getIcon()))
-                .configuredProperties(Collections.emptyMap())//
-                .actionsSummary(actionsSummary);
+                .configuredProperties(Collections.emptyMap());
+
+            if (actionsSummary.getTotalActions() != 0) {
+                // connector could be created as a skeleton, without any actions
+                // let's not add empty summary then
+                builder.addActionsSummary(actionsSummary);
+            }
+
+            return builder;
         }
 
     }
 
-    ActionsSummary getActionsSummary();
+    List<ActionsSummary> getActionsSummary();
 
     String getDescription();
 

--- a/app/common/model/src/test/java/io/syndesis/common/model/api/APISummaryTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/api/APISummaryTest.java
@@ -15,10 +15,12 @@
  */
 package io.syndesis.common.model.api;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import io.syndesis.common.model.action.ActionsSummary;
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.connection.Connector;
 
@@ -37,8 +39,11 @@ public class APISummaryTest {
             ).build()
         ).build();
 
-        assertThat(summary.getActionsSummary().getTotalActions()).isEqualTo(4);
-        Map<String, Integer> actionCountByTags = summary.getActionsSummary().getActionCountByTags();
+        final List<ActionsSummary> actionsSummaries = summary.getActionsSummary();
+        assertThat(actionsSummaries).hasSize(1);
+        final ActionsSummary actionsSummary = actionsSummaries.get(0);
+        assertThat(actionsSummary.getTotalActions()).isEqualTo(4);
+        Map<String, Integer> actionCountByTags = actionsSummary.getActionCountByTags();
         assertThat(actionCountByTags).containsEntry("1", 1);
         assertThat(actionCountByTags).containsEntry("2", 3);
         assertThat(actionCountByTags).containsEntry("3", 2);

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGenerator.java
@@ -134,7 +134,7 @@ public class OpenApiConnectorGenerator extends ConnectorGenerator {
             .build();
 
         return APISummary.Builder.createFrom(connector)
-            .actionsSummary(actionsSummary)
+            .actionsSummary(Collections.singleton(actionsSummary))
             .errors(modelInfo.getErrors())
             .warnings(modelInfo.getWarnings())
             .putAllConfiguredProperties(connectorSettings.getConfiguredProperties())

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/openapi/OpenApiGenerator.java
@@ -133,7 +133,7 @@ public class OpenApiGenerator implements APIGenerator {
         return new APISummary.Builder()//
             .name(title)//
             .description(description)//
-            .actionsSummary(actionsSummary)//
+            .addActionsSummary(actionsSummary)//
             .errors(modelInfo.getErrors())//
             .warnings(modelInfo.getWarnings())//
             // needed if the user wants to change it

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGenerator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGenerator.java
@@ -165,8 +165,6 @@ public class SoapApiConnectorGenerator extends ConnectorGenerator {
                 .build();
         }
 
-        final Map<String, String> configuredProperties = connectorSettings.getConfiguredProperties();
-
         // create connector from template and connectorSettings, and add connector properties and parse warnings and errors
         final Connector connector = configuredConnector(connectorTemplate, connectorSettings);
         final APISummary.Builder summaryBuilder = APISummary.Builder.createFrom(connector)
@@ -182,25 +180,23 @@ public class SoapApiConnectorGenerator extends ConnectorGenerator {
                     toListValue(modelInfo.getServices().stream()
                             .map(QName::toString)
                             .collect(Collectors.toList())));
-            summaryBuilder.putConfiguredProperty(PORTS_PROPERTY, toMapValue(modelInfo.getPorts()));
+            final Map<QName, List<String>> ports = modelInfo.getPorts();
+            summaryBuilder.putConfiguredProperty(PORTS_PROPERTY, toMapValue(ports));
 
             // default or user selected service and port names
-            final QName serviceName = modelInfo.getDefaultService().map(s -> {
-                    summaryBuilder.putConfiguredProperty(SERVICE_NAME_PROPERTY, s.toString());
-                    return s;
-                }).orElse(configuredProperties.containsKey(SERVICE_NAME_PROPERTY) ?
-                    QName.valueOf(configuredProperties.get(SERVICE_NAME_PROPERTY)) : null);
+            modelInfo.getDefaultService().ifPresent(s -> {
+                summaryBuilder.putConfiguredProperty(SERVICE_NAME_PROPERTY, s.toString());
+            });
 
-            final String portName = modelInfo.getDefaultPort().map(p -> {
+            modelInfo.getDefaultPort().ifPresent(p -> {
                     summaryBuilder.putConfiguredProperty(PORT_NAME_PROPERTY, p);
-                    return p;
-                }).orElse(configuredProperties.get(PORT_NAME_PROPERTY));
+            });
 
-            // parse PortType if service and port are provided
-            if (serviceName != null && portName != null) {
-                // get actions from WSDL operations
+            for (QName service : modelInfo.getServices()) {
                 try {
-                    summaryBuilder.actionsSummary(SoapApiModelParser.parseActionsSummary(definition, serviceName, portName));
+                    for (String port : ports.get(service)) {
+                        summaryBuilder.addActionsSummary(SoapApiModelParser.parseActionsSummary(definition, service, port));
+                    }
                 } catch (ParserException e) {
                     summaryBuilder.addError(e.toViolation());
                 }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiModelInfo.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapApiModelInfo.java
@@ -69,6 +69,11 @@ public interface SoapApiModelInfo {
     }
 
     @Value.Default
+    default Map<String, String> getAddresses() {
+        return Collections.emptyMap();
+    }
+
+    @Value.Default
     default List<Violation> getWarnings() {
         return Collections.emptyList();
     }

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapConnectorConstants.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/SoapConnectorConstants.java
@@ -40,6 +40,7 @@ public final class SoapConnectorConstants {
 
     static final String SERVICES_PROPERTY = "services";
     static final String PORTS_PROPERTY = "ports";
+    static final String ADRESSES_PROPERTY = "addresses";
 
     private SoapConnectorConstants() {
         // constants

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -160,6 +160,18 @@ public final class SoapApiModelParser {
                 }
             }
 
+            @SuppressWarnings("unchecked")
+            final Map<QName, Service> services = definition.getServices();
+
+            services.forEach((serviceName, service) -> {
+                @SuppressWarnings("unchecked")
+                final Map<String, Port> ports = service.getPorts();
+
+                ports.keySet().forEach(portName -> {
+                    builder.putAddresses(portName, getAddress(definition, serviceName, portName));
+                });
+            });
+
         } catch (IOException e) {
             addError(builder, "Error reading WSDL: " + e.getMessage(), e);
         } catch (WSDLException | BusException e) {

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -142,7 +142,7 @@ public final class SoapApiModelParser {
 
             // set default service, port and address if present
             final SoapApiModelInfo localBuild = builder.build();
-            if (localBuild.getServices().size() == 1) {
+            if (localBuild.getServices().size() >= 1) {
 
                 final QName defaultService = localBuild.getServices().get(0);
                 builder.defaultService(defaultService);

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGeneratorTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/openapi/OpenApiConnectorGeneratorTest.java
@@ -329,7 +329,7 @@ public class OpenApiConnectorGeneratorTest {
 
         final APISummary expected = new APISummary.Builder()//
             .name("Swagger Petstore")//
-            .actionsSummary(actionsSummary)//
+            .addActionsSummary(actionsSummary)//
             .build();
         assertThat(summary).isEqualToIgnoringGivenFields(expected, "icon", "description", "properties", "warnings", "configuredProperties");
         assertThat(summary.getIcon()).matches(s -> s.isPresent() && s.get().startsWith("data:image"));

--- a/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
+++ b/app/server/api-generator/src/test/java/io/syndesis/server/api/generator/soap/SoapApiConnectorGeneratorExampleTest.java
@@ -94,10 +94,10 @@ public class SoapApiConnectorGeneratorExampleTest extends AbstractSoapExampleTes
         assertThat(services).isNotEmpty();
         assertThat(ports).isNotEmpty();
 
-        final ActionsSummary actionsSummary = apiSummary.getActionsSummary();
-        assertThat(actionsSummary).isNotNull();
-        assertThat(actionsSummary.getTotalActions()).isGreaterThan(0);
-        assertThat(actionsSummary.getActionCountByTags()).isNotEmpty();
+        final List<ActionsSummary> actionsSummary = apiSummary.getActionsSummary();
+        assertThat(actionsSummary).isNotNull().hasSize(1);
+        assertThat(actionsSummary.get(0).getTotalActions()).isGreaterThan(0);
+        assertThat(actionsSummary.get(0).getActionCountByTags()).isNotEmpty();
     }
 
     @ParameterizedTest(name = "{0}")

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandler.java
@@ -49,6 +49,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.syndesis.common.model.Kind;
 import io.syndesis.common.model.ListResult;
+import io.syndesis.common.model.action.ActionsSummary;
 import io.syndesis.common.model.action.ConnectorAction;
 import io.syndesis.common.model.api.APISummary;
 import io.syndesis.common.model.connection.ConfigurationProperty;
@@ -143,7 +144,21 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
 
         final APISummary summary = APISummary.Builder.createFrom(connector).build();
 
-        return connector.builder().actionsSummary(summary.getActionsSummary()).build();
+        final ActionsSummary actionsSummary = actionSummary(summary);
+
+        return connector.builder().actionsSummary(actionsSummary).build();
+    }
+
+    private static ActionsSummary actionSummary(final APISummary summary) {
+        final List<ActionsSummary> actionsSummary = summary.getActionsSummary();
+        final int size = actionsSummary.size();
+        if (size == 0) {
+            return ActionsSummary.Builder.empty();
+        } else if (size != 1) {
+            throw new UnsupportedOperationException("APISummary.Builder.createFrom should create not more than one ActionsSummary, got: " + size);
+        }
+
+        return actionsSummary.get(0);
     }
 
     /**
@@ -233,7 +248,9 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
             .map(c -> {
                 final APISummary summary = APISummary.Builder.createFrom(c).build();
 
-                return c.builder().actionsSummary(summary.getActionsSummary()).build();
+                final ActionsSummary actionsSummary = actionSummary(summary);
+
+                return c.builder().actionsSummary(actionsSummary).build();
             })
             .collect(Collectors.toList());
 
@@ -261,7 +278,9 @@ public class ConnectorHandler extends BaseHandler implements Lister<Connector>, 
             .map(c -> {
                 final APISummary summary = APISummary.Builder.createFrom(c).build();
 
-                return c.builder().actionsSummary(summary.getActionsSummary()).build();
+                final ActionsSummary actionsSummary = actionSummary(summary);
+
+                return c.builder().actionsSummary(actionsSummary).build();
             })
             .collect(Collectors.toList());
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/ConnectorTemplateITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/ConnectorTemplateITCase.java
@@ -15,6 +15,7 @@
  */
 package io.syndesis.server.runtime.connector;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -48,8 +49,8 @@ public class ConnectorTemplateITCase extends BaseITCase {
 
     @Configuration
     public static class TestConfiguration {
-        private static final ActionsSummary ACTIONS_SUMMARY = new ActionsSummary.Builder().totalActions(5).putActionCountByTag("foo", 3)
-            .putActionCountByTag("bar", 2).build();
+        private static final List<ActionsSummary> ACTIONS_SUMMARY = Collections.singletonList(new ActionsSummary.Builder().totalActions(5).putActionCountByTag("foo", 3)
+            .putActionCountByTag("bar", 2).build());
 
         private static final ConfigurationProperty PROPERTY_1 = new ConfigurationProperty.Builder().displayName("Property 1").build();
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomConnectorITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomConnectorITCase.java
@@ -19,6 +19,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,8 +76,8 @@ public class CustomConnectorITCase extends BaseITCase {
 
     @Configuration
     public static class TestConfiguration {
-        private static final ActionsSummary ACTIONS_SUMMARY = new ActionsSummary.Builder().totalActions(5).putActionCountByTag("foo", 3)
-            .putActionCountByTag("bar", 2).build();
+        private static final List<ActionsSummary> ACTIONS_SUMMARY = Collections.singletonList(new ActionsSummary.Builder().totalActions(5).putActionCountByTag("foo", 3)
+            .putActionCountByTag("bar", 2).build());
 
         private static final ConfigurationProperty PROPERTY_1 = new ConfigurationProperty.Builder().displayName("Property 1").build();
 

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/connector/CustomSwaggerConnectorITCase.java
@@ -18,6 +18,8 @@ package io.syndesis.server.runtime.connector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
 
 import io.syndesis.common.model.Violation;
 import io.syndesis.common.model.action.ActionsSummary;
@@ -56,9 +58,9 @@ public class CustomSwaggerConnectorITCase extends BaseITCase {
 
     @Configuration
     public static class TestConfiguration {
-        private static final ActionsSummary ACTIONS_SUMMARY = new ActionsSummary.Builder().totalActions(5)
+        private static final List<ActionsSummary> ACTIONS_SUMMARY = Collections.singletonList(new ActionsSummary.Builder().totalActions(5)
             .putActionCountByTag("updating", 1).putActionCountByTag("creating", 1).putActionCountByTag("fetching", 2)
-            .putActionCountByTag("destruction", 1).putActionCountByTag("tasks", 5).build();
+            .putActionCountByTag("destruction", 1).putActionCountByTag("tasks", 5).build());
 
         @Bean(TEMPLATE_ID)
         public ConnectorGenerator swaggerConnectorGenerator() {

--- a/app/ui-react/packages/api/src/useApiConnectorCreator.tsx
+++ b/app/ui-react/packages/api/src/useApiConnectorCreator.tsx
@@ -29,6 +29,7 @@ interface ICreateApiConnectorProps {
   tokenEndpoint?: string;
   username?: string;
   wsdlURL?: string;
+  address?: string;
 }
 
 export function useApiConnectorCreator() {
@@ -46,6 +47,7 @@ export function useApiConnectorCreator() {
               addTimestamp: connector.addTimestamp,
               addUsernameTokenCreated: connector.addUsernameTokenCreated,
               addUsernameTokenNonce: connector.addUsernameTokenNonce,
+              address: connector.address,
               authenticationType: connector.authenticationType,
               authorizationEndpoint: connector.authorizationEndpoint,
               basePath: connector.basePath,

--- a/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
+++ b/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
@@ -53,15 +53,6 @@ export function useApiConnectorSummary(
           url: `${apiContext.apiUri}/connectors/custom/info`,
         });
         const summary = await response.json();
-        if (summary.errorCode) {
-          throw new Error(summary.userMsg);
-        }
-        if (Array.isArray(summary.errors) && summary.errors.length > 0) {
-          const errorMessage = summary.errors
-              .map((e: string | any) => (e.message ? e.message : e))
-              .join('\n');
-          throw new Error(errorMessage);
-        }
         setApiSummary(summary as IApiSummarySoap);
       } catch (e) {
         setError(e as Error);

--- a/app/ui-react/packages/api/src/useApiProviderSummary.tsx
+++ b/app/ui-react/packages/api/src/useApiProviderSummary.tsx
@@ -26,22 +26,6 @@ export function useApiProviderSummary(specification: string) {
           url: `${apiContext.apiUri}/apis/info`,
         });
         const summary = await response.json();
-        if (summary.errorCode) {
-          throw new Error(summary.userMsg);
-        }
-        if (!summary.actionsSummary) {
-          let errorMessage = '';
-          // we should be getting an array of error objects
-          if (Array.isArray(summary.errors)) {
-            errorMessage = summary.errors
-              .map((e: string | any) => (e.message ? e.message : e))
-              .join('\n');
-          } else {
-            // but in case we don't, let's show what we got and hope for the best
-            errorMessage = JSON.stringify(summary);
-          }
-          throw new Error(errorMessage);
-        }
         setApiSummary(summary as APISummary);
       } catch (e) {
         setError(e as Error);

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -12,7 +12,10 @@
       "APISummary": {
         "properties": {
           "actionsSummary": {
-            "$ref": "#/components/schemas/ActionsSummary"
+            "items": {
+              "$ref": "#/components/schemas/ActionsSummary"
+            },
+            "type": "array"
           },
           "configuredProperties": {
             "additionalProperties": {

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorBreadSteps.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorBreadSteps.tsx
@@ -1,11 +1,13 @@
-import { WizardNav, WizardNavItem } from '@patternfly/react-core';
 import * as React from 'react';
+
+import { WizardNav, WizardNavItem } from '@patternfly/react-core';
 
 export interface IApiConnectorCreatorBreadStepsProps {
   /**
    * The one-based active step number.
    */
   step: number;
+  i18nConfiguration: string;
   i18nDetails: string;
   i18nReview: string;
   i18nSecurity: string;
@@ -18,7 +20,14 @@ export interface IApiConnectorCreatorBreadStepsProps {
  * @see [step]{@link IApiConnectorCreatorBreadStepsProps#step}
  */
 export const ApiConnectorCreatorBreadSteps: React.FunctionComponent<IApiConnectorCreatorBreadStepsProps> =
-  ({ i18nDetails, i18nReview, i18nSecurity, i18nSelectMethod, step }) => (
+  ({
+    i18nConfiguration,
+    i18nDetails,
+    i18nReview,
+    i18nSecurity,
+    i18nSelectMethod,
+    step,
+  }) => (
     <WizardNav>
       <WizardNavItem
         step={1}
@@ -36,12 +45,18 @@ export const ApiConnectorCreatorBreadSteps: React.FunctionComponent<IApiConnecto
         step={3}
         isCurrent={step === 3}
         isDisabled={step < 3}
-        content={i18nSecurity}
+        content={i18nConfiguration}
       />
       <WizardNavItem
         step={4}
         isCurrent={step === 4}
         isDisabled={step < 4}
+        content={i18nSecurity}
+      />
+      <WizardNavItem
+        step={5}
+        isCurrent={step === 5}
+        isDisabled={step < 5}
         content={i18nDetails}
       />
     </WizardNav>

--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorService.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorService.tsx
@@ -8,7 +8,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { ButtonLink } from '../../../Layout';
 
 export interface IServiceAndPortTypes {
   value?: string;
@@ -16,8 +15,6 @@ export interface IServiceAndPortTypes {
 }
 
 export interface IApiConnectorCreatorServiceProps {
-  handleNext: (service: string, port: string) => void;
-  i18nBtnNext: string;
   i18nPort: string;
   i18nService: string;
   i18nServicePortTitle?: string;
@@ -28,6 +25,8 @@ export interface IApiConnectorCreatorServiceProps {
   portsAvailable: any[];
   serviceName: string;
   servicesAvailable: string[];
+  onServiceNameChange: (serviceName: string) => void;
+  onPortNameChange: (portName: string) => void;
 }
 
 /**
@@ -38,8 +37,6 @@ export interface IApiConnectorCreatorServiceProps {
  */
 export const ApiConnectorCreatorService: React.FunctionComponent<IApiConnectorCreatorServiceProps> =
   ({
-    handleNext,
-    i18nBtnNext,
     i18nPort,
     i18nService,
     i18nServicePortTitle,
@@ -47,6 +44,8 @@ export const ApiConnectorCreatorService: React.FunctionComponent<IApiConnectorCr
     portsAvailable,
     serviceName,
     servicesAvailable,
+    onServiceNameChange,
+    onPortNameChange,
   }) => {
     const [port, setPort] = React.useState(portName);
     const [portsArray, setPortsArray] = React.useState(
@@ -56,15 +55,16 @@ export const ApiConnectorCreatorService: React.FunctionComponent<IApiConnectorCr
 
     const handleChangeSelectedPort = (params: string) => {
       setPort(params);
+      onPortNameChange(params);
     };
 
     const handleChangeSelectedService = (params: string) => {
       setService(params);
       setPortsArray(portsAvailable[params]);
-    };
-
-    const handleClickNext = () => {
-      handleNext(service, port);
+      onServiceNameChange(params);
+      if (portsAvailable[params].length > 0) {
+        onPortNameChange(portsAvailable[params][0]);
+      }
     };
 
     return (
@@ -113,16 +113,6 @@ export const ApiConnectorCreatorService: React.FunctionComponent<IApiConnectorCr
               </FormGroup>
             </>
           </Form>
-        </StackItem>
-        <StackItem>
-          <ButtonLink
-            id={'button-next'}
-            data-testid={'button-next'}
-            as={'primary'}
-            onClick={handleClickNext}
-          >
-            {i18nBtnNext}
-          </ButtonLink>
         </StackItem>
       </Stack>
     );

--- a/app/ui-react/packages/ui/stories/Customization/api-connector-create/1-ProvideDocument.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/api-connector-create/1-ProvideDocument.stories.tsx
@@ -1,16 +1,18 @@
-import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
-import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import {
-  ApiConnectorCreatorLayout,
-  ApiConnectorCreatorService,
-} from '../../../src';
+
 import {
   ApiConnectorCreatorBreadSteps,
   ApiConnectorCreatorSelectMethod,
   ApiConnectorCreatorToggleList,
 } from '../../../src/Customization/apiClientConnectors/create';
+import {
+  ApiConnectorCreatorLayout,
+  ApiConnectorCreatorService,
+} from '../../../src';
+
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
 
 const stories = storiesOf(
   'Customization/ApiClientConnector/CreateApiConnector/1 - Provide Document',
@@ -64,6 +66,7 @@ stories.add('Provide Document', () => {
       navigation={
         <ApiConnectorCreatorBreadSteps
           step={1}
+          i18nConfiguration={'Additional Configuration'}
           i18nDetails={'Review/Edit Connector Details'}
           i18nReview={'Imported Operations'}
           i18nSecurity={'Specify Security'}

--- a/app/ui-react/packages/ui/stories/Customization/api-connector-create/2-ImportedOperations.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/api-connector-create/2-ImportedOperations.stories.tsx
@@ -1,13 +1,15 @@
-import { boolean } from '@storybook/addon-knobs';
-import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { ApiConnectorCreatorLayout } from '../../../src';
+
 import {
   ApiConnectorCreatorBreadSteps,
   ApiConnectorCreatorFooter,
   ApiConnectorCreatorToggleList,
 } from '../../../src/Customization/apiClientConnectors/create';
+
+import { ApiConnectorCreatorLayout } from '../../../src';
 import { OpenApiReviewActions } from '../../../src/Shared';
+import { boolean } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
 
 const stories = storiesOf(
   'Customization/ApiClientConnector/CreateApiConnector/2 - Imported Operations',
@@ -75,6 +77,7 @@ stories.add('Review Actions', () => {
       navigation={
         <ApiConnectorCreatorBreadSteps
           step={2}
+          i18nConfiguration={'Additional Configuration'}
           i18nDetails={'Review/Edit Connector Details'}
           i18nReview={'Imported Operations'}
           i18nSecurity={'Specify Security'}

--- a/app/ui-react/packages/ui/stories/Customization/api-connector-create/3-Security.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/api-connector-create/3-Security.stories.tsx
@@ -100,6 +100,7 @@ const component = (authenticationType: string) => {
       navigation={
         <ApiConnectorCreatorBreadSteps
           step={3}
+          i18nConfiguration={'Additional Configuration'}
           i18nDetails={'Review/Edit Connector Details'}
           i18nReview={'Imported Operations'}
           i18nSecurity={'Specify Security'}

--- a/app/ui-react/packages/ui/stories/Customization/api-connector-create/4-Details.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Customization/api-connector-create/4-Details.stories.tsx
@@ -1,18 +1,20 @@
-import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
-import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import {
-  ApiConnectorCreatorLayout,
-  ApiConnectorDetailBody,
-} from '../../../src';
+
 import {
   ApiConnectorCreatorBreadSteps,
   ApiConnectorCreatorDetails,
   ApiConnectorCreatorFooter,
   ApiConnectorCreatorToggleList,
 } from '../../../src/Customization/apiClientConnectors/create';
+import {
+  ApiConnectorCreatorLayout,
+  ApiConnectorDetailBody,
+} from '../../../src';
+
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
 import icons from '../../Shared/icons';
+import { storiesOf } from '@storybook/react';
 
 const stories = storiesOf(
   'Customization/ApiClientConnector/CreateApiConnector/4 - Details',
@@ -48,6 +50,7 @@ stories.add('Review/Edit Connector Details', () => {
       navigation={
         <ApiConnectorCreatorBreadSteps
           step={4}
+          i18nConfiguration={'Additional Configuration'}
           i18nDetails={'Review/Edit Connector Details'}
           i18nReview={'Imported Operations'}
           i18nSecurity={'Specify Security'}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/ApiConnectorCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/ApiConnectorCreatorApp.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
+
 import { Route, Switch } from 'react-router';
+
 import { WithClosedNavigation } from '../../shared';
 import { DetailsPage } from './pages/create/DetailsPage';
 import { EditSpecificationPage } from './pages/create/EditSpecificationPage';
 import { ReviewActionsPage } from './pages/create/ReviewActionsPage';
 import { SecurityPage } from './pages/create/SecurityPage';
 import { SelectMethodPage } from './pages/create/SelectMethodPage';
+import { ServicePortPage } from './pages/create/ServicePortPage';
 import routes from './routes';
 
 export const ApiConnectorCreatorApp: React.FunctionComponent = () => {
@@ -28,16 +31,17 @@ export const ApiConnectorCreatorApp: React.FunctionComponent = () => {
           component={EditSpecificationPage}
         />
         <Route
+          path={routes.create.servicePort}
+          exact={true}
+          component={ServicePortPage}
+        />
+        <Route
           path={routes.create.security}
           exact={true}
           component={SecurityPage}
         />
-        <Route
-          path={routes.create.save}
-          exact={true}
-          component={DetailsPage}
-        />
+        <Route path={routes.create.save} exact={true} component={DetailsPage} />
       </Switch>
     </WithClosedNavigation>
   );
-}
+};

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/locales/api-client-connectors-translations.en.json
@@ -9,6 +9,9 @@
   "apiConnectorsPageTitle": "API Client Connectors",
   "basePath": "Base URL",
   "create": {
+    "configuration": {
+      "title": "Additional Configuration"
+    },
     "details": {
       "saveButton": "Create API Connector",
       "successNotification": "API Connector successfully created",

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
@@ -1,6 +1,6 @@
-import { useApiConnectorCreator } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import { IApiSummarySoap } from '@syndesis/models';
+import * as React from 'react';
+
 import {
   ApiConnectorCreatorBreadcrumb,
   ApiConnectorCreatorBreadSteps,
@@ -9,13 +9,15 @@ import {
   ApiConnectorCreatorLayout,
   ApiConnectorCreatorToggleList,
 } from '@syndesis/ui';
+import { ApiConnectorInfoForm, IConnectorValues } from '../../components';
+
+import { useApiConnectorCreator } from '@syndesis/api';
+import { IApiSummarySoap } from '@syndesis/models';
 import { useRouteData } from '@syndesis/utils';
-import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { UIContext } from '../../../../app';
 import { PageTitle } from '../../../../shared';
 import { WithLeaveConfirmation } from '../../../../shared/WithLeaveConfirmation';
-import { ApiConnectorInfoForm, IConnectorValues } from '../../components';
 import { ICreateConnectorProps } from '../../models';
 import resolvers from '../../resolvers';
 import routes from '../../routes';
@@ -53,8 +55,8 @@ export const DetailsPage: React.FunctionComponent = () => {
               ...state.configured,
               ...values,
               connectorTemplateId: state.connectorTemplateId,
-              specification: state.specification.configuredProperties!
-                .specification,
+              specification:
+                state.specification.configuredProperties!.specification,
             });
             actions.setSubmitting(false);
             allowNavigation();
@@ -135,7 +137,10 @@ export const DetailsPage: React.FunctionComponent = () => {
                   }
                   navigation={
                     <ApiConnectorCreatorBreadSteps
-                      step={4}
+                      step={5}
+                      i18nConfiguration={t(
+                        'apiClientConnectors:create:configuration:title'
+                      )}
                       i18nDetails={t(
                         'apiClientConnectors:create:details:title'
                       )}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/DetailsPage.tsx
@@ -34,6 +34,17 @@ export const DetailsPage: React.FunctionComponent = () => {
   const { state, history } = useRouteData<null, IDetailsPageRouteState>();
   const createApiConnector = useApiConnectorCreator();
 
+  const [chosenAddress] = React.useState(() => {
+    const addresses = state.specification.configuredProperties?.addresses;
+    const portName = state.configured?.portName;
+    if (addresses && portName) {
+      const addressesMap = JSON.parse(addresses);
+      return addressesMap[portName];
+    }
+
+    return undefined;
+  });
+
   return (
     <WithLeaveConfirmation
       i18nTitle={t('apiClientConnectors:create:unsavedChangesTitle')}
@@ -96,6 +107,7 @@ export const DetailsPage: React.FunctionComponent = () => {
                 state.specification.properties?.host?.defaultValue
               }
               address={
+                chosenAddress ||
                 state.specification.configuredProperties?.address ||
                 state.specification.properties?.address?.defaultValue
               }

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
@@ -1,5 +1,6 @@
-import { useApiConnectorSummary } from '@syndesis/api';
 import * as H from '@syndesis/history';
+import * as React from 'react';
+
 import {
   ApiConnectorCreatorBreadcrumb,
   ApiConnectorCreatorBreadSteps,
@@ -10,10 +11,11 @@ import {
   PageLoader,
 } from '@syndesis/ui';
 import { useRouteData, WithLoader } from '@syndesis/utils';
-import * as React from 'react';
+import { ApiError, PageTitle } from '../../../../shared';
+
+import { useApiConnectorSummary } from '@syndesis/api';
 import { Translation } from 'react-i18next';
 import { UIContext } from '../../../../app';
-import { ApiError, PageTitle } from '../../../../shared';
 import { WithLeaveConfirmation } from '../../../../shared/WithLeaveConfirmation';
 import { ICreateConnectorProps } from '../../models';
 import resolvers from '../../resolvers';
@@ -48,7 +50,7 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
 
   return (
     <Translation ns={['apiClientConnectors', 'shared']}>
-      {t => (
+      {(t) => (
         <WithLeaveConfirmation
           i18nTitle={t('apiClientConnectors:create:unsavedChangesTitle')}
           i18nConfirmationMessage={t(
@@ -101,7 +103,7 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                         apiProviderDescription={apiSummary!.description}
                         apiProviderName={apiSummary!.name}
                         i18nOperationsHtmlMessage={`<strong>${
-                          apiSummary!.actionsSummary!.totalActions
+                          apiSummary?.actionsSummary?.totalActions || 0
                         }</strong> operations`}
                         i18nWarningsHeading={t(
                           'apiClientConnectors:create:review:sectionWarnings'
@@ -109,7 +111,7 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                         warningMessages={
                           apiSummary!.warnings
                             ? apiSummary!.warnings!.map(
-                                warning => (warning as any).message
+                                (warning) => (warning as any).message
                               )
                             : undefined
                         }
@@ -119,7 +121,10 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                         errorMessages={
                           apiSummary!.errors
                             ? apiSummary!.errors!.map(
-                                (e: any) => `${e.property}: ${e.message}`
+                                (e: any) =>
+                                  `${e.property ? e.property + ': ' : ''} ${
+                                    e.message
+                                  }`
                               )
                             : undefined
                         }
@@ -135,16 +140,28 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                         )}
                         isNextLoading={false}
                         isNextDisabled={!!apiSummary!.errors}
-                        nextHref={resolvers.create.security({
-                          configured: state.configured,
-                          connectorTemplateId: state.connectorTemplateId,
-                          specification: apiSummary!,
-                        })}
+                        nextHref={
+                          state.connectorTemplateId ===
+                          'soap-connector-template'
+                            ? resolvers.create.servicePort({
+                                apiSummary: apiSummary!,
+                                configured: state.configured,
+                                connectorTemplateId: state.connectorTemplateId,
+                                specification: state.specification,
+                              })
+                            : resolvers.create.security({
+                                configured: state.configured,
+                                connectorTemplateId: state.connectorTemplateId,
+                                specification: apiSummary!,
+                              })
+                        }
                         reviewEditHref={
-                          !state.connectorTemplateId
+                          !state.connectorTemplateId &&
+                          apiSummary?.configuredProperties
                             ? resolvers.create.specification({
-                                specification: apiSummary!.configuredProperties!
-                                  .specification,
+                                specification:
+                                  apiSummary!.configuredProperties!
+                                    .specification,
                               })
                             : ''
                         }
@@ -153,6 +170,9 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                     navigation={
                       <ApiConnectorCreatorBreadSteps
                         step={2}
+                        i18nConfiguration={t(
+                          'apiClientConnectors:create:configuration:title'
+                        )}
                         i18nDetails={t(
                           'apiClientConnectors:create:details:title'
                         )}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ReviewActionsPage.tsx
@@ -102,9 +102,16 @@ export const ReviewActionsPage: React.FunctionComponent = () => {
                         )}
                         apiProviderDescription={apiSummary!.description}
                         apiProviderName={apiSummary!.name}
-                        i18nOperationsHtmlMessage={`<strong>${
-                          apiSummary?.actionsSummary?.totalActions || 0
-                        }</strong> operations`}
+                        i18nOperationsHtmlMessage={`<strong>${apiSummary?.actionsSummary?.reduce(
+                          (sum, summary) => sum + (summary.totalActions || 0),
+                          0
+                        )}</strong> operations${
+                          (apiSummary?.actionsSummary?.length || 0) > 1
+                            ? ' in <strong>' +
+                              apiSummary?.actionsSummary?.length +
+                              '</strong> services'
+                            : ''
+                        }`}
                         i18nWarningsHeading={t(
                           'apiClientConnectors:create:review:sectionWarnings'
                         )}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
@@ -38,11 +38,19 @@ export const SecurityPage: React.FunctionComponent = () => {
   const { portName, serviceName, wsdlURL } =
     specification.configuredProperties!;
 
-  const backHref = resolvers.create.review({
-    configured,
-    connectorTemplateId,
-    specification: specification.configuredProperties!.specification,
-  });
+  const backHref =
+    connectorTemplateId === 'soap-connector-template'
+      ? resolvers.create.servicePort({
+          apiSummary: specification,
+          configured,
+          connectorTemplateId,
+          specification: specification.configuredProperties!.specification,
+        })
+      : resolvers.create.review({
+          configured,
+          connectorTemplateId,
+          specification: specification.configuredProperties!.specification,
+        });
 
   const defaultValues: ICreateConnectorProps = {
     authenticationType:
@@ -166,7 +174,10 @@ export const SecurityPage: React.FunctionComponent = () => {
                       }
                       navigation={
                         <ApiConnectorCreatorBreadSteps
-                          step={3}
+                          step={4}
+                          i18nConfiguration={t(
+                            'apiClientConnectors:create:configuration:title'
+                          )}
                           i18nDetails={t(
                             'apiClientConnectors:create:details:title'
                           )}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SecurityPage.tsx
@@ -35,8 +35,7 @@ export const SecurityPage: React.FunctionComponent = () => {
   const { state, history } = useRouteData<null, ISecurityPageRouteState>();
   const { configured, connectorTemplateId, specification } = state;
   const { properties } = specification;
-  const { portName, serviceName, wsdlURL } =
-    specification.configuredProperties!;
+  const { wsdlURL } = specification.configuredProperties!;
 
   const backHref =
     connectorTemplateId === 'soap-connector-template'
@@ -83,8 +82,7 @@ export const SecurityPage: React.FunctionComponent = () => {
       resolvers.create.save({
         configured: {
           ...values,
-          portName,
-          serviceName,
+          ...configured,
           wsdlURL,
         },
         connectorTemplateId,

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
@@ -5,7 +5,6 @@ import {
   ApiConnectorCreatorBreadSteps,
   ApiConnectorCreatorLayout,
   ApiConnectorCreatorSelectMethod,
-  ApiConnectorCreatorService,
   ApiConnectorCreatorToggleList,
   PageLoader,
 } from '@syndesis/ui';
@@ -21,9 +20,8 @@ export const SelectMethodPage: React.FunctionComponent = () => {
   const { history } = useRouteData();
   const [connectorTemplateId, setConnectorTemplateId] = React.useState('');
   const [spec, setSpec] = React.useState('');
-  const [showSoapConfig, setShowSoapConfig] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
-  const { apiSummary, error, loading, setError } = useApiConnectorSummary(
+  const { error, loading, setError } = useApiConnectorSummary(
     spec,
     connectorTemplateId
   );
@@ -33,64 +31,29 @@ export const SelectMethodPage: React.FunctionComponent = () => {
     if (error) {
       uiContext.pushNotification((error as Error).message, 'error');
       setError(false);
-      setShowSoapConfig(false);
       setIsLoading(false);
       setSpec('');
       setConnectorTemplateId('');
     }
   }, [error, uiContext, history, setError]);
 
-  /**
-   * Only use the loader state from useApiConnectorSummary
-   * for the SOAP connector configuration, and not on
-   * initial page load.
-   */
-  React.useEffect(() => {
-    if (showSoapConfig) {
-      setIsLoading(loading);
+  const onNext = (specification: string, connectorTemplate?: string) => {
+    setIsLoading(loading);
+    if (connectorTemplate) {
+      setConnectorTemplateId(connectorTemplate);
     }
-  }, [loading, showSoapConfig]);
-
-  /**
-   * Called on 'Next' from the SOAP service & port selection form
-   */
-  const onServiceConfigured = (service: string, port: string) => {
-    const availablePorts = JSON.parse(apiSummary!.configuredProperties!.ports);
-    const availableServices = JSON.parse(
-      apiSummary!.configuredProperties!.services
-    );
-    const firstSvc = port || availableServices[0];
-    const firstPort = port || availablePorts[firstSvc][0];
-
+    setSpec(specification);
     history.push(
       resolvers.create.review({
-        configured: {
-          portName: port || firstPort,
-          serviceName: service || firstSvc,
-          wsdlURL: apiSummary!.configuredProperties!.wsdlURL,
-        },
-        connectorTemplateId,
-        specification: spec,
+        connectorTemplateId: connectorTemplate,
+        specification,
       })
     );
   };
 
-  const onNext = (specification: string, connectorTemplate?: string) => {
-    setIsLoading(loading);
-
-    if (!connectorTemplate) {
-      setIsLoading(false);
-      history.push(resolvers.create.review({ specification }));
-    } else {
-      setSpec(specification);
-      setConnectorTemplateId(connectorTemplate);
-      setShowSoapConfig(true);
-    }
-  };
-
   return (
     <Translation ns={['apiClientConnectors', 'shared']}>
-      {t => (
+      {(t) => (
         <>
           <PageTitle
             title={t('apiClientConnectors:create:selectMethod:title')}
@@ -111,73 +74,48 @@ export const SelectMethodPage: React.FunctionComponent = () => {
             {() => (
               <ApiConnectorCreatorLayout
                 content={
-                  <>
-                    {!showSoapConfig && (
-                      <ApiConnectorCreatorSelectMethod
-                        disableDropzone={false}
-                        fileExtensions={t(
-                          'apiClientConnectors:create:selectMethod:dndFileExtensions'
-                        )}
-                        i18nBtnNext={t('shared:Next')}
-                        i18nHelpMessage={t(
-                          'apiClientConnectors:create:selectMethod:dndHelpMessage'
-                        )}
-                        i18nInstructions={t(
-                          'apiClientConnectors:create:selectMethod:dndInstructions'
-                        )}
-                        i18nNoFileSelectedMessage={t(
-                          'apiClientConnectors:create:selectMethod:dndNoFileSelectedLabel'
-                        )}
-                        i18nSelectedFileLabel={t(
-                          'apiClientConnectors:create:selectMethod:dndSelectedFileLabel'
-                        )}
-                        i18nUploadFailedMessage={t(
-                          'apiClientConnectors:create:selectMethod:dndUploadFailedMessage'
-                        )}
-                        i18nUploadSuccessMessage={t(
-                          'apiClientConnectors:create:selectMethod:dndUploadSuccessMessage'
-                        )}
-                        i18nMethodFromFile={t(
-                          'apiClientConnectors:create:selectMethod:methodFromFile'
-                        )}
-                        i18nMethodFromUrl={t(
-                          'apiClientConnectors:create:selectMethod:methodFromUrl'
-                        )}
-                        i18nUrlNote={t(
-                          'apiClientConnectors:create:selectMethod:urlNote'
-                        )}
-                        onNext={onNext}
-                      />
+                  <ApiConnectorCreatorSelectMethod
+                    disableDropzone={false}
+                    fileExtensions={t(
+                      'apiClientConnectors:create:selectMethod:dndFileExtensions'
                     )}
-                    {/* Where users can specify a SOAP service and port if connector is WSDL file */}
-                    {showSoapConfig && apiSummary && (
-                      <ApiConnectorCreatorService
-                        handleNext={onServiceConfigured}
-                        i18nBtnNext={t('shared:Next')}
-                        i18nPort={t('apiClientConnectors:create:soap:port')}
-                        i18nService={t(
-                          'apiClientConnectors:create:soap:service'
-                        )}
-                        i18nServicePortTitle={t(
-                          'apiClientConnectors:create:soap:servicePortTitle'
-                        )}
-                        portName={apiSummary!.configuredProperties!.portName}
-                        portsAvailable={JSON.parse(
-                          apiSummary!.configuredProperties!.ports
-                        )}
-                        serviceName={
-                          apiSummary!.configuredProperties!.serviceName
-                        }
-                        servicesAvailable={JSON.parse(
-                          apiSummary!.configuredProperties!.services
-                        )}
-                      />
+                    i18nBtnNext={t('shared:Next')}
+                    i18nHelpMessage={t(
+                      'apiClientConnectors:create:selectMethod:dndHelpMessage'
                     )}
-                  </>
+                    i18nInstructions={t(
+                      'apiClientConnectors:create:selectMethod:dndInstructions'
+                    )}
+                    i18nNoFileSelectedMessage={t(
+                      'apiClientConnectors:create:selectMethod:dndNoFileSelectedLabel'
+                    )}
+                    i18nSelectedFileLabel={t(
+                      'apiClientConnectors:create:selectMethod:dndSelectedFileLabel'
+                    )}
+                    i18nUploadFailedMessage={t(
+                      'apiClientConnectors:create:selectMethod:dndUploadFailedMessage'
+                    )}
+                    i18nUploadSuccessMessage={t(
+                      'apiClientConnectors:create:selectMethod:dndUploadSuccessMessage'
+                    )}
+                    i18nMethodFromFile={t(
+                      'apiClientConnectors:create:selectMethod:methodFromFile'
+                    )}
+                    i18nMethodFromUrl={t(
+                      'apiClientConnectors:create:selectMethod:methodFromUrl'
+                    )}
+                    i18nUrlNote={t(
+                      'apiClientConnectors:create:selectMethod:urlNote'
+                    )}
+                    onNext={onNext}
+                  />
                 }
                 navigation={
                   <ApiConnectorCreatorBreadSteps
                     step={1}
+                    i18nConfiguration={t(
+                      'apiClientConnectors:create:configuration:title'
+                    )}
                     i18nDetails={t('apiClientConnectors:create:details:title')}
                     i18nReview={t('apiClientConnectors:create:review:title')}
                     i18nSecurity={t(

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ServicePortPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ServicePortPage.tsx
@@ -1,0 +1,170 @@
+import * as H from '@syndesis/history';
+import * as React from 'react';
+
+import {
+  ApiConnectorCreatorBreadcrumb,
+  ApiConnectorCreatorBreadSteps,
+  ApiConnectorCreatorFooter,
+  ApiConnectorCreatorLayout,
+  ApiConnectorCreatorService,
+  ApiConnectorCreatorToggleList,
+} from '@syndesis/ui';
+
+import { IApiSummarySoap } from '@syndesis/models';
+import { useRouteData } from '@syndesis/utils';
+import { Translation } from 'react-i18next';
+import { PageTitle } from '../../../../shared';
+import { WithLeaveConfirmation } from '../../../../shared/WithLeaveConfirmation';
+import { ICreateConnectorProps } from '../../models';
+import resolvers from '../../resolvers';
+import routes from '../../routes';
+
+export interface IServicePortRouteState {
+  apiSummary: IApiSummarySoap;
+  connectorTemplateId?: string;
+  configured?: ICreateConnectorProps;
+  specification: string;
+}
+
+export const ServicePortPage: React.FunctionComponent = () => {
+  const { history } = useRouteData();
+  const { state } = useRouteData<null, IServicePortRouteState>();
+  const { apiSummary, connectorTemplateId, configured, specification } = state;
+
+  /**
+   * Called on 'Next' from the SOAP service & port selection form
+   */
+  const onServiceConfigured = (service: string, port: string) => {
+    const availablePorts = JSON.parse(apiSummary!.configuredProperties!.ports);
+    const availableServices = JSON.parse(
+      apiSummary!.configuredProperties!.services
+    );
+    const firstSvc = port || availableServices[0];
+    const firstPort = port || availablePorts[firstSvc][0];
+
+    history.push(
+      resolvers.create.review({
+        configured: {
+          portName: port || firstPort,
+          serviceName: service || firstSvc,
+          wsdlURL: apiSummary!.configuredProperties!.wsdlURL,
+        },
+        connectorTemplateId,
+        specification,
+      })
+    );
+  };
+
+  return (
+    <Translation ns={['apiClientConnectors', 'shared']}>
+      {(t) => (
+        <WithLeaveConfirmation
+          i18nTitle={t('apiClientConnectors:create:unsavedChangesTitle')}
+          i18nConfirmationMessage={t(
+            'apiClientConnectors:create:unsavedChangesMessage'
+          )}
+          shouldDisplayDialog={(location: H.LocationDescriptor) => {
+            const url =
+              typeof location === 'string' ? location : location.pathname!;
+            return !url.startsWith(routes.create.root);
+          }}
+        >
+          {() => (
+            <>
+              <PageTitle title={'TODO'} />
+              <ApiConnectorCreatorBreadcrumb
+                cancelHref={resolvers.list()}
+                connectorsHref={resolvers.list()}
+                i18nCancel={t('shared:Cancel')}
+                i18nConnectors={t('apiClientConnectors:apiConnectorsPageTitle')}
+                i18nCreateConnection={t(
+                  'apiClientConnectors:CreateApiConnector'
+                )}
+              />
+              <ApiConnectorCreatorLayout
+                content={
+                  <ApiConnectorCreatorService
+                    handleNext={onServiceConfigured}
+                    i18nBtnNext={t('shared:Next')}
+                    i18nPort={t('apiClientConnectors:create:soap:port')}
+                    i18nService={t('apiClientConnectors:create:soap:service')}
+                    i18nServicePortTitle={t(
+                      'apiClientConnectors:create:soap:servicePortTitle'
+                    )}
+                    portName={apiSummary!.configuredProperties!.portName}
+                    portsAvailable={JSON.parse(
+                      apiSummary!.configuredProperties!.ports
+                    )}
+                    serviceName={apiSummary!.configuredProperties!.serviceName}
+                    servicesAvailable={JSON.parse(
+                      apiSummary!.configuredProperties!.services
+                    )}
+                  />
+                }
+                footer={
+                  <ApiConnectorCreatorFooter
+                    backHref={resolvers.create.review({
+                      configured,
+                      connectorTemplateId,
+                      specification,
+                    })}
+                    i18nBack={t('shared:Back')}
+                    i18nNext={t('shared:Next')}
+                    i18nReviewEdit={t(
+                      'apiClientConnectors:create:review:btnReviewEdit'
+                    )}
+                    isNextLoading={false}
+                    isNextDisabled={!!apiSummary!.errors}
+                    nextHref={resolvers.create.security({
+                      configured: state.configured,
+                      connectorTemplateId: state.connectorTemplateId,
+                      specification: apiSummary!,
+                    })}
+                    reviewEditHref={
+                      !state.connectorTemplateId &&
+                      apiSummary?.configuredProperties
+                        ? resolvers.create.specification({
+                            specification:
+                              apiSummary!.configuredProperties!.specification,
+                          })
+                        : ''
+                    }
+                  />
+                }
+                navigation={
+                  <ApiConnectorCreatorBreadSteps
+                    step={3}
+                    i18nConfiguration={t(
+                      'apiClientConnectors:create:configuration:title'
+                    )}
+                    i18nDetails={t('apiClientConnectors:create:details:title')}
+                    i18nReview={t('apiClientConnectors:create:review:title')}
+                    i18nSecurity={t(
+                      'apiClientConnectors:create:security:title'
+                    )}
+                    i18nSelectMethod={t(
+                      'apiClientConnectors:create:selectMethod:title'
+                    )}
+                  />
+                }
+                toggle={
+                  <ApiConnectorCreatorToggleList
+                    step={1}
+                    i18nDetails={t('apiClientConnectors:create:details:title')}
+                    i18nReview={t('apiClientConnectors:create:review:title')}
+                    i18nSecurity={t(
+                      'apiClientConnectors:create:security:title'
+                    )}
+                    i18nSelectMethod={t(
+                      'apiClientConnectors:create:selectMethod:title'
+                    )}
+                  />
+                }
+              />
+            </>
+          )}
+        </WithLeaveConfirmation>
+      )}
+    </Translation>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ServicePortPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/ServicePortPage.tsx
@@ -27,33 +27,15 @@ export interface IServicePortRouteState {
 }
 
 export const ServicePortPage: React.FunctionComponent = () => {
-  const { history } = useRouteData();
   const { state } = useRouteData<null, IServicePortRouteState>();
   const { apiSummary, connectorTemplateId, configured, specification } = state;
 
-  /**
-   * Called on 'Next' from the SOAP service & port selection form
-   */
-  const onServiceConfigured = (service: string, port: string) => {
-    const availablePorts = JSON.parse(apiSummary!.configuredProperties!.ports);
-    const availableServices = JSON.parse(
-      apiSummary!.configuredProperties!.services
-    );
-    const firstSvc = port || availableServices[0];
-    const firstPort = port || availablePorts[firstSvc][0];
-
-    history.push(
-      resolvers.create.review({
-        configured: {
-          portName: port || firstPort,
-          serviceName: service || firstSvc,
-          wsdlURL: apiSummary!.configuredProperties!.wsdlURL,
-        },
-        connectorTemplateId,
-        specification,
-      })
-    );
-  };
+  const [serviceName, setServiceName] = React.useState(
+    configured?.serviceName || apiSummary!.configuredProperties!.serviceName
+  );
+  const [portName, setPortName] = React.useState(
+    configured?.portName || apiSummary!.configuredProperties!.portName
+  );
 
   return (
     <Translation ns={['apiClientConnectors', 'shared']}>
@@ -84,21 +66,21 @@ export const ServicePortPage: React.FunctionComponent = () => {
               <ApiConnectorCreatorLayout
                 content={
                   <ApiConnectorCreatorService
-                    handleNext={onServiceConfigured}
-                    i18nBtnNext={t('shared:Next')}
                     i18nPort={t('apiClientConnectors:create:soap:port')}
                     i18nService={t('apiClientConnectors:create:soap:service')}
                     i18nServicePortTitle={t(
                       'apiClientConnectors:create:soap:servicePortTitle'
                     )}
-                    portName={apiSummary!.configuredProperties!.portName}
+                    portName={portName}
                     portsAvailable={JSON.parse(
                       apiSummary!.configuredProperties!.ports
                     )}
-                    serviceName={apiSummary!.configuredProperties!.serviceName}
+                    serviceName={serviceName}
                     servicesAvailable={JSON.parse(
                       apiSummary!.configuredProperties!.services
                     )}
+                    onServiceNameChange={setServiceName}
+                    onPortNameChange={setPortName}
                   />
                 }
                 footer={
@@ -116,7 +98,11 @@ export const ServicePortPage: React.FunctionComponent = () => {
                     isNextLoading={false}
                     isNextDisabled={!!apiSummary!.errors}
                     nextHref={resolvers.create.security({
-                      configured: state.configured,
+                      configured: {
+                        ...state.configured,
+                        portName,
+                        serviceName,
+                      },
                       connectorTemplateId: state.connectorTemplateId,
                       specification: apiSummary!,
                     })}

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/resolvers.ts
@@ -1,10 +1,12 @@
+import { makeResolver, makeResolverNoParams } from '@syndesis/utils';
+
 /* tslint:disable:object-literal-sort-keys no-empty-interface */
 import { Connector } from '@syndesis/models';
-import { makeResolver, makeResolverNoParams } from '@syndesis/utils';
 import { IDetailsPageRouteState } from './pages/create/DetailsPage';
 import { IEditSpecificationRouteState } from './pages/create/EditSpecificationPage';
 import { IReviewActionsRouteState } from './pages/create/ReviewActionsPage';
 import { ISecurityPageRouteState } from './pages/create/SecurityPage';
+import { IServicePortRouteState } from './pages/create/ServicePortPage';
 import routes from './routes';
 
 export default {
@@ -57,6 +59,21 @@ export default {
         specification,
       },
     })),
+    servicePort: makeResolver<
+      IServicePortRouteState,
+      null,
+      IServicePortRouteState
+    >(
+      routes.create.servicePort,
+      ({ apiSummary, connectorTemplateId, configured, specification }) => ({
+        state: {
+          apiSummary,
+          configured,
+          connectorTemplateId,
+          specification,
+        },
+      })
+    ),
     security: makeResolver<
       ISecurityPageRouteState,
       null,

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/routes.ts
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/routes.ts
@@ -10,6 +10,7 @@ export default include('/api-connector', {
     root: '',
     save: 'save',
     security: 'security',
+    servicePort: 'servicePort',
     specification: 'specification',
     upload: 'upload',
   }),

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
@@ -45,156 +45,168 @@ export interface IReviewActionsPageProps extends IPageWithEditorBreadcrumb {
  * extracted from the API specification previously created or provided
  * earlier in the API Provider editor.
  */
-export const ReviewActionsPage: React.FunctionComponent<
-  IReviewActionsPageProps
-> = ({ cancelHref, editHref, nextHref, getBreadcrumb }) => {
-  const uiContext = React.useContext(UIContext);
-  const [errorAlert, setErrorAlert] = React.useState<ErrorResponse | undefined>(
-    undefined
-  );
-  const [nextDisabled, setNextDisabled] = React.useState(false);
-  const { params, state, history } = useRouteData<
-    IBaseApiProviderRouteParams,
-    IApiProviderReviewActionsRouteState
-  >();
-  const { apiSummary, loading, error } = useApiProviderSummary(
-    state.specification
-  );
-  const getIntegration = useApiProviderIntegration();
+export const ReviewActionsPage: React.FunctionComponent<IReviewActionsPageProps> =
+  ({ cancelHref, editHref, nextHref, getBreadcrumb }) => {
+    const uiContext = React.useContext(UIContext);
+    const [errorAlert, setErrorAlert] = React.useState<
+      ErrorResponse | undefined
+    >(undefined);
+    const [nextDisabled, setNextDisabled] = React.useState(false);
+    const { params, state, history } = useRouteData<
+      IBaseApiProviderRouteParams,
+      IApiProviderReviewActionsRouteState
+    >();
+    const { apiSummary, loading, error } = useApiProviderSummary(
+      state.specification
+    );
+    const getIntegration = useApiProviderIntegration();
 
-  const onNext = async () => {
-    setErrorAlert(undefined);
-    setNextDisabled(true);
-    try {
-      const integration = await getIntegration(
-        apiSummary!.configuredProperties!.specification,
-        state.integration
-      );
-      integration.id = state.integration.id;
-      integration.name = '';
-      history.push(nextHref(integration, params, state));
-    } catch (e) {
-      setErrorAlert(e as ErrorResponse);
-    }
-    setNextDisabled(false);
+    const onNext = async () => {
+      setErrorAlert(undefined);
+      setNextDisabled(true);
+      try {
+        const integration = await getIntegration(
+          apiSummary!.configuredProperties!.specification,
+          state.integration
+        );
+        integration.id = state.integration.id;
+        integration.name = '';
+        history.push(nextHref(integration, params, state));
+      } catch (e) {
+        setErrorAlert(e as ErrorResponse);
+      }
+      setNextDisabled(false);
+    };
+
+    React.useEffect(() => {
+      if (error) {
+        uiContext.pushNotification((error as Error).message, 'error');
+        history.push(cancelHref(params, state) as H.LocationDescriptorObject);
+      }
+    }, [error, uiContext, history, cancelHref, params, state]);
+
+    return (
+      <Translation ns={['integrations', 'shared']}>
+        {(t) => (
+          <>
+            <PageTitle
+              title={t('integrations:apiProvider:reviewActions:title')}
+            />
+            <IntegrationEditorLayout
+              title={t('integrations:apiProvider:reviewActions:title')}
+              description={t(
+                'integrations:apiProvider:reviewActions:description'
+              )}
+              toolbar={getBreadcrumb(
+                t('integrations:apiProvider:reviewActions:title'),
+                params,
+                state
+              )}
+              content={
+                <PageSection>
+                  <WithLoader
+                    loading={loading}
+                    loaderChildren={<PageLoader />}
+                    error={error !== false}
+                    errorChildren={<ApiError error={error as Error} />}
+                  >
+                    {() => (
+                      <>
+                        <OpenApiReviewActions
+                          i18nApiDefinitionHeading={t(
+                            'integrations:apiProvider:reviewActions:sectionApiDefinition'
+                          )}
+                          i18nDescriptionLabel={t(
+                            'integrations:apiProvider:reviewActions:descriptionLabel'
+                          )}
+                          i18nImportedHeading={t(
+                            'integrations:apiProvider:reviewActions:sectionImported'
+                          )}
+                          i18nNameLabel={t(
+                            'integrations:apiProvider:reviewActions:nameLabel'
+                          )}
+                          alert={
+                            errorAlert && (
+                              <SyndesisAlert
+                                level={SyndesisAlertLevel.WARN}
+                                message={errorAlert!.userMsg}
+                                detail={errorAlert!.developerMsg}
+                                i18nTextExpanded={t('shared:HideDetails')}
+                                i18nTextCollapsed={t('shared:ShowDetails')}
+                              />
+                            )
+                          }
+                          apiProviderDescription={
+                            apiSummary?.description || '?'
+                          }
+                          apiProviderName={apiSummary?.name || '?'}
+                          i18nOperationsHtmlMessage={`<strong>${apiSummary?.actionsSummary?.reduce(
+                            (sum, summary) => sum + (summary.totalActions || 0),
+                            0
+                          )}</strong> operations${
+                            (apiSummary?.actionsSummary?.length || 0) > 1
+                              ? ' in <strong>' +
+                                apiSummary?.actionsSummary?.length +
+                                '</strong> services'
+                              : ''
+                          }`}
+                          i18nWarningsHeading={t(
+                            'integrations:apiProvider:reviewActions:sectionWarnings'
+                          )}
+                          warningMessages={
+                            apiSummary?.warnings
+                              ? apiSummary!.warnings.map(
+                                  (warning) => (warning as any).message
+                                )
+                              : undefined
+                          }
+                          i18nErrorsHeading={t(
+                            'integrations:apiProvider:reviewActions:sectionErrors'
+                          )}
+                          errorMessages={
+                            apiSummary?.errors
+                              ? apiSummary!.errors.map(
+                                  (e: any) =>
+                                    `${e.property ? e.property + ': ' : ''}${
+                                      e.message
+                                    }`
+                                )
+                              : undefined
+                          }
+                          actions={
+                            <div>
+                              <ButtonLink
+                                href={editHref(params, {
+                                  ...state,
+                                  specification:
+                                    apiSummary?.configuredProperties
+                                      ?.specification || state.specification,
+                                })}
+                              >
+                                {t(
+                                  'integrations:apiProvider:reviewActions:btnReviewEdit'
+                                )}
+                              </ButtonLink>
+                              <ButtonLink
+                                onClick={onNext}
+                                disabled={nextDisabled || apiSummary!.errors}
+                                as={'primary'}
+                                style={{ marginLeft: '10px' }}
+                              >
+                                {t('shared:Next')}
+                              </ButtonLink>
+                            </div>
+                          }
+                        />
+                      </>
+                    )}
+                  </WithLoader>
+                </PageSection>
+              }
+              cancelHref={cancelHref(params, state)}
+            />
+          </>
+        )}
+      </Translation>
+    );
   };
-
-  React.useEffect(() => {
-    if (error) {
-      uiContext.pushNotification((error as Error).message, 'error');
-      history.push(cancelHref(params, state) as H.LocationDescriptorObject);
-    }
-  }, [error, uiContext, history, cancelHref, params, state]);
-
-  return (
-    <Translation ns={['integrations', 'shared']}>
-      {t => (
-        <>
-          <PageTitle
-            title={t('integrations:apiProvider:reviewActions:title')}
-          />
-          <IntegrationEditorLayout
-            title={t('integrations:apiProvider:reviewActions:title')}
-            description={t(
-              'integrations:apiProvider:reviewActions:description'
-            )}
-            toolbar={getBreadcrumb(
-              t('integrations:apiProvider:reviewActions:title'),
-              params,
-              state
-            )}
-            content={
-              <PageSection>
-                <WithLoader
-                  loading={loading}
-                  loaderChildren={<PageLoader />}
-                  error={error !== false}
-                  errorChildren={<ApiError error={error as Error} />}
-                >
-                  {() => (
-                    <>
-                      <OpenApiReviewActions
-                        i18nApiDefinitionHeading={t(
-                          'integrations:apiProvider:reviewActions:sectionApiDefinition'
-                        )}
-                        i18nDescriptionLabel={t(
-                          'integrations:apiProvider:reviewActions:descriptionLabel'
-                        )}
-                        i18nImportedHeading={t(
-                          'integrations:apiProvider:reviewActions:sectionImported'
-                        )}
-                        i18nNameLabel={t(
-                          'integrations:apiProvider:reviewActions:nameLabel'
-                        )}
-                        alert={
-                          errorAlert && (
-                            <SyndesisAlert
-                              level={SyndesisAlertLevel.WARN}
-                              message={errorAlert!.userMsg}
-                              detail={errorAlert!.developerMsg}
-                              i18nTextExpanded={t('shared:HideDetails')}
-                              i18nTextCollapsed={t('shared:ShowDetails')}
-                            />
-                          )
-                        }
-                        apiProviderDescription={apiSummary!.description}
-                        apiProviderName={apiSummary!.name}
-                        i18nOperationsHtmlMessage={`${
-                          apiSummary!.actionsSummary!.totalActions
-                        } operations`}
-                        i18nWarningsHeading={t(
-                          'integrations:apiProvider:reviewActions:sectionWarnings'
-                        )}
-                        warningMessages={
-                          apiSummary!.warnings
-                            ? apiSummary!.warnings.map(
-                                warning => (warning as any).message
-                              )
-                            : undefined
-                        }
-                        i18nErrorsHeading={t(
-                          'integrations:apiProvider:reviewActions:sectionErrors'
-                        )}
-                        errorMessages={
-                          apiSummary!.errors
-                            ? apiSummary!.errors.map(
-                                (e: any) => `${e.property}: ${e.message}`
-                              )
-                            : undefined
-                        }
-                        actions={
-                          <div>
-                            <ButtonLink
-                              href={editHref(params, {
-                                ...state,
-                                specification: apiSummary!.configuredProperties!
-                                  .specification,
-                              })}
-                            >
-                              {t(
-                                'integrations:apiProvider:reviewActions:btnReviewEdit'
-                              )}
-                            </ButtonLink>
-                            <ButtonLink
-                              onClick={onNext}
-                              disabled={nextDisabled || apiSummary!.errors}
-                              as={'primary'}
-                              style={{ marginLeft: '10px' }}
-                            >
-                              {t('shared:Next')}
-                            </ButtonLink>
-                          </div>
-                        }
-                      />
-                    </>
-                  )}
-                </WithLoader>
-              </PageSection>
-            }
-            cancelHref={cancelHref(params, state)}
-          />
-        </>
-      )}
-    </Translation>
-  );
-};


### PR DESCRIPTION
We used to have two screens on the "Imported Operations" step, akka
review step of the custom API client wizard. That caused issues with
error handling: the screen to specify service and port would throw an
`Error` if the provided WSDL file cannot be parsed. So in #9633 instead
of reaching this screen a notification would appear indicating of this
error situation. Unfortunately, this also changed the flow for the
OpenAPI. So when an error was generated editing the successfully parsed
OpenAPI document we would render the first screen (upload) of the wizard
and show the error notification. And in process loose any changes user
has made to the document.

This instead adds an additional step in the wizard "Additional
Configuration" to specify service/port for WSDL documents, and is
skipped for OpenAPI documents, also changing the order of the
"Imported Operations" (review) screen, so that it precedes this new
screen. This way we won't `Error`-out in trying to access nonexistent
data, as it could not be parsed.

Ref. https://issues.redhat.com/browse/ENTESB-16902