### PR TITLE
refactor(server): simplify test

### DIFF
--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
@@ -131,7 +131,7 @@ public class ConnectorHandlerTest {
 
             final Response response = handler.getConnectorIcon("connector-id").get();
 
-            assertThat(response.getStatusInfo()).as("Wrong status code").isEqualTo(Response.Status.OK);
+            assertThat(response.getStatusInfo().getStatusCode()).as("Wrong status code").isEqualTo(Response.Status.OK.getStatusCode());
             assertThat(response.getHeaderString(CONTENT_TYPE)).as("Wrong content type").isEqualTo("image/png");
             assertThat(response.getHeaderString(CONTENT_LENGTH)).as("Wrong content length").isEqualTo("2018");
 


### PR DESCRIPTION
This test is a bit flaky, at least when run with Infinitest it fails
intermittently. The underlying issue could be that the `equals` method
on `StatusInfo` is not properly implemented. This tests against the
status code (an `int`) instead and seems to fix the issue.