### PR TITLE
fix(build): connection reset on downloads

### DIFF
--- a/app/.mvn/jvm.config
+++ b/app/.mvn/jvm.config
@@ -1,1 +1,7 @@
--Xmx1024m -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseStringDeduplication
+-Xmx1024m
+-Djava.awt.headless=true
+-XX:+UseG1GC
+-XX:+UseStringDeduplication
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10

--- a/app/.mvn/maven.config
+++ b/app/.mvn/maven.config
@@ -1,6 +1,3 @@
 -Dmaven.artifact.threads=8
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
--Dmaven.wagon.http.retryHandler.requestSentEnabled=true
--Dmaven.wagon.http.retryHandler.count=10
 -Dsurefire.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt
 -Dfailsafe.excludesFile=${maven.multiModuleProjectDirectory}/excluded_tests.txt


### PR DESCRIPTION
Seems like the issue still remains[1] with the connection reset when
Maven Wagon downloads the dependencies. This moves the configuration
to `jvm.config`, seems that other[2] projects are doing the same; and
changes the TTL to 30 (from 120).

[1] https://github.com/syndesisio/syndesis/runs/3073457608
[2] https://github.com/GoogleContainerTools/skaffold/blob/master/exam...
...ples/jib-multimodule/.mvn/jvm.config