### PR TITLE
chore(deps): remove node-sass download

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -128,9 +128,6 @@
     <maven-shared-utils.version>3.1.0</maven-shared-utils.version>
     <maven-download.version>1.3.0</maven-download.version>
 
-    <!-- UI dependencies -->
-    <node-sass-version>4.12.0</node-sass-version>
-
     <!-- Common dependencies -->
     <assertj-core.version>3.16.1</assertj-core.version>
     <shrinkwrap.version>2.2.6</shrinkwrap.version>

--- a/app/ui-react/pom.xml
+++ b/app/ui-react/pom.xml
@@ -285,62 +285,6 @@
       </build>
     </profile>
     <profile>
-      <id>rebuild-saas</id>
-      <activation>
-        <property>
-          <name>sass-binary-site</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>download-node-sass</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <configuration>
-                  <url>${sass-binary-site}/v${node-sass-version}/${os.type}-x64-64_binding.node</url>
-                  <outputFileName>binding.node</outputFileName>
-                  <outputDirectory>${project.build.directory}/${os.type}-x64-64</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.github.eirslett</groupId>
-            <artifactId>frontend-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>yarn unset sass binary url</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>yarn</goal>
-                </goals>
-                <configuration>
-                  <arguments>config delete sass-binary-site</arguments>
-                </configuration>
-              </execution>
-              <execution>
-                <id>yarn set sass binary dir</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>yarn</goal>
-                </goals>
-                <configuration>
-                  <arguments>config set sass-binary-path ${project.build.directory}/linux-x64-64/binding.node</arguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>verbose</id>
       <properties>
         <yarn-verbose>--verbose</yarn-verbose>


### PR DESCRIPTION
Seems we are no longer using node-sass, so this removes the build
configuration used to download the prebuilt binary.

Ref. https://issues.redhat.com/browse/ENTESB-17290