### PR TITLE
chore: tag default branch releases with `latest`

### DIFF
--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -140,6 +140,9 @@ release::run() {
 
     # Pushing to image registry
     push_container_images "$release_version" "$moving_tag"
+    if [ "$(git branch --show-current)" == "$(github_default_branch)" ]; then
+        push_container_images "$release_version" latest
+    fi
 
     # Release staging repo
     release_staging_repo "$topdir" "$maven_opts"

--- a/tools/bin/commands/util/common_funcs
+++ b/tools/bin/commands/util/common_funcs
@@ -142,11 +142,15 @@ syndesis_config_dir() {
   echo $dir
 }
 
+github_default_branch() {
+  curl -s https://api.github.com/repos/syndesisio/syndesis |jq -r .default_branch
+}
+
 # ======================================================
 # Git update functions
 git_rebase_upstream() {
   local default_branch
-  default_branch=$(curl -s https://api.github.com/repos/syndesisio/syndesis |jq -r .default_branch)
+  default_branch=$(github_default_branch)
   echo "git fetch upstream ${default_branch}"
   git fetch upstream "${default_branch}"
   echo -n "git rebase upstream/${default_branch}"


### PR DESCRIPTION
On Docker Hub we have a super old release tagged with `latest`, on
quay.io we don't have any image tagged with `latest`. This tags a
release from the GitHub default branch with `latest` on (pre-)release.