### PR TITLE
chore: add dependency report to the S2I image

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Run integration tests
         run: tools/bin/syndesis integration-test --s2i --logging
       - name: Archive logs and test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: checks-integration-tests
@@ -142,3 +143,5 @@ jobs:
             app/test/integration-test/target/*.log
             app/test/integration-test/target/citrus-reports/**/*
             app/test/integration-test/target/failsafe-reports/*
+            app/s2i/target/invoker-reports/*
+            app/s2i/target/it/project/build.log

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -415,6 +415,28 @@
               <skipInvocation>false</skipInvocation>
             </configuration>
           </execution>
+          <execution>
+            <!--
+              Generates dependency tree report to make it easier
+              to trace back a dependency to it's root cause for
+              inclusion.
+            -->
+            <id>create-dependencies-txt</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <goals>
+                <goal>--batch-mode -T3.0C dependency:tree -Doutput=${image.build.directory}/dependencies.txt -DappendOutput=true</goal>
+              </goals>
+              <mergeUserSettings>true</mergeUserSettings>
+              <projectsDirectory>${project.build.directory}/generated</projectsDirectory>
+              <localRepositoryPath>${image.build.directory}/repository</localRepositoryPath>
+              <settingsFile>${project.build.directory}/settings_local.xml</settingsFile>
+              <skipInvocation>false</skipInvocation>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -381,7 +381,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
+                <goal>--batch-mode de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>
@@ -406,7 +406,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies</goal>
+                <goal>--batch-mode de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/s2i/src/main/assembly/repository.xml
+++ b/app/s2i/src/main/assembly/repository.xml
@@ -45,6 +45,7 @@
       <includes>
         <include>settings.xml</include>
         <include>licenses.xml</include>
+        <include>dependencies.txt</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
+++ b/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
@@ -196,7 +196,29 @@ public class Application implements ApplicationRunner {
         final GatheredDependencies deps = collectAllSteps();
 
         StringBuilder parentPom = new StringBuilder(5000);
-        parentPom.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://maven.apache.org/POM/4.0.0\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><modelVersion>4.0.0</modelVersion> <groupId>io.syndesis.integrations</groupId><artifactId>project</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging><modules>\n");
+        parentPom.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://maven.apache.org/POM/4.0.0\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><modelVersion>4.0.0</modelVersion> <groupId>io.syndesis.integrations</groupId><artifactId>project</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging>\n");
+        final Map<String, String> repositories = mavenProperties.getRepositories();
+        // make sure we have these if they're not specified, the generated projects should
+        // have them, but the go-offline-maven-plugin needs them in the parent POM
+        repositories.put("central", "https://repo.maven.apache.org/maven2/");
+        repositories.put("redhat-ga", "https://maven.repository.redhat.com/ga/");
+        repositories.put("atlassian-public", "https://packages.atlassian.com/maven-external");
+        if (!repositories.isEmpty()) {
+            parentPom.append("<repositories>\n");
+            for (Map.Entry<String, String> repository : repositories.entrySet()) {
+                parentPom.append("<repository>\n<id>")
+                    .append(repository.getKey())
+                    .append("</id>\n")
+                    .append("<url>")
+                    .append(repository.getValue())
+                    .append("</url>\n")
+                    .append("<releases>\n<enabled>true</enabled>\n<updatePolicy>never</updatePolicy>\n</releases>\n<snapshots>\n<enabled>true</enabled>\n<updatePolicy>never</updatePolicy>\n</snapshots>\n</repository>");
+            }
+            parentPom.append("</repositories>\n");
+        }
+
+        parentPom.append("<modules>");
+
         int i = 0;
         for (final Step step : deps.steps) {
           final Integration integration = new Integration.Builder()


### PR DESCRIPTION
When trying to track down why a dependency is present in the S2I image
we often need to drill down Maven POM files in search of the origin of a
dependency, it is also difficult to understand what brought in a
transitive dependency.

This adds the dependency report in a file called `dependencies.txt` to
the S2I image and the repository ZIP to help with that.