### PR TITLE
fix(ci): align maven-deploy-plugin

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -29,6 +29,8 @@
   <properties>
     <spring-boot.version>2.3.9.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-790053</camel.version>
+    <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>
   </properties>
 
     <!-- Metadata need to publish to central -->
@@ -212,7 +214,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.0.0-M1</version>
+            <version>${dep.plugin.deploy.version}</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -212,7 +212,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>2.8.2</version>
+            <version>3.0.0-M1</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -32,6 +32,8 @@
     <atlasmap.version>2.2.3</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>
+    <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>
   </properties>
 
   <!-- Metadata need to publish to central -->
@@ -456,7 +458,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.0.0-M1</version>
+            <version>${dep.plugin.deploy.version}</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -456,7 +456,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>2.8.2</version>
+            <version>3.0.0-M1</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -49,6 +49,8 @@
 
     <fabric8.maven.plugin.version>4.2.0</fabric8.maven.plugin.version>
     <maven.exec.plugin.version>1.2.1</maven.exec.plugin.version>
+    <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>
     <frontend-maven-plugin-version>1.8.0</frontend-maven-plugin-version>
     <node.version>v14.17.3</node.version>
     <yarn.version>v1.22.5</yarn.version>


### PR DESCRIPTION
The plugin version diverged after the upgrade of base pom. Both extensions an integration boms are not depending from that pom and we must align versions in order to let the dependencies been deployed correctly. Deploy was failing because of the following error:
```
[ERROR] Found multiple major versions of maven-deploy-plugin; this is a malformed project.
	[org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:2.7:runtime, org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:3.0.0-M1:runtime]
```