### PR TITLE
fix(build): make sure `unpack` is not skipped

### DIFF
--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -275,6 +275,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
+              <skip>false</skip>
               <artifactItems>
                 <artifactItem>
                   <!-- uncompresses prettier to target/prettier-plugin-sort-json/prettier so that the JSON plugin sort can require it -->


### PR DESCRIPTION
Using the `dependency-maven-plugin` we unpack an additional prettier
plugin to sort JSON files while formatting. The execution of the
`unpack` goal would be skipped when building with the `flash` profile,
and we need it to run in all cases for the formatting using prettier to
work. So this sets `<skip>false</skip>` in the plugin's configuration.