### PR TITLE
refactor: name sanitization

### DIFF
--- a/app/common/util/pom.xml
+++ b/app/common/util/pom.xml
@@ -125,6 +125,16 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/app/common/util/src/main/java/io/syndesis/common/util/Names.java
+++ b/app/common/util/src/main/java/io/syndesis/common/util/Names.java
@@ -15,85 +15,104 @@
  */
 package io.syndesis.common.util;
 
-import java.util.Locale;
 import java.util.regex.Pattern;
-import static io.syndesis.common.util.Strings.truncate;
 
 public final class Names {
 
-    private static final Pattern VALID_REGEX = Pattern.compile("^[a-z0-9][-A-Za-z0-9\\\\]{0,61}[a-z0-9]$");
-    private static final Pattern INVALID_START_REGEX = Pattern.compile("^[^a-z0-9]+");
-    private static final Pattern INVALID_CHARACTER_REGEX = Pattern.compile("[^a-zA-Z0-9-\\._]");
-    private static final String SPACE = " ";
-    private static final String BLANK = "";
-    private static final String DASH = "-";
-    private static final String DOT = "\\.";
-    private static final String UNDERSCORE = "_";
-    //The actual limit is 253,
+    private static final String DEFAULT_NAME = "default";
+
+    // The actual limit is 253,
     // but individual resources have other limitations
     // (e.g. service has 63: RFC 1035)
     private static final int MAXIMUM_NAME_LENGTH = 63;
 
+    private static final Pattern VALID_REGEX = Pattern.compile("^[a-z0-9](?:[-A-Za-z0-9\\\\]{0,61}[a-z0-9])?$");
+
     private Names() {
-        //Utility
+        // Utility
     }
 
-    /**
-     * Sanitizes the specified name by applying the following rules:
-     * 1. Replace spaces with dashes.
-     * 2. Replace underscores with dashes.
-     * 3. Replace dots with dashes
-     * 4. Ensures that the first character is a alphanumeric
-     * 5. Remove invalid characters.
-     * 6. Keep the first 64 characters.
-     * @param name  The specified name.
-     * @return      The sanitized string.
-     */
-    public static String sanitize(String name) {
-        final String firstPass = name
-            .replace(SPACE, DASH)
-            .replace(UNDERSCORE, DASH)
-            .replaceAll(DOT, DASH)
-            .toLowerCase(Locale.US);
-
-        final String secondPass = INVALID_START_REGEX.matcher(firstPass).replaceAll(BLANK);
-
-        final String thirdPass = INVALID_CHARACTER_REGEX.matcher(secondPass).replaceAll(BLANK);
-
-        final String fourthPass = truncate(thirdPass.chars()
-             //Handle consecutive dashes
-            .collect(StringBuilder::new,
-                (b, chr) -> {
-                    int lastChar = b.length() > 0 ? b.charAt(b.length() - 1) : -1;
-
-                    if (lastChar != '-' || chr != '-') {
-                        b.appendCodePoint(chr);
-                    }
-             }, StringBuilder::append)
-            .toString(), MAXIMUM_NAME_LENGTH);
-
-        final int fourthPassLength = fourthPass.length();
-        if (Character.isLetterOrDigit(fourthPass.charAt(fourthPassLength - 1))) {
-            // this includes some letters and numbers out of ASCII range,
-            // but those should have been filtered out prior
-            return fourthPass;
-        }
-
-        if (fourthPassLength < MAXIMUM_NAME_LENGTH) {
-            return fourthPass + "0";
-        }
-
-        return fourthPass.substring(0, MAXIMUM_NAME_LENGTH - 1) + "0";
-    }
-
-
-    public static boolean isValid(String name) {
+    public static boolean isValid(final String name) {
         return VALID_REGEX.matcher(name).matches() && name.length() <= MAXIMUM_NAME_LENGTH;
     }
 
-    public static void validate(String name) {
+    /**
+     * Sanitizes the specified name.
+     *
+     * @param name The specified name.
+     * @return The sanitized string.
+     */
+    public static String sanitize(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Specified name is empty or null");
+        }
+
+        final StringBuilder sanitized = new StringBuilder();
+        char lastChar = 0;
+        final char[] nameAry = name.toCharArray();
+        for (int i = 0; i < nameAry.length && i < MAXIMUM_NAME_LENGTH; i++) {
+            final char ch = nameAry[i];
+            final char nextChar = determineNextCharacter(lastChar, ch);
+            if (nextChar == 0) {
+                continue;
+            }
+
+            lastChar = nextChar;
+            sanitized.append(nextChar);
+        }
+
+        if (sanitized.length() == 0) {
+            // if we didn't manage to find any characters to append as sanitized
+            // use the default name
+            return DEFAULT_NAME;
+        }
+
+        // make sure that the last character iz lowercase letter or digit
+        final int lastIdx = sanitized.length() - 1;
+        final char ch = sanitized.charAt(lastIdx);
+        if (ch == '-') {
+            if (lastIdx + 1 < MAXIMUM_NAME_LENGTH) {
+                sanitized.append('0');
+            } else {
+                sanitized.setCharAt(lastIdx, '0');
+            }
+        }
+
+        return sanitized.toString();
+    }
+
+    public static void validate(final String name) {
         if (!isValid(name)) {
             throw new IllegalArgumentException("Invalid name: [" + name + "].");
         }
+    }
+
+    private static char determineNextCharacter(final char lastChar, final char ch) {
+        if (isDigit(ch)) {
+            return ch;
+        } else if (shouldConvertToDash(ch) && lastChar != '-' && lastChar != 0) {
+            // don't add consecutive '-'
+            return '-';
+        } else {
+            final char[] chars = Character.toChars(ch);
+
+            if (isLetter(chars[0])) {
+                return Character.toLowerCase(chars[0]);
+            }
+        }
+
+        return 0;
+    }
+
+    private static boolean isDigit(final char ch) {
+        return ch >= '0' && ch <= '9';
+    }
+
+    private static boolean isLetter(final char ch) {
+        return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+    }
+
+    private static boolean shouldConvertToDash(final char ch) {
+        return ch == ' ' || ch == '_' || ch == '-' || ch == '.';
     }
 }

--- a/app/common/util/src/test/java/io/syndesis/common/util/NamesTest.java
+++ b/app/common/util/src/test/java/io/syndesis/common/util/NamesTest.java
@@ -15,6 +15,12 @@
  */
 package io.syndesis.common.util;
 
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -38,11 +44,24 @@ public class NamesTest {
         "01234567890123456789012345678901234567890123456789012345678901x, 01234567890123456789012345678901234567890123456789012345678901X",
         "0123456789012345678901234567890123456789012345678901234567890x, 0123456789012345678901234567890123456789012345678901234567890X",
         "012345678901234567890123456789012345678901234567890123456789012, 012345678901234567890123456789012345678901234567890123456789012.",
-        "012345678901234567890123456789012345678901234567890123456789010, 01234567890123456789012345678901234567890123456789012345678901."
+        "012345678901234567890123456789012345678901234567890123456789010, 01234567890123456789012345678901234567890123456789012345678901.",
+        "default, \"'",
+        "this-is-a-test-integration-name-that-wants-to-exceed-sixtyfour0, This is a test integration name that wants to exceed sixtyfour character lenghts... not even sure where it will be truncated at, but it will somewhere...",
+        "test-integration, test-integration"
     })
     public void testGetSanitizedName(final String projectName, final String integrationName) throws Exception {
         final String sanitized = Names.sanitize(integrationName);
         assertEquals(projectName, sanitized);
         assertTrue(Names.isValid(sanitized), "Sanitized name: `" + sanitized + "` is not valid");
+    }
+
+    @Property
+    boolean shouldGenerateValidSanitizedNames(@ForAll("stringsWithAtLeastOneCharacter") final String name) {
+        return Names.isValid(Names.sanitize(name));
+    }
+
+    @Provide
+    Arbitrary<String> stringsWithAtLeastOneCharacter() {
+        return Arbitraries.strings().ofMinLength(1);
     }
 }

--- a/app/common/util/src/test/resources/junit-platform.properties
+++ b/app/common/util/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+jqwik.reporting.onlyfailures=true


### PR DESCRIPTION
Refactors the name sanitization to make sure to cover edge cases like
the one mentioned in #4906. Now for names that are reduced to
zero-length we use the default name instead.

Fixes #4906