### PR TITLE
fix(tool): fix operator download with specific tag (1.12.x)

### DIFF
--- a/tools/bin/commands/util/operator_funcs
+++ b/tools/bin/commands/util/operator_funcs
@@ -89,17 +89,19 @@ download_operator_binary() {
     esac
 
     if [[ "${pattern}" != "unknown" ]]; then
-        release_uri="https://api.github.com/repos/syndesisio/syndesis/releases?per_page=4"
         release_tag="$(readopt --tag)"
-
-        if [[ -n "$release_tag" ]]; then
-            release_uri="https://api.github.com/repos/syndesisio/syndesis/releases/tags/${release_tag}"
-        fi
-
         asset_name="${OPERATOR}-${pattern}"
-        url=$(curl -s $release_uri \
-            | jq -r '.[]| select(.tag_name |startswith("2.")|not)| .assets[] | select(.name |startswith("'"${asset_name}"'"))| .browser_download_url' \
-            | head -1)
+
+        local url
+        if [[ -n "$release_tag" ]]; then
+            url=$(curl -s "https://api.github.com/repos/syndesisio/syndesis/releases/tags/${release_tag}" \
+                | jq -r 'select(.tag_name |startswith("2.")|not)| .assets[] | select(.name |startswith("'"${asset_name}"'"))| .browser_download_url' \
+                | head -1)
+        else
+            url=$(curl -s "https://api.github.com/repos/syndesisio/syndesis/releases?per_page=4" \
+                | jq -r '.[]| select(.tag_name |startswith("2.")|not)| .assets[] | select(.name |startswith("'"${asset_name}"'"))| .browser_download_url' \
+                | head -1)
+        fi
 
         #
         # Check curl returns a valid url


### PR DESCRIPTION
When the specific release is fetched from GitHub API the result is not
an array but a single object, so parsing that JSON with `jq` must not
read it as an array.

(cherry picked from commit fabc63b)