### PR TITLE
fix: manage environment variables on publish

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/WithEnvironment.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/WithEnvironment.java
@@ -17,7 +17,6 @@ package io.syndesis.common.model;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.immutables.value.Value;
 
@@ -28,8 +27,4 @@ public interface WithEnvironment {
         return Collections.emptyMap();
     }
 
-    @Value.Default
-    default Set<String> getRemovedEnvironment() {
-        return Collections.emptySet();
-    }
 }

--- a/app/server/controller/src/test/java/io/syndesis/server/controller/integration/online/PublishHandlerTest.java
+++ b/app/server/controller/src/test/java/io/syndesis/server/controller/integration/online/PublishHandlerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.controller.integration.online;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.integration.api.IntegrationProjectGenerator;
+import io.syndesis.server.controller.integration.IntegrationPublishValidator;
+import io.syndesis.server.controller.integration.online.customizer.DeploymentDataCustomizer;
+import io.syndesis.server.dao.IntegrationDao;
+import io.syndesis.server.dao.IntegrationDeploymentDao;
+import io.syndesis.server.openshift.DeploymentData;
+import io.syndesis.server.openshift.OpenShiftService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class PublishHandlerTest {
+
+    private final List<DeploymentDataCustomizer> customizers = Collections.emptyList();
+
+    private final IntegrationDao integrationDao = mock(IntegrationDao.class);
+
+    private final IntegrationDeploymentDao integrationDeploymentDao = mock(IntegrationDeploymentDao.class);
+
+    private final OpenShiftService openShiftService = mock(OpenShiftService.class);
+
+    private final IntegrationProjectGenerator projectGenerator = mock(IntegrationProjectGenerator.class);
+
+    private final IntegrationPublishValidator validator = mock(IntegrationPublishValidator.class);
+
+    @Test
+    void shouldComputeRemovedEnvironmentVariables() {
+        final PublishHandler handler = new PublishHandler(openShiftService, integrationDao, integrationDeploymentDao, projectGenerator, customizers, validator);
+
+        final Integration integration = new Integration.Builder()
+            .id("id")
+            .putEnvironment("ENV1", "VALUE1")
+            .putEnvironment("ENV4UPDATED", "VALUE4")
+            .build();
+
+        final IntegrationDeployment integrationDeployment = new IntegrationDeployment.Builder()
+            .spec(integration)
+            .userId("user")
+            .build();
+
+        final List<IntegrationDeployment> previousDeployments = Collections.singletonList(
+            new IntegrationDeployment.Builder()
+                .spec(new Integration.Builder()
+                    .putEnvironment("ENV1", "VALUE1")
+                    .putEnvironment("ENV2", "VALUE2")
+                    .putEnvironment("ENV4", "VALUE4")
+                    .build())
+                .build());
+
+        final DeploymentData deploymentData = handler.createDeploymentData(integration, integrationDeployment, previousDeployments);
+
+        assertThat(deploymentData.getRemovedEnvironment()).containsOnly("ENV2", "ENV4");
+        assertThat(deploymentData.getEnvironment()).extracting(EnvVar::getName).containsOnly("ENV1", "ENV4UPDATED");
+    }
+}

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.server.endpoint.v1.handler.integration;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -202,13 +201,9 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
     public void update(final String id, final Integration integration) {
         final Integration existing = getIntegration(id);
 
-        final Set<String> removedEnvironment = new HashSet<>(existing.getEnvironment().keySet());
-        removedEnvironment.removeAll(integration.getEnvironment().keySet());
-
         final Integration updatedIntegration = new Integration.Builder()
             .createFrom(encryptionSupport.encrypt(integration))
             .version(existing.getVersion() + 1)
-            .removedEnvironment(removedEnvironment)
             .updatedAt(now())
             .build();
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandlerTest.java
@@ -169,32 +169,6 @@ public class IntegrationHandlerTest {
         verify(openShiftService).delete("second to delete");
     }
 
-    @Test
-    public void shouldKeepTrackOfRemovedEnvironmentVariablesOnUpdate() {
-        final Integration existing = new Integration.Builder()
-            .id("i")
-            .putEnvironment("A", "1")
-            .putEnvironment("B", "2")
-            .build();
-        when(dataManager.fetch(Integration.class, "i")).thenReturn(existing);
-
-        final Integration updated = new Integration.Builder()
-            .putEnvironment("A", "1")
-            .putEnvironment("C", "3")
-            .build();
-
-        when(encryptionSupport.encrypt(updated)).thenReturn(updated);
-
-        handler.update("i", updated);
-
-        verify(dataManager).update(new Integration.Builder()
-            .createFrom(updated)
-            .version(2)
-            .updatedAt(1507562580000L)
-            .addRemovedEnvironment("B")
-            .build());
-    }
-
     private static DataShape dataShape(DataShapeKinds kind) {
         return dataShape(kind, null);
     }

--- a/app/ui-react/packages/models/openapi.internal.json
+++ b/app/ui-react/packages/models/openapi.internal.json
@@ -1280,13 +1280,6 @@
             },
             "type": "object"
           },
-          "removedEnvironment": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
           "resources": {
             "items": {
               "$ref": "#/components/schemas/ResourceIdentifier"
@@ -1655,13 +1648,6 @@
               "$ref": "#/components/schemas/ConfigurationProperty"
             },
             "type": "object"
-          },
-          "removedEnvironment": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
           },
           "resources": {
             "items": {

--- a/app/ui-react/packages/models/openapi.json
+++ b/app/ui-react/packages/models/openapi.json
@@ -1104,13 +1104,6 @@
             },
             "type": "object"
           },
-          "removedEnvironment": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
           "resources": {
             "items": {
               "$ref": "#/components/schemas/ResourceIdentifier"
@@ -1436,13 +1429,6 @@
               "$ref": "#/components/schemas/ConfigurationProperty"
             },
             "type": "object"
-          },
-          "removedEnvironment": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
           },
           "resources": {
             "items": {


### PR DESCRIPTION
Instead of managing the environment variables, i.e. in this case removal
of environment variables, at the point the integration is updated this
manages the environment variables at the point of publishing by
examining environment variables of previous deployments and adding any
environment variables that are not present on the latest deployment to
the list of environment variables to remove.

Ref. https://issues.redhat.com/browse/ENTESB-17748