### PR TITLE
fix: keep track of removed environment variables

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/WithEnvironment.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/WithEnvironment.java
@@ -17,12 +17,19 @@ package io.syndesis.common.model;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.immutables.value.Value;
 
 public interface WithEnvironment {
+
     @Value.Default
     default Map<String, String> getEnvironment() {
         return Collections.emptyMap();
+    }
+
+    @Value.Default
+    default Set<String> getRemovedEnvironment() {
+        return Collections.emptySet();
     }
 }

--- a/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
+++ b/app/server/controller/src/main/java/io/syndesis/server/controller/integration/online/PublishHandler.java
@@ -151,6 +151,7 @@ public class PublishHandler extends BaseOnlineHandler implements StateChangeHand
         integration.getConfiguredProperties().forEach(deploymentDataBuilder::addProperty);
         integration.getLabels().forEach((k, v) -> deploymentDataBuilder.addLabel(k, v));
         integration.getEnvironment().forEach((k, v) -> deploymentDataBuilder.addEnvironmentVariable(k, v));
+        integration.getRemovedEnvironment().forEach(deploymentDataBuilder::removeEnvironmentVariable);
 
         DeploymentData data = deploymentDataBuilder.build();
 

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/DeploymentData.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/DeploymentData.java
@@ -19,8 +19,10 @@ package io.syndesis.server.openshift;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
 
@@ -37,6 +39,8 @@ public final class DeploymentData {
     private EnumSet<Exposure> exposure = EnumSet.noneOf(Exposure.class);
 
     private final List<EnvVar> environment = new ArrayList<>();
+
+    private final Set<String> removedEnvironment = new HashSet<>();
 
     public Map<String, String> getAnnotations() {
         return annotations;
@@ -129,9 +133,18 @@ public final class DeploymentData {
             that.environment.add(new EnvVar(name, value, null));
             return this;
         }
+
+        public DeploymentData.Builder removeEnvironmentVariable(final String name) {
+            that.removedEnvironment.add(name);
+            return this;
+        }
     }
 
     public List<EnvVar> getEnvironment() {
         return environment;
+    }
+
+    public Set<String> getRemovedEnvironment() {
+        return removedEnvironment;
     }
 }

--- a/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
+++ b/app/server/openshift/src/main/java/io/syndesis/server/openshift/OpenShiftServiceImpl.java
@@ -279,6 +279,7 @@ public class OpenShiftServiceImpl implements OpenShiftService {
                     .collect(Collectors.toList());
             // add missing vars
             envVars.addAll(envVarMap.values());
+            envVars.removeIf(e -> deploymentData.getRemovedEnvironment().contains(e.getName()));
 
             // edit ports to avoid duplicate or missing ports
             final ContainerPort[] ports = {

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -1280,6 +1280,13 @@
             },
             "type": "object"
           },
+          "removedEnvironment": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
           "resources": {
             "items": {
               "$ref": "#/components/schemas/ResourceIdentifier"
@@ -1648,6 +1655,13 @@
               "$ref": "#/components/schemas/ConfigurationProperty"
             },
             "type": "object"
+          },
+          "removedEnvironment": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
           },
           "resources": {
             "items": {

--- a/app/ui-react/packages/models/openapi.json
+++ b/app/ui-react/packages/models/openapi.json
@@ -1104,6 +1104,13 @@
             },
             "type": "object"
           },
+          "removedEnvironment": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
           "resources": {
             "items": {
               "$ref": "#/components/schemas/ResourceIdentifier"
@@ -1429,6 +1436,13 @@
               "$ref": "#/components/schemas/ConfigurationProperty"
             },
             "type": "object"
+          },
+          "removedEnvironment": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
           },
           "resources": {
             "items": {


### PR DESCRIPTION
We don't know if an environment variable in the integration's
DeploymentConfig was removed in the UI or if it was added by manually by
editing the DeploymentConfig as we keep track only of the next wanted
state of the environment variables. So when an environment variable is
removed via the UI we can't detect that and remove it from the
DeploymentConfig.

This keeps track of removed environment variables on integration update
by examining the current state and the next state of the integration and
looking at the difference in environment variables. So when an
environment variable is removed using the UI we now know that we also
need to remove it from the DeploymentConfig.

Ref. https://issues.redhat.com/browse/ENTESB-17748