### PR TITLE
fix: robustness for connection verification

### DIFF
--- a/app/server/verifier/pom.xml
+++ b/app/server/verifier/pom.xml
@@ -30,6 +30,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.syndesis.common</groupId>
+      <artifactId>common-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -61,11 +66,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
@@ -77,11 +77,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-core-spi</artifactId>
     </dependency>
@@ -89,6 +84,11 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
     </dependency>
 
     <!-- required by resteasy-jackson2-provider -->

--- a/app/server/verifier/src/main/java/io/syndesis/server/verifier/VerifierCommand.java
+++ b/app/server/verifier/src/main/java/io/syndesis/server/verifier/VerifierCommand.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.verifier;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import io.syndesis.common.util.json.JsonUtils;
+
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+
+final class VerifierCommand extends HystrixCommand<List<Verifier.Result>> {
+
+    private static final List<Verifier.Result> ERROR = Collections.singletonList(ImmutableResult.builder()
+        .status(Verifier.Result.Status.ERROR)
+        .scope(Verifier.Scope.CONNECTIVITY)
+        .addErrors(ImmutableVerifierError.builder()
+            .code("SYNDESIS000")
+            .description("Unable to perform verification")
+            .build())
+        .build());
+
+    private static final GenericType<List<Verifier.Result>> LIST_OF_RESULT = new GenericType<List<Verifier.Result>>() {
+        // type token
+    };
+
+    final MetadataConfigurationProperties config;
+
+    final String connectorId;
+
+    final Map<String, String> options;
+
+    final ResteasyProviderFactory providerFactory;
+
+    VerifierCommand(final MetadataConfigurationProperties config, final String connectorId, final Map<String, String> options) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Meta"))
+            .andThreadPoolPropertiesDefaults(HystrixThreadPoolProperties.Setter()
+                .withCoreSize(config.getThreads()))
+            .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                .withExecutionTimeoutInMilliseconds(config.getTimeout())));
+
+        this.config = config;
+        this.connectorId = connectorId;
+        this.options = options;
+
+        final ResteasyJackson2Provider resteasyJacksonProvider = new ResteasyJackson2Provider();
+
+        resteasyJacksonProvider.setMapper(JsonUtils.copyObjectMapperConfiguration());
+
+        providerFactory = ResteasyProviderFactory.newInstance();
+        providerFactory.register(resteasyJacksonProvider);
+    }
+
+    Client newClient() {
+        return ClientBuilder.newClient(providerFactory);
+    }
+
+    @Override
+    protected List<Verifier.Result> getFallback() {
+        return ERROR;
+    }
+
+    @Override
+    protected List<Verifier.Result> run() throws Exception {
+        final String url = String.format("http://%s/api/v1/verifier/%s", config.getService(), connectorId);
+
+        final Client client = newClient();
+        try {
+            final WebTarget target = client.target(url);
+
+            return target.request(MediaType.APPLICATION_JSON).post(
+                Entity.entity(options, MediaType.APPLICATION_JSON),
+                LIST_OF_RESULT);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/app/ui-react/packages/api/src/useConnectionHelpers.tsx
+++ b/app/ui-react/packages/api/src/useConnectionHelpers.tsx
@@ -34,7 +34,7 @@ export const useConnectionHelpers = () => {
     configuredProperties?: { [key: string]: string }
   ): Connection => {
     const connection = {} as Connection;
-    return produce(connection, draft => {
+    return produce(connection, (draft) => {
       draft.name = name;
       draft.description = description;
       draft.configuredProperties = configuredProperties;
@@ -64,7 +64,7 @@ export const useConnectionHelpers = () => {
     description?: string,
     configuredProperties?: { [key: string]: string }
   ): Connection => {
-    return produce(connection, draft => {
+    return produce(connection, (draft) => {
       draft.name = name || draft.name;
       // allow empty descriptions
       draft.description =
@@ -85,7 +85,20 @@ export const useConnectionHelpers = () => {
       url: `${apiContext.apiUri}/connectors/${connectorId}/verifier`,
     });
     if (!response.ok) {
-      throw new Error(response.statusText);
+      return [
+        {
+          errors: [
+            {
+              attributes: {},
+              code: response.status.toString(),
+              description: response.statusText,
+              parameters: [],
+            },
+          ],
+          scope: 'CONNECTIVITY',
+          status: 'ERROR',
+        },
+      ];
     }
     return (await response.json()) as IConfigurationValidation[];
   };
@@ -93,7 +106,7 @@ export const useConnectionHelpers = () => {
   const saveConnection = async (
     connection: Connection
   ): Promise<Connection> => {
-    return produce(connection, async draft => {
+    return produce(connection, async (draft) => {
       const response = await callFetch({
         body: draft,
         headers: apiContext.headers,


### PR DESCRIPTION
Changes the UI to handle the error rather than to rethrow it. Adds
Hystrix command with a fallback with generic error on the server side.

Ref. https://issues.redhat.com/browse/ENTESB-15153