### PR TITLE
fix: soap connector actions missing in info

### DIFF
--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -138,9 +138,10 @@ public final class SoapApiModelParser {
             builder.model(definition);
             validateModel(definition, builder);
 
-            // set default service, port and address if present
+            // set default service, port and address to the first service, port and address in the WSDL
+            // otherwise we don't generate any action summary
             final SoapApiModelInfo localBuild = builder.build();
-            if (localBuild.getServices().size() == 1) {
+            if (localBuild.getServices().size() > 1) {
 
                 final QName defaultService = localBuild.getServices().get(0);
                 builder.defaultService(defaultService);


### PR DESCRIPTION
If a WSDL file contains more than one service the amount of imported
actions is 0. This changes the condition so that the action info is
generated for the first service if at least one service exists. This is
not 100% accurate but it's better than not displaying 0 actions
imported.