### PR TITLE
fix(ui): don't revert to upload on OpenAPI error

### DIFF
--- a/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
+++ b/app/ui-react/packages/api/src/useApiConnectorSummary.tsx
@@ -56,7 +56,7 @@ export function useApiConnectorSummary(
         if (summary.errorCode) {
           throw new Error(summary.userMsg);
         }
-        if (Array.isArray(summary.errors) && summary.errors.length > 0) {
+        if (connectorTemplateId === 'soap-connector-template' && Array.isArray(summary.errors) && summary.errors.length > 0) {
           const errorMessage = summary.errors
               .map((e: string | any) => (e.message ? e.message : e))
               .join('\n');


### PR DESCRIPTION
When an error is introduced in editing an OpenAPI document we would
revert to the upload screen, this is because in #9633 we introduced
better error handling for the custom SOAP client connectors, where we
needed to prevent reaching the review screen for unparsable WSDL files.

The error handling for both OpenAPI and SOAP custom client connectors
is shared and the intent in #9633 was not to allow reaching the review
screen unless the given document (WSDL, OpenAPI) can be parsed.

Recoverable parse errors can be introduced by editing the OpenAPI
document on the review screen, and in that case the common error handler
would revert to the upload screen, loosing any edits made by the user.

Since the review screen will not error-out for OpenAPI documents, only
for WSDL documents. So this changes the point of raising the `Error` so
errors are raised only for SOAP custom connectors. Thus preventing
reaching the review screen for SOAP connectors.

Ref. https://issues.redhat.com/browse/ENTESB-16902