### PR TITLE
Fix Kafka CRD API version

### DIFF
--- a/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataRetrieval.java
+++ b/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataRetrieval.java
@@ -47,7 +47,7 @@ public class KafkaMetaDataRetrieval extends ComponentMetadataRetrieval {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaMetaDataRetrieval.class);
 
     static final CustomResourceDefinition KAFKA_CRD = new CustomResourceDefinitionBuilder()
-        .withApiVersion("apiextensions.k8s.io/v1beta2")
+        .withApiVersion("apiextensions.k8s.io/v1")
         .withKind("CustomResourceDefinition")
         .withNewMetadata()
             .withName("kafkas.kafka.strimzi.io")


### PR DESCRIPTION
`apiextensions.k8s.io/v1beta2` is not a valid version for `apiextensions.k8s.io`
Since Strimzi from version 0.23.0 (https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.23.0) and AMQ Streams from version 1.8.0 uses CRD api version `v1` (`apiextensions.k8s.io/v1`), I used that one. 

However, autodiscover kafka broker will not work on OCP4.9 until the kubernetes-client is updated. ( since this https://github.com/mkralik3/syndesis/blob/1a8e51c1cd4120a5bf7e8b4b21ab74f9a5847733/app/connector/kafka/src/main/java/io/syndesis/connector/kafka/KafkaMetaDataRetrieval.java#L105 uses `v1beta1` which is not exist on OCP4.9  ) 
^ cc @zregvart 