### PR TITLE
ENTESB-17341 nodeAffinity and toleration are not set in an integration pod

### DIFF
--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -82,7 +82,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
     private static final Map<String, String> INTEGRATION_DEFAULT_LABELS = defaultLabels();
 
     public static final CustomResourceDefinition SYNDESIS_CRD = new CustomResourceDefinitionBuilder()
-        .withApiVersion("apiextensions.k8s.io/v1beta2")
+        .withApiVersion("apiextensions.k8s.io/v1beta3")
         .withKind("CustomResourceDefinition")
         .withNewMetadata()
             .withName("syndesises.syndesis.io")
@@ -90,7 +90,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
         .withNewSpec()
             .withGroup("syndesis.io")
             .withScope("Namespaced")
-            .withVersion("v1beta2")
+            .withVersion("v1beta3")
             .withNewNames()
                 .withKind("Syndesis")
                 .withListKind("SyndesisList")


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-17341

OpenShiftServiceImpl was using an outdated v1beta2 syndesis CRD version
updated to v1beta3

The syndesis CRD version check is in operator build, because any syndesis CRD upgrade is driven by the operator code, so it is my understanding that if there is a change in the syndesis api version, that is going to occur in operator code.
