### PR TITLE
fix: connectorTemplateId state

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorSelectMethod.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/create/ApiConnectorCreatorSelectMethod.tsx
@@ -62,7 +62,9 @@ export const ApiConnectorCreatorSelectMethod: React.FunctionComponent<IApiConnec
     i18nUrlNote,
     onNext,
   }) => {
-    const [connectorTemplateId, setConnectorTemplateId] = React.useState('');
+    const [connectorTemplateId, setConnectorTemplateId] = React.useState<
+      string | undefined
+    >(undefined);
     const [method, setMethod] = React.useState(FILE);
     const [specification, setSpecification] = React.useState('');
     const [url, setUrl] = React.useState('');

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/create/SelectMethodPage.tsx
@@ -18,7 +18,9 @@ import resolvers from '../../resolvers';
 
 export const SelectMethodPage: React.FunctionComponent = () => {
   const { history } = useRouteData();
-  const [connectorTemplateId, setConnectorTemplateId] = React.useState('');
+  const [connectorTemplateId, setConnectorTemplateId] = React.useState<
+    string | undefined
+  >(undefined);
   const [specification, setSpecification] = React.useState<string | undefined>(
     undefined
   );
@@ -38,7 +40,7 @@ export const SelectMethodPage: React.FunctionComponent = () => {
       setIsLoading(false);
       setSpecification(undefined);
       setUrl(undefined);
-      setConnectorTemplateId('');
+      setConnectorTemplateId(undefined);
     }
   }, [error, uiContext, history, setError]);
 


### PR DESCRIPTION
We opted to use the `??` operator when defaulting the
`connectorTempalateId` property with the intention if it wasn't _set_
then it should default to `swagger-connector-template`. This created an
issue with setting the default React state of `connectorTempalateId` to
`""` as the `??` operator would use that value instead of the dafault
`swagger-connector-template`. That is, before when we used the ternary
operator (`?:`) it would consider the empty string as falsy and it would
use the default value instead.
This changes the default React state to `undefined` so that the logic
using the `??` operator branches to using the correct default value.

Ref. https://issues.redhat.com/browse/ENTESB-17811