### PR TITLE
chore: additional flags in daily release

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 5 * * *'
   workflow_dispatch:
+    flags:
+      description: 'Additional command line flags'
+      required: false
 
 jobs:
   release:
@@ -51,8 +54,9 @@ jobs:
           QUAYIO_USER: ${{ secrets.QUAYIO_USER }}
           QUAYIO_PASSWORD: ${{ secrets.QUAYIO_PASSWORD }}
           SYNDESISCI_TOKEN: ${{ secrets.SYNDESISCI_TOKEN }}
+          ADDITIONAL_FLAGS: ${{ github.event.inputs.flags }}
         run: |
           git config --global user.email admin@syndesis.io
           git config --global user.name 'Syndesis CI'
           git config --global 'http.https://github.com/.extraheader' "Authorization: basic $(echo -n x-access-token:${SYNDESISCI_TOKEN}|base64 --wrap=0)"
-          tools/bin/syndesis release --snapshot-release --git-remote origin --docker-user "${DOCKER_USER}" --docker-password "${DOCKER_PASSWORD}" --github-user syndesisci --github-token "${SYNDESISCI_TOKEN}" --quayio-user "${QUAYIO_USER}" --quayio-password "${QUAYIO_PASSWORD}"
+          tools/bin/syndesis release --snapshot-release --git-remote origin --docker-user "${DOCKER_USER}" --docker-password "${DOCKER_PASSWORD}" --github-user syndesisci --github-token "${SYNDESISCI_TOKEN}" --quayio-user "${QUAYIO_USER}" --quayio-password "${QUAYIO_PASSWORD}" ${ADDITIONAL_FLAGS}

--- a/tools/bin/commands/release
+++ b/tools/bin/commands/release
@@ -585,6 +585,10 @@ extract_maven_opts() {
         maven_opts+=" -Dgpg.keyname=${gpg_keyname} -Dgpg.passphrase=${gpg_passphrase}"
     fi
 
+    if [ "$(hasflag --verbose)" ]; then
+        maven_opts="$maven_opts -X"
+    fi
+
     echo "${maven_opts}"
 }
 


### PR DESCRIPTION
Seems that our daily release builds have failed, to try to troubleshoot
this this adds an option to specify additional flags for the release.
Also makes changes to the release script so if `--verbose` option is
given debug logs are turned on for Maven.