### PR TITLE
chore: don't create daily releases if unchanged

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -20,17 +20,31 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           persist-credentials: false
+          fetch-depth: 0
+      - name: Check for changes
+        id: should
+        env:
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          RELEASE_TAGS=$(git tag --contains $(git rev-parse HEAD) | grep "^${BRANCH/.x/}") || true
+          if [ -n "${RELEASE_TAGS}" ]; then
+            echo The latest change was already included in a release, skipping release
+            echo ::set-output name=skip::true
+          fi
       - name: Set up JDK ${{ matrix.java }}
+        if: steps.should.outputs.skip != 'true'
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Maven Repository
+        if: steps.should.outputs.skip != 'true'
         uses: actions/cache@v1
         with:
           path: ~/.m2
           key: release-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: release-${{ runner.os }}-m2
       - name: Daily release of ${{ matrix.branch }}
+        if: steps.should.outputs.skip != 'true'
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
We don't need to create daily release if we didn't create any changes.
So this cancels the running workflow if the HEAD of the branch is
already included in a release tag.