### PR TITLE
fix: maintain data shape parameters

### DIFF
--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@atlasmap/atlasmap": "^2.3.1",
+    "@atlasmap/core": "^2.3.1",
     "@types/patternfly-react": "*",
     "loglevel": "^1.7.1",
     "react-dnd-html5-backend": "^14.0.0",

--- a/app/ui-react/packages/atlasmap-adapter/src/DataMapperAdapter.tsx
+++ b/app/ui-react/packages/atlasmap-adapter/src/DataMapperAdapter.tsx
@@ -102,7 +102,7 @@ export interface IParameterOption {
   value: string;
 }
 
-export interface IParameter {
+export interface IParameterDefinition {
   name: string;
   label: string;
   value: string;
@@ -110,22 +110,85 @@ export interface IParameter {
   options?: IParameterOption[];
   hidden?: boolean;
   required?: boolean;
+  enabled?: boolean;
+}
+
+export interface IParameters {
+  [name: string]: string;
 }
 
 export const DataShapeParametersDialog: React.FunctionComponent<{
   title: string;
   shown: boolean;
-  parameters: IParameter[];
-  onConfirm: (parameters: IParameter[]) => void;
+  parameterDefinition: IParameterDefinition[];
+  parameters?: IParameters;
+  onConfirm: (parameters: IParameters) => void;
   onCancel: () => void;
-}> = ({ title, shown, parameters, onConfirm, onCancel }) => {
+}> = ({
+  title,
+  shown,
+  parameterDefinition,
+  parameters,
+  onConfirm,
+  onCancel,
+}) => {
+  // Clicking Cancel in the AtlasMap parameters dialog results in the reset of the internal
+  // state of the dialog in such a way that the parameters selected by the user are lost,
+  // or at least not shown. For example if the user selects "Skip Header Record" and ticks
+  // it so it's value is set to `true`, by clicking on "Confirm" a single parameter for
+  // "Skip Header Record" is provided on `onConfirm` callback with the side effect of
+  // changing the internal state in `definedParameters`, on "onCancel" callback
+  // resets the internal state in `definedParameters` to initial state loosing all user
+  // entered values.
+  // As a workaround, we're mixing the initial parameters with the selected parameters
+  // so that we can keep the state of `definedParameters` as expected for the dialog
+  // to present all possible values and keep the user selected values.
+  // The trick is in setting the unexported property `enabled` which is consulted in
+  // the `reset` function in handling of cancel.
+  // Ref. https://github.com/atlasmap/atlasmap/issues/2990
+  const computeDialogParameters = (
+    given?: IParameters
+  ): IParameterDefinition[] => {
+    if (given === undefined) {
+      return [];
+    }
+
+    return parameterDefinition.map((defn) => {
+      if (defn.name in given) {
+        defn.value = given[defn.name];
+        // dirty trick to get `reset` within ParametersDialog not to reset the
+        // state of `definedParameters`
+        defn.enabled = true;
+      }
+
+      return defn;
+    });
+  };
+
+  // we wish to maintain the interface between usage of DataShapeParametersDialog
+  // and AtlasMap, and hide any idiosyncrasies, to `onConfirm` we wish to provide
+  // only key-value IParameters choosen by the user, while maintaining the state
+  // of ParametersDialog in AtlasMap, as noted above
+  const handleConfirm = (given: IParameterDefinition[]) => {
+    const newParameters = given.reduce((givenParams, givenParam) => {
+      givenParams[givenParam.name] = givenParam.value;
+      return givenParams;
+    }, {});
+    setParams(computeDialogParameters(newParameters));
+    onConfirm(newParameters);
+  };
+
+  const [params, setParams] = React.useState(
+    computeDialogParameters(parameters)
+  );
+
   return (
     <ParametersDialog
       isOpen={shown}
       title={title}
       onCancel={onCancel}
-      onConfirm={onConfirm}
-      parameters={parameters}
+      onConfirm={handleConfirm}
+      parameters={params.length === 0 ? parameterDefinition : params}
     />
   );
 };

--- a/app/ui-react/packages/atlasmap-adapter/src/DataMapperAdapter.tsx
+++ b/app/ui-react/packages/atlasmap-adapter/src/DataMapperAdapter.tsx
@@ -6,6 +6,7 @@ import {
   IAtlasmapProviderProps,
   ParametersDialog,
 } from '@atlasmap/atlasmap';
+import { getCsvParameterOptions } from '@atlasmap/core';
 
 export enum DocumentType {
   JAVA = 'JAVA',
@@ -128,3 +129,5 @@ export const DataShapeParametersDialog: React.FunctionComponent<{
     />
   );
 };
+
+export const atlasmapCSVParameterOptions = getCsvParameterOptions;

--- a/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/endpoint/DescribeDataShapeForm.tsx
@@ -41,99 +41,13 @@ const kinds = [
   },
   {
     label: 'CSV Instance',
-    parameters: [
-      {
-        boolean: true,
-        label: 'Allow Duplicate Header Names',
-        name: 'allowDuplicateHeaderNames',
-        required: false,
-        value: 'true',
-      },
-      {
-        boolean: true,
-        label: 'Allow Missing Column Names',
-        name: 'allowMissingColumnNames',
-        required: false,
-        value: 'true',
-      },
-      {
-        label: 'Comment Marker',
-        name: 'commentMarker',
-        required: false,
-        value: '',
-      },
-      {
-        label: 'Delimiter',
-        name: 'delimiter',
-        required: false,
-        value: '',
-      },
-      {
-        label: 'Escape',
-        name: 'escape',
-        required: false,
-        value: '',
-      },
-      {
-        boolean: true,
-        label: 'First Record As Header',
-        name: 'firstRecordAsHeader',
-        required: false,
-        value: 'true',
-      },
-      {
-        label: 'Headers',
-        name: 'headers',
-        required: false,
-        value: '',
-      },
-      {
-        boolean: true,
-        label: 'Ignore Empty Lines',
-        name: 'ignoreEmptyLines',
-        required: false,
-        value: 'true',
-      },
-      {
-        boolean: true,
-        label: 'Ignore Header Case',
-        name: 'ignoreHeaderCase',
-        required: false,
-        value: 'true',
-      },
-      {
-        boolean: true,
-        label: 'Ignore Surrounding Spaces',
-        name: 'ignoreSurroundingSpaces',
-        required: false,
-        value: 'true',
-      },
-      {
-        label: 'Null String',
-        name: 'nullString',
-        required: false,
-        value: '',
-      },
-      {
-        boolean: true,
-        label: 'Skip Header Record',
-        name: 'skipHeaderRecord',
-        required: false,
-        value: 'true',
-      },
-    ],
     value: 'csv-instance',
   },
 ];
 
 const titleFor = (kind: string): string => {
-  const found = kinds.find(k => k.value === kind);
+  const found = kinds.find((k) => k.value === kind);
   return (found && found.label + ' Parameters') || '';
-};
-
-const parametersFor = (kind: string): [] => {
-  const found = kinds.find(k => k.value === kind);
-  return (found && (found.parameters as [])) || [];
 };
 
 export interface IDescribeDataShapeFormProps {
@@ -162,205 +76,210 @@ export interface IDescribeDataShapeFormProps {
   onNameChange: (name: string) => void;
   onDescriptionChange: (description: string) => void;
   onShowParameters: (kind: string, parameters: []) => void;
+  parametersFor: (kind: string) => any;
 }
 
-export const DescribeDataShapeForm: React.FunctionComponent<IDescribeDataShapeFormProps> = ({
-  kind,
-  definition,
-  name,
-  description,
-  parametersDialog: parametersDialog,
-  i18nDefinition,
-  i18nDefinitionHelp,
-  i18nSelectType,
-  i18nSelectTypeHelp,
-  i18nDataTypeName,
-  i18nDataTypeNameHelp,
-  i18nDataTypeDescription,
-  i18nDataTypeDescriptionHelp,
-  i18nDataTypeParameters,
-  i18nDataTypeParametersHelp,
-  i18nDataTypeParametersAction,
-  i18nNext,
-  i18nBackAction,
-  backActionHref,
-  onNext,
-  onKindChange,
-  onDefinitionChange,
-  onNameChange,
-  onDescriptionChange,
-  onShowParameters,
-}) => (
-  <PageSection>
-    <Container>
-      <div className="row row-cards-pf">
-        <Card>
-          <CardBody>
-            <Form>
-              <FormGroup
-                fieldId={'describe-data-shape-form-kind-input'}
-                label={
-                  <>
-                    {i18nSelectType}
-                    <Popover
-                      aria-label={i18nSelectTypeHelp}
-                      bodyContent={i18nSelectTypeHelp}
-                    >
-                      <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-                    </Popover>
-                  </>
-                }
-              >
-                <FormSelect
-                  value={kind}
-                  data-testid={'describe-data-shape-form-kind-input'}
-                  id={'describe-data-shape-form-kind-input'}
-                  onChange={value => onKindChange(value)}
+export const DescribeDataShapeForm: React.FunctionComponent<IDescribeDataShapeFormProps> =
+  ({
+    kind,
+    definition,
+    name,
+    description,
+    parametersDialog: parametersDialog,
+    i18nDefinition,
+    i18nDefinitionHelp,
+    i18nSelectType,
+    i18nSelectTypeHelp,
+    i18nDataTypeName,
+    i18nDataTypeNameHelp,
+    i18nDataTypeDescription,
+    i18nDataTypeDescriptionHelp,
+    i18nDataTypeParameters,
+    i18nDataTypeParametersHelp,
+    i18nDataTypeParametersAction,
+    i18nNext,
+    i18nBackAction,
+    backActionHref,
+    onNext,
+    onKindChange,
+    onDefinitionChange,
+    onNameChange,
+    onDescriptionChange,
+    onShowParameters,
+    parametersFor,
+  }) => (
+    <PageSection>
+      <Container>
+        <div className="row row-cards-pf">
+          <Card>
+            <CardBody>
+              <Form>
+                <FormGroup
+                  fieldId={'describe-data-shape-form-kind-input'}
+                  label={
+                    <>
+                      {i18nSelectType}
+                      <Popover
+                        aria-label={i18nSelectTypeHelp}
+                        bodyContent={i18nSelectTypeHelp}
+                      >
+                        <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
+                      </Popover>
+                    </>
+                  }
                 >
-                  {kinds.map((aKind, index) => (
-                    <FormSelectOption
-                      key={index}
-                      value={aKind.value}
-                      label={aKind.label}
-                    />
-                  ))}
-                </FormSelect>
-              </FormGroup>
-              {kind !== 'any' && (
-                <>
-                  <FormGroup
-                    fieldId={'describe-data-shape-form-definition-editor'}
-                    label={
-                      <>
-                        {i18nDefinition}
-                        <Popover
-                          aria-label={i18nDefinitionHelp}
-                          bodyContent={i18nDefinitionHelp}
-                        >
-                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-                        </Popover>
-                      </>
-                    }
+                  <FormSelect
+                    value={kind}
+                    data-testid={'describe-data-shape-form-kind-input'}
+                    id={'describe-data-shape-form-kind-input'}
+                    onChange={(value) => onKindChange(value)}
                   >
-                    <TextEditor
-                      id={'describe-data-shape-form-definition-editor'}
-                      value={definition || ''}
-                      onChange={(editor, data, text) =>
-                        onDefinitionChange(text)
-                      }
-                      options={{
-                        lineNumbers: true,
-                        lineWrapping: true,
-                        readOnly: false,
-                        showCursorWhenSelecting: true,
-                        tabSize: 2,
-                      }}
-                    />
-                  </FormGroup>
-                  {parametersFor(kind).length > 0 && (
+                    {kinds.map((aKind, index) => (
+                      <FormSelectOption
+                        key={index}
+                        value={aKind.value}
+                        label={aKind.label}
+                      />
+                    ))}
+                  </FormSelect>
+                </FormGroup>
+                {kind !== 'any' && (
+                  <>
                     <FormGroup
-                      fieldId={'describe-data-shape-form-parameters'}
+                      fieldId={'describe-data-shape-form-definition-editor'}
                       label={
                         <>
-                          {i18nDataTypeParameters}
+                          {i18nDefinition}
                           <Popover
-                            aria-label={i18nDataTypeParametersHelp}
-                            bodyContent={i18nDataTypeParametersHelp}
+                            aria-label={i18nDefinitionHelp}
+                            bodyContent={i18nDefinitionHelp}
                           >
                             <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
                           </Popover>
                         </>
                       }
                     >
-                      <Container>
-                        <Button
-                          type={'button'}
-                          variant={'tertiary'}
-                          data-testid={
-                            'describe-data-shape-form-parameters-button'
-                          }
-                          onClick={() =>
-                            onShowParameters(
-                              titleFor(kind),
-                              parametersFor(kind)
-                            )
-                          }
-                        >
-                          <i className={'fa fa-ellipsis-h'} />{' '}
-                          {i18nDataTypeParametersAction}
-                        </Button>
-                        {parametersDialog}
-                      </Container>
+                      <TextEditor
+                        id={'describe-data-shape-form-definition-editor'}
+                        value={definition || ''}
+                        onChange={(editor, data, text) =>
+                          onDefinitionChange(text)
+                        }
+                        options={{
+                          lineNumbers: true,
+                          lineWrapping: true,
+                          readOnly: false,
+                          showCursorWhenSelecting: true,
+                          tabSize: 2,
+                        }}
+                      />
                     </FormGroup>
-                  )}
-                  <FormGroup
-                    fieldId={'describe-data-shape-form-name-input'}
-                    label={
-                      <>
-                        {i18nDataTypeName}
-                        <Popover
-                          aria-label={i18nDataTypeNameHelp}
-                          bodyContent={i18nDataTypeNameHelp}
-                        >
-                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-                        </Popover>
-                      </>
-                    }
+                    {parametersFor(kind).length > 0 && (
+                      <FormGroup
+                        fieldId={'describe-data-shape-form-parameters'}
+                        label={
+                          <>
+                            {i18nDataTypeParameters}
+                            <Popover
+                              aria-label={i18nDataTypeParametersHelp}
+                              bodyContent={i18nDataTypeParametersHelp}
+                            >
+                              <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
+                            </Popover>
+                          </>
+                        }
+                      >
+                        <Container>
+                          <Button
+                            type={'button'}
+                            variant={'tertiary'}
+                            data-testid={
+                              'describe-data-shape-form-parameters-button'
+                            }
+                            onClick={() =>
+                              onShowParameters(
+                                titleFor(kind),
+                                parametersFor(kind)
+                              )
+                            }
+                          >
+                            <i className={'fa fa-ellipsis-h'} />{' '}
+                            {i18nDataTypeParametersAction}
+                          </Button>
+                          {parametersDialog}
+                        </Container>
+                      </FormGroup>
+                    )}
+                    <FormGroup
+                      fieldId={'describe-data-shape-form-name-input'}
+                      label={
+                        <>
+                          {i18nDataTypeName}
+                          <Popover
+                            aria-label={i18nDataTypeNameHelp}
+                            bodyContent={i18nDataTypeNameHelp}
+                          >
+                            <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
+                          </Popover>
+                        </>
+                      }
+                    >
+                      <TextInput
+                        data-testid={'describe-data-shape-form-name-input'}
+                        type="text"
+                        value={name}
+                        onChange={(value) => onNameChange(value)}
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      fieldId={'describe-data-shape-form-description-input'}
+                      label={
+                        <>
+                          {i18nDataTypeDescription}
+                          <Popover
+                            aria-label={i18nDataTypeDescriptionHelp}
+                            bodyContent={i18nDataTypeDescriptionHelp}
+                          >
+                            <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
+                          </Popover>
+                        </>
+                      }
+                    >
+                      <TextInput
+                        type="text"
+                        data-testid={
+                          'describe-data-shape-form-description-input'
+                        }
+                        value={description}
+                        onChange={(value) => onDescriptionChange(value)}
+                      />
+                    </FormGroup>
+                  </>
+                )}
+              </Form>
+            </CardBody>
+            <CardFooter className="syn-card__footer">
+              {backActionHref && (
+                <>
+                  <ButtonLink
+                    data-testid={'describe-data-shape-form-back-button'}
+                    href={backActionHref}
                   >
-                    <TextInput
-                      data-testid={'describe-data-shape-form-name-input'}
-                      type="text"
-                      value={name}
-                      onChange={value => onNameChange(value)}
-                    />
-                  </FormGroup>
-                  <FormGroup
-                    fieldId={'describe-data-shape-form-description-input'}
-                    label={
-                      <>
-                        {i18nDataTypeDescription}
-                        <Popover
-                          aria-label={i18nDataTypeDescriptionHelp}
-                          bodyContent={i18nDataTypeDescriptionHelp}
-                        >
-                          <OutlinedQuestionCircleIcon className="pf-u-ml-xs" />
-                        </Popover>
-                      </>
-                    }
-                  >
-                    <TextInput
-                      type="text"
-                      data-testid={'describe-data-shape-form-description-input'}
-                      value={description}
-                      onChange={value => onDescriptionChange(value)}
-                    />
-                  </FormGroup>
+                    <i className={'fa fa-chevron-left'} /> {i18nBackAction}
+                  </ButtonLink>
+                  &nbsp;
                 </>
               )}
-            </Form>
-          </CardBody>
-          <CardFooter className="syn-card__footer">
-            {backActionHref && (
-              <>
-                <ButtonLink
-                  data-testid={'describe-data-shape-form-back-button'}
-                  href={backActionHref}
-                >
-                  <i className={'fa fa-chevron-left'} /> {i18nBackAction}
-                </ButtonLink>
-                &nbsp;
-              </>
-            )}
-            <ButtonLink
-              data-testid={'describe-data-shape-form-next-button'}
-              onClick={onNext}
-              as={'primary'}
-            >
-              {i18nNext}
-            </ButtonLink>
-          </CardFooter>
-        </Card>
-      </div>
-    </Container>
-  </PageSection>
-);
+              <ButtonLink
+                data-testid={'describe-data-shape-form-next-button'}
+                onClick={onNext}
+                as={'primary'}
+              >
+                {i18nNext}
+              </ButtonLink>
+            </CardFooter>
+          </Card>
+        </div>
+      </Container>
+    </PageSection>
+  );

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/DescribeChoiceDataShapePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/DescribeChoiceDataShapePage.tsx
@@ -183,7 +183,7 @@ export class DescribeChoiceDataShapePage extends React.Component<IDescribeChoice
                           initialDefinition={dataShape.specification}
                           initialName={dataShape.name}
                           initialDescription={dataShape.description}
-                          initialParameters={dataShape.parameters}
+                          parameters={dataShape.parameters}
                           onUpdatedDataShape={handleUpdatedDataShape}
                           backActionHref={backHref}
                           parametersFor={(kind: string) => {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/DescribeChoiceDataShapePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/choice/DescribeChoiceDataShapePage.tsx
@@ -40,6 +40,8 @@ import { PageTitle } from '../../../../../shared';
 import { IEditorSidebarProps } from '../EditorSidebar';
 import { WithDescribeDataShapeForm } from '../shape/WithDescribeDataShapeForm';
 import { createChoiceConfiguration } from './utils';
+import { atlasmapCSVParameterOptions } from '@syndesis/atlasmap-adapter';
+import { DataShapeKinds } from '@syndesis/api';
 
 export interface IDescribeChoiceDataShapePageProps
   extends IPageWithEditorBreadcrumb {
@@ -184,6 +186,13 @@ export class DescribeChoiceDataShapePage extends React.Component<IDescribeChoice
                           initialParameters={dataShape.parameters}
                           onUpdatedDataShape={handleUpdatedDataShape}
                           backActionHref={backHref}
+                          parametersFor={(kind: string) => {
+                            if (kind === DataShapeKinds.CSV_INSTANCE) {
+                              return atlasmapCSVParameterOptions();
+                            } else {
+                              return [];
+                            }
+                          }}
                         />
                       }
                       cancelHref={this.props.cancelHref(params, state)}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
@@ -27,6 +27,8 @@ import { WithRouteData } from '@syndesis/utils';
 import { PageTitle } from '../../../../../shared';
 import { IEditorSidebarProps } from '../EditorSidebar';
 import { WithDescribeDataShapeForm } from '../shape/WithDescribeDataShapeForm';
+import { DataShapeKinds } from '@syndesis/api';
+import { atlasmapCSVParameterOptions } from '@syndesis/atlasmap-adapter';
 
 export interface IDescribeDataShapePageProps extends IPageWithEditorBreadcrumb {
   backHref: (
@@ -217,6 +219,13 @@ export class DescribeDataShapePage extends React.Component<IDescribeDataShapePag
                           initialParameters={dataShape.parameters}
                           onUpdatedDataShape={handleUpdatedDataShape}
                           backActionHref={backHref}
+                          parametersFor={(kind: string) => {
+                            if (kind === DataShapeKinds.CSV_INSTANCE) {
+                              return atlasmapCSVParameterOptions();
+                            } else {
+                              return [];
+                            }
+                          }}
                         />
                       }
                       cancelHref={this.props.cancelHref(params, state)}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
@@ -216,7 +216,7 @@ export class DescribeDataShapePage extends React.Component<IDescribeDataShapePag
                           initialDefinition={dataShape.specification}
                           initialName={dataShape.name}
                           initialDescription={dataShape.description}
-                          initialParameters={dataShape.parameters}
+                          parameters={dataShape.parameters}
                           onUpdatedDataShape={handleUpdatedDataShape}
                           backActionHref={backHref}
                           parametersFor={(kind: string) => {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/shape/WithDescribeDataShapeForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/shape/WithDescribeDataShapeForm.tsx
@@ -20,6 +20,7 @@ export interface IWithDescribeDataShapeFormProps {
   };
   backActionHref: H.LocationDescriptor;
   onUpdatedDataShape: (dataShape: DataShape) => void;
+  parametersFor: (kind: string) => IParameter[];
 }
 
 export interface IWithDescribeDataShapeFormState {
@@ -38,6 +39,7 @@ export class WithDescribeDataShapeForm extends React.Component<
   IWithDescribeDataShapeFormState
 > {
   private definition: string | undefined;
+  private parametersFor: (kind: string) => IParameter[];
   constructor(props: IWithDescribeDataShapeFormProps) {
     super(props);
     this.state = {
@@ -56,6 +58,7 @@ export class WithDescribeDataShapeForm extends React.Component<
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
     this.handleNext = this.handleNext.bind(this);
     this.handleShowParameters = this.handleShowParameters.bind(this);
+    this.parametersFor = this.props.parametersFor.bind(this);
   }
   public handleKindChange(newKind: string) {
     this.setState({ kind: newKind, parameters: [], initialParameters: [] });
@@ -162,6 +165,7 @@ export class WithDescribeDataShapeForm extends React.Component<
           onDescriptionChange={this.handleDescriptionChange}
           onDefinitionChange={this.handleDefinitionChange}
           onShowParameters={this.handleShowParameters}
+          parametersFor={this.parametersFor}
         />
       </>
     );


### PR DESCRIPTION
fix: maintain data shape parameters (afc06bb)

Even though an issue in AtlasMap was resolved[1] it doesn't seem to help
in the Syndesis use case. This refactors the support for providing data
shape parameters and uses one dirty trick to avoid resetting the
internal state of AtlasMap's `ParametersDialog`. The key is in setting
the `enabled=true` parameter which should leave the value present in the
dialog. The refactoring focused on removing the complexity of AtlasMap
to the AtlasMap adapter so that pages that use the
`DataShapeParametersDialog` can have a simpler interface and need not
take any concern of the AtlasMap internal state.

Ref. https://issues.redhat.com/browse/ENTESB-17416

[1] https://github.com/atlasmap/atlasmap/issues/2990

chore: don't hardcode AtlasMap CSV parameters (05c8328)

We now can access AtlasMap supported CSV parameters directly from
AtlasMap[1], so we don't need to hardcode them on our end.