### PR TITLE
fix(tools): include name of the registry

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -446,7 +446,7 @@ push_container_images_to_registry() {
     local release_version=$2
     local moving_tag=$3
 
-    echo "==== Pushing to Docker Hub"
+    echo "==== Pushing to ${registry}"
     for module in $ALL_IMAGE_MODULES; do
         local image="syndesis/syndesis-$module"
         docker tag "$image:$release_version" "$registry/$image:$release_version"


### PR DESCRIPTION
We push to both Docker Hub and Quay.io, let's reflect that in the output.