### PR TITLE
chore: pull images as possible from quay.io

### DIFF
--- a/install/operator/build/conf/config-test.yaml
+++ b/install/operator/build/conf/config-test.yaml
@@ -14,14 +14,14 @@ Syndesis:
                 Channel: "stable"
             SamplerType: "const"
             SamplerParam: "0"
-            ImageAgent: "jaegertracing/jaeger-agent:1.13"
-            ImageAllInOne: "jaegertracing/all-in-one:1.13"
-            ImageOperator: "jaegertracing/jaeger-operator:1.13"
+            ImageAgent: "quay.io/jaegertracing/jaeger-agent:1.27"
+            ImageAllInOne: "quay.io/jaegertracing/all-in-one:1.27"
+            ImageOperator: "quay.io/jaegertracing/jaeger-operator:1.27"
         Ops:
             Enabled: false
         Todo:
             Enabled: false
-            Image: "docker.io/centos/php-71-centos7"
+            Image: "quay.io/centos7/php-73-centos7:7.3"
         Knative:
             Enabled: false
         PublicApi:
@@ -29,14 +29,14 @@ Syndesis:
             RouteHostname: "mypublichost.com"
     Components:
         Oauth:
-            Image: "quay.io/openshift/origin-oauth-proxy:v4.0.0"
+            Image: "quay.io/openshift/origin-oauth-proxy:4.9"
         UI:
-            Image: "docker.io/syndesis/syndesis-ui:latest"
+            Image: "quay.io/syndesis/syndesis-ui:latest"
         S2I:
-            Image: "docker.io/syndesis/syndesis-s2i:latest"
+            Image: "quay.io/syndesis/syndesis-s2i:latest"
         Prometheus:
             Rules: ""
-            Image: "docker.io/prom/prometheus:v2.1.0"
+            Image: "quay.io/prometheus/prometheus:v2.30.3"
             Resources:
                 Limit:
                     Memory: "512Mi"
@@ -45,11 +45,11 @@ Syndesis:
                 VolumeCapacity: "1Gi"
                 VolumeAccessMode: "ReadWriteOnce"
         Upgrade:
-            Image: "docker.io/syndesis/syndesis-upgrade:latest"
+            Image: "quay.io/syndesis/syndesis-upgrade:latest"
             Resources:
                 VolumeCapacity: "1Gi"
         Meta:
-            Image: "docker.io/syndesis/syndesis-meta:latest"
+            Image: "quay.io/syndesis/syndesis-meta:latest"
             Resources:
                 Limit:
                     Memory: "512Mi"
@@ -61,9 +61,9 @@ Syndesis:
             Name: "syndesis"
             User: "syndesis"
             URL: "postgresql://syndesis-db:5432/syndesis?sslmode=disable"
-            Image: "postgresql:9.6"
+            Image: "quay.io/centos7/postgresql-12-centos7:latest"
             Exporter:
-                Image: "docker.io/wrouesnel/postgres_exporter:v0.4.7"
+                Image: "quay.io/testing-farm/postgres_exporter:v0.8.0"
             Resources:
                 Limit:
                     Memory: "255Mi"
@@ -72,7 +72,7 @@ Syndesis:
                 VolumeCapacity: "1Gi"
                 VolumeAccessMode: "ReadWriteOnce"
         Server:
-            Image: "docker.io/syndesis/syndesis-server:latest"
+            Image: "quay.io/syndesis/syndesis-server:latest"
             Resources:
                 Limit:
                     Memory: "800Mi"

--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -14,14 +14,14 @@ Syndesis:
             Olm:
                 Package: "jaeger-product"
                 Channel: "stable"
-            ImageAgent: "jaegertracing/jaeger-agent:1.13"
-            ImageAllInOne: "jaegertracing/all-in-one:1.13"
-            ImageOperator: "jaegertracing/jaeger-operator:1.13"
+            ImageAgent: "quay.io/jaegertracing/jaeger-agent:1.27"
+            ImageAllInOne: "quay.io/jaegertracing/all-in-one:1.27"
+            ImageOperator: "quay.io/jaegertracing/jaeger-operator:1.27"
         Ops:
             Enabled: false
         Todo:
             Enabled: false
-            Image: "docker.io/centos/php-72-centos7"
+            Image: "quay.io/centos7/php-73-centos7:7.3"
         Knative:
             Enabled: false
         PublicApi:
@@ -29,15 +29,15 @@ Syndesis:
             DisableSarCheck: false
     Components:
         Oauth:
-            Image: "quay.io/openshift/origin-oauth-proxy:4.7"
+            Image: "quay.io/openshift/origin-oauth-proxy:4.9"
             DisableSarCheck: false
         UI:
-            Image: "docker.io/syndesis/syndesis-ui:latest"
+            Image: "quay.io/syndesis/syndesis-ui:latest"
         S2I:
-            Image: "docker.io/syndesis/syndesis-s2i:latest"
+            Image: "quay.io/syndesis/syndesis-s2i:latest"
         Prometheus:
             Rules: ""
-            Image: "docker.io/prom/prometheus:v2.23.0"
+            Image: "quay.io/prometheus/prometheus:v2.30.3"
             Resources:
                 Limit:
                     Memory: "512Mi"
@@ -46,11 +46,11 @@ Syndesis:
                 VolumeCapacity: "1Gi"
                 VolumeAccessMode: "ReadWriteOnce"
         Upgrade:
-            Image: "docker.io/syndesis/syndesis-upgrade:latest"
+            Image: "quay.io/syndesis/syndesis-upgrade:latest"
             Resources:
                 VolumeCapacity: "1Gi"
         Meta:
-            Image: "docker.io/syndesis/syndesis-meta:latest"
+            Image: "quay.io/syndesis/syndesis-meta:latest"
             Resources:
                 Limit:
                     Memory: "512Mi"
@@ -62,9 +62,9 @@ Syndesis:
             Name: "syndesis"
             User: "syndesis"
             URL: "postgresql://syndesis-db:5432/syndesis?sslmode=disable"
-            Image: "centos/postgresql-12-centos7"
+            Image: "quay.io/centos7/postgresql-12-centos7:latest"
             Exporter:
-                Image: "docker.io/wrouesnel/postgres_exporter:v0.4.7"
+                Image: "quay.io/testing-farm/postgres_exporter:v0.8.0"
             Resources:
                 Limit:
                     Memory: "255Mi"
@@ -74,7 +74,7 @@ Syndesis:
                 VolumeAccessMode: "ReadWriteOnce"
             LoggerImage: "quay.io/centos/centos:7"
         Server:
-            Image: "docker.io/syndesis/syndesis-server:latest"
+            Image: "quay.io/syndesis/syndesis-server:latest"
             Resources:
                 Limit:
                     Memory: "800Mi"

--- a/install/operator/pkg/cmd/internal/install/install_defaults.go
+++ b/install/operator/pkg/cmd/internal/install/install_defaults.go
@@ -1,3 +1,3 @@
 package install
 
-const defaultDatabaseImage = "centos/postgresql-12-centos7"
+const defaultDatabaseImage = "quay.io/centos7/postgresql-12-centos7:latest"

--- a/install/operator/pkg/syndesis/configuration/configuration_test.go
+++ b/install/operator/pkg/syndesis/configuration/configuration_test.go
@@ -271,9 +271,9 @@ func Test_setSyndesisFromCustomResource(t *testing.T) {
 							Enabled:       true,
 							SamplerType:   "const",
 							SamplerParam:  "0",
-							ImageAgent:    "jaegertracing/jaeger-agent:1.13",
-							ImageAllInOne: "jaegertracing/all-in-one:1.13",
-							ImageOperator: "jaegertracing/jaeger-operator:1.13",
+							ImageAgent:    "quay.io/jaegertracing/jaeger-agent:1.27",
+							ImageAllInOne: "quay.io/jaegertracing/all-in-one:1.27",
+							ImageOperator: "quay.io/jaegertracing/all-in-one:1.27",
 						},
 						Todo: synapi.AddonSpec{Enabled: true},
 						PublicApi: synapi.PublicApiConfiguration{
@@ -294,16 +294,16 @@ func Test_setSyndesisFromCustomResource(t *testing.T) {
 							},
 							SamplerType:   "const",
 							SamplerParam:  "0",
-							ImageAgent:    "jaegertracing/jaeger-agent:1.13",
-							ImageAllInOne: "jaegertracing/all-in-one:1.13",
-							ImageOperator: "jaegertracing/jaeger-operator:1.13",
+							ImageAgent:    "quay.io/jaegertracing/jaeger-agent:1.27",
+							ImageAllInOne: "quay.io/jaegertracing/all-in-one:1.27",
+							ImageOperator: "quay.io/jaegertracing/all-in-one:1.27",
 						},
 						Ops: OpsConfiguration{
 							AddonConfiguration: AddonConfiguration{Enabled: false},
 						},
 						Todo: TodoConfiguration{
 							AddonConfiguration: AddonConfiguration{Enabled: true},
-							Image:              "docker.io/centos/php-71-centos7",
+							Image:              "quay.io/centos7/php-73-centos7:7.3",
 						},
 						Knative: KnativeConfiguration{
 							AddonConfiguration: AddonConfiguration{Enabled: false},
@@ -462,16 +462,16 @@ func getConfigLiteral() *Config {
 					},
 					SamplerType:   "const",
 					SamplerParam:  "0",
-					ImageAgent:    "jaegertracing/jaeger-agent:1.13",
-					ImageAllInOne: "jaegertracing/all-in-one:1.13",
-					ImageOperator: "jaegertracing/jaeger-operator:1.13",
+					ImageAgent:    "quay.io/jaegertracing/jaeger-agent:1.27",
+					ImageAllInOne: "quay.io/jaegertracing/all-in-one:1.27",
+					ImageOperator: "quay.io/jaegertracing/jaeger-operator:1.27",
 				},
 				Ops: OpsConfiguration{
 					AddonConfiguration: AddonConfiguration{Enabled: false},
 				},
 				Todo: TodoConfiguration{
 					AddonConfiguration: AddonConfiguration{Enabled: false},
-					Image:              "docker.io/centos/php-71-centos7",
+					Image:              "quay.io/centos7/php-73-centos7:7.3",
 				},
 				Knative: KnativeConfiguration{
 					AddonConfiguration: AddonConfiguration{Enabled: false},
@@ -483,16 +483,16 @@ func getConfigLiteral() *Config {
 			},
 			Components: ComponentsSpec{
 				Oauth: OauthConfiguration{
-					Image: "quay.io/openshift/origin-oauth-proxy:v4.0.0",
+					Image: "quay.io/openshift/origin-oauth-proxy:4.9",
 				},
 				UI: UIConfiguration{
-					Image: "docker.io/syndesis/syndesis-ui:latest",
+					Image: "quay.io/syndesis/syndesis-ui:latest",
 				},
 				S2I: S2IConfiguration{
-					Image: "docker.io/syndesis/syndesis-s2i:latest",
+					Image: "quay.io/syndesis/syndesis-s2i:latest",
 				},
 				Server: ServerConfiguration{
-					Image: "docker.io/syndesis/syndesis-server:latest",
+					Image: "quay.io/syndesis/syndesis-server:latest",
 					Resources: Resources{
 						Limit: ResourceParams{
 							Memory: "800Mi",
@@ -520,7 +520,7 @@ func getConfigLiteral() *Config {
 					},
 				},
 				Meta: MetaConfiguration{
-					Image: "docker.io/syndesis/syndesis-meta:latest",
+					Image: "quay.io/syndesis/syndesis-meta:latest",
 					Resources: ResourcesWithPersistentVolume{
 						Limit: ResourceParams{
 							Memory: "512Mi",
@@ -533,12 +533,12 @@ func getConfigLiteral() *Config {
 					},
 				},
 				Database: DatabaseConfiguration{
-					Image: "postgresql:9.6",
+					Image: "quay.io/centos7/postgresql-12-centos7:latest",
 					User:  "syndesis",
 					Name:  "syndesis",
 					URL:   "postgresql://syndesis-db:5432/syndesis?sslmode=disable",
 					Exporter: ExporterConfiguration{
-						Image: "docker.io/wrouesnel/postgres_exporter:v0.4.7",
+						Image: "quay.io/testing-farm/postgres_exporter:v0.8.0",
 					},
 					Resources: ResourcesWithPersistentVolume{
 						Limit: ResourceParams{
@@ -552,7 +552,7 @@ func getConfigLiteral() *Config {
 					},
 				},
 				Prometheus: PrometheusConfiguration{
-					Image: "docker.io/prom/prometheus:v2.1.0",
+					Image: "quay.io/prometheus/prometheus:v2.30.3",
 					Resources: ResourcesWithPersistentVolume{
 						Limit: ResourceParams{
 							Memory: "512Mi",
@@ -565,7 +565,7 @@ func getConfigLiteral() *Config {
 					},
 				},
 				Upgrade: UpgradeConfiguration{
-					Image:     "docker.io/syndesis/syndesis-upgrade:latest",
+					Image:     "quay.io/syndesis/syndesis-upgrade:latest",
 					Resources: VolumeOnlyResources{VolumeCapacity: "1Gi"},
 				},
 				AMQ: AMQConfiguration{


### PR DESCRIPTION
chore: pull images as possible from quay.io (bcce7e6d64f7035ed223862a21640b0a3004a983)

All but the crunchy images are available on quay.io, so we can pull from
there and try to avoid Docker Hub rate limits. This also upgrades some
of the releases, mostly as older releases are not available on quay.io.

Fixes #9751

chore: tag default branch releases with latest (2d1ade6)

On Docker Hub we have a super old release tagged with `latest`, on
quay.io we don't have any image tagged with `latest`. This tags a
release from the GitHub default branch with `latest` on (pre-)release.

