### PR TITLE
fix: Add a test ID to the form group containing a select typeahead for ENTESB-13112

### DIFF
--- a/app/ui-react/packages/auto-form/src/widgets/FormTypeaheadComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormTypeaheadComponent.tsx
@@ -77,6 +77,7 @@ export const FormTypeaheadComponent: React.FunctionComponent<IFormControlProps> 
           ) : undefined
         }
         {...props.property.formGroupAttributes}
+        data-testid={`form-group-${id}`}
         fieldId={id}
         isRequired={props.property.required}
         validated={getValidationState(props)}


### PR DESCRIPTION
This is to work around https://github.com/patternfly/patternfly-react/issues/6107 by providing a test ID on the element that's as close as we can control, the enclosing form group.  The ID would be in the format `form-group-` and then the object property name.

Hopefully addresses [ENTESB-13112](https://issues.redhat.com/browse/ENTESB-13112)