### PR TITLE
fix: make sure CXF version is aligned with Camel

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -96,7 +96,7 @@
     <org.jboss.xnio.version>3.8.4.Final</org.jboss.xnio.version>
 
     <!-- CXF version, to be kept in sync with the one referenced by camel version above -->
-    <cxf.version>3.3.6.fuse-790025</cxf.version>
+    <cxf.version>3.3.6.fuse-790048</cxf.version>
     <wss4j.version>2.2.2</wss4j.version>
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -485,7 +485,24 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>determine-cxf-version</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>evaluate</goal>
+            </goals>
+            <configuration>
+              <expression>cxf-version</expression>
+              <artifact>org.apache.camel:camel-parent:2.23.2.fuse-790053</artifact>
+              <output>${project.basedir}/src/test/resources/cxf-version.txt</output>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -584,6 +601,11 @@
       <groupId>io.syndesis.server</groupId>
       <artifactId>server-metrics-jsondb</artifactId>
       <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-core</artifactId>
     </dependency>
 
     <!-- DAO implementations: -->

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/CxfToCamelVersionAlignementTest.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/CxfToCamelVersionAlignementTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.cxf.version.Version;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CxfToCamelVersionAlignementTest {
+
+    @Test
+    public void cxfVersionShouldBeAligned() throws IOException {
+        String cxfVersion = Version.getCurrentVersion();
+
+        try (InputStream stream = CxfToCamelVersionAlignementTest.class.getResourceAsStream("/cxf-version.txt")) {
+            assertThat(stream).as("Version of CXF needs to be: " + cxfVersion
+                + ". Update the `cxf.version` property in syndesis-parent POM")
+                .hasContent(cxfVersion);
+        }
+    }
+}

--- a/app/server/runtime/src/test/resources/.gitignore
+++ b/app/server/runtime/src/test/resources/.gitignore
@@ -1,0 +1,1 @@
+/cxf-version.txt


### PR DESCRIPTION
We need to make sure that the version of CXF we use is the same version
as used by Camel. This adds a test to make sure that fact holds.