### PR TITLE
chore(deps): bump openapi-generator-maven-plugin in /app/server/runtime

### DIFF
--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -363,7 +363,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>4.2.2</version>
+        <version>5.1.0</version>
         <executions>
           <execution>
             <id>internal-api-asciidoc</id>


### PR DESCRIPTION
Bumps openapi-generator-maven-plugin from 4.2.2 to 5.1.0.

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 626a71f86ff92a1109df8aa9883cd2f8f15cc86d)