### PR TITLE
fix(tool): force push release tag

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -520,16 +520,11 @@ git_push() {
         echo "==== Pushing to GitHub"
         if [ -n "$release_version" ]; then
             echo "* Pushing $release_version"
-            if [ $(hasflag --snapshot-release) ]; then
-                # Force push to allow multiple releases per day
-                git push -f -u $remote $release_version
-            else
-                git push -u $remote $release_version
-            fi
+            git push -f -u "$remote" "$release_version"
         fi
         if [ ! $(hasflag --snapshot-release) ] && [ -n "$moving_tag" ]; then
             echo "* Pushing symbolic tag $moving_tag"
-            git push -f -u $remote $moving_tag
+            git push -f -u "$remote" "$moving_tag"
         fi
     fi
 }


### PR DESCRIPTION
We need to force push a release tag as the release is triggered by
creating a tag (with the same name) in the first place, so without force
pushing it, the release will fail.