### PR TITLE
chore: support lowercase table names with Oracle

### DIFF
--- a/app/connector/sql/pom.xml
+++ b/app/connector/sql/pom.xml
@@ -234,7 +234,26 @@
       <artifactId>mysql</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>oracle-xe</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/DatabaseContainers.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/DatabaseContainers.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class DatabaseContainers implements TestTemplateInvocationContextProvider {
@@ -122,6 +123,10 @@ public class DatabaseContainers implements TestTemplateInvocationContextProvider
             return new MariaDBContainer<>(imageName);
         case "mysql":
             return new MySQLContainer<>(imageName);
+        case "oracle/database":
+            return new OracleContainer(imageName)
+                .withEnv("ORACLE_PWD", "password")
+                .withPassword("password");
         default:
             throw new IllegalArgumentException("Unsupported container: " + imageName);
         }

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/IfImagePresentCondition.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/IfImagePresentCondition.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.testcontainers.DockerClientFactory;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+
+public class IfImagePresentCondition implements ExecutionCondition {
+
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @ExtendWith(IfImagePresentCondition.class)
+    static @interface IfImagePresent {
+        String value();
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        return AnnotationUtils.findAnnotation(context.getElement(), IfImagePresent.class)
+            .map(i -> {
+                final String imageName = i.value();
+                if (imagePresent(imageName)) {
+                    return ConditionEvaluationResult.enabled("Image `" + imageName + "` is present, enabling test");
+                }
+
+                return ConditionEvaluationResult.disabled("Image `" + imageName + "` is not present, disabling test");
+            })
+            .orElse(ConditionEvaluationResult.enabled("No @IfImagePresent annotation, free to proceed"));
+    }
+
+    private static boolean imagePresent(final String imageName) {
+        // we must not close the global DockerClient
+        @SuppressWarnings("resource")
+        final DockerClient client = DockerClientFactory.lazyClient();
+        try (InspectImageCmd command = client.inspectImageCmd(imageName)) {
+            command.exec();
+            return true;
+        } catch (final NotFoundException ignored) {
+            return false;
+        }
+    }
+
+}

--- a/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/OracleSqlMetaDataITCase.java
+++ b/app/connector/sql/src/test/java/io/syndesis/connector/sql/common/OracleSqlMetaDataITCase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.sql.common;
+
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import io.syndesis.connector.sql.common.DatabaseContainers.Database;
+import io.syndesis.connector.sql.common.IfImagePresentCondition.IfImagePresent;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IfImagePresent("oracle/database:18.4.0-xe")
+@Database("oracle/database:18.4.0-xe")
+public class OracleSqlMetaDataITCase {
+
+    @BeforeEach
+    public void createTestTable(final JdbcDatabaseContainer<?> oracle) throws SQLException {
+        try (Connection connection = oracle.createConnection("")) {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("CREATE TABLE table1 (column1 VARCHAR(50), column2 VARCHAR(50))");
+            }
+        }
+    }
+
+    @AfterEach
+    public void dropTestTable(final JdbcDatabaseContainer<?> oracle) throws SQLException {
+        try (Connection connection = oracle.createConnection("")) {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("DROP TABLE table1");
+            }
+        }
+    }
+
+    @ExtendWith(DatabaseContainers.class)
+    @TestTemplate
+    public void shouldGenerateMetadataForLowercaseTableNames(final JdbcDatabaseContainer<?> oracle) throws SQLException {
+        try (Connection connection = oracle.createConnection("")) {
+            final SqlStatementParser parser = new SqlStatementParser(connection, "select column1 from table1 where column2 = :#value_");
+            final SqlStatementMetaData info = parser.parse();
+            final List<SqlParam> inParams = info.getInParams();
+
+            final DbMetaDataHelper helper = new DbMetaDataHelper(connection);
+            final List<SqlParam> paramList = helper.getJDBCInfoByColumnOrder(null, null, "table1", inParams);
+
+            assertThat(paramList).hasSize(1);
+
+            final SqlParam sqlParam = paramList.get(0);
+            assertThat(sqlParam.getJdbcType()).isEqualTo(JDBCType.VARCHAR);
+        }
+    }
+}

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3552,6 +3552,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>oracle-xe</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-api</artifactId>
         <version>${docker-java.version}</version>


### PR DESCRIPTION
When dealing with Oracle database metadata it seems that we need to
provide the table/column names in upper case. This adds an additional
variant, to the one variant we already use with PostgreSQL which seems
to need lower case names, to uppercase the names.

The integration test with Oracle runs over 5min due to a very long
database startup and since the Oracle XE image is not available for pull
from an official source, the test is enabled only if the image is built
locally from the Dockerfiles available at[1].

Ref. https://issues.redhat.com/browse/ENTESB-17710

[1] https://github.com/oracle/docker-images/tree/main/OracleDatabase/SingleInstance