### PR TITLE
chore: 2.23.2.fuse-790054-redhat-00001 of Camel

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
-    <camel.version>2.23.2.fuse-790053</camel.version>
+    <camel.version>2.23.2.fuse-790054-redhat-00001</camel.version>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
     <dep.plugin.deploy.version>2.8.2</dep.plugin.deploy.version>
   </properties>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
-    <camel.version>2.23.2.fuse-790053</camel.version>
+    <camel.version>2.23.2.fuse-790054-redhat-00001</camel.version>
     <atlasmap.version>2.3.2</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -94,13 +94,13 @@
     <opentracing.spring.web.starter.version>3.0.0</opentracing.spring.web.starter.version>
 
     <!-- Global camel version used everywhere -->
-    <camel.version>2.23.2.fuse-790053</camel.version>
+    <camel.version>2.23.2.fuse-790054-redhat-00001</camel.version>
 
     <undertow.version>2.2.12.Final</undertow.version>
     <org.jboss.xnio.version>3.8.4.Final</org.jboss.xnio.version>
 
     <!-- CXF version, to be kept in sync with the one referenced by camel version above -->
-    <cxf.version>3.3.6.fuse-790048</cxf.version>
+    <cxf.version>3.3.6.fuse-790049-redhat-00001</cxf.version>
     <wss4j.version>2.2.2</wss4j.version>
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->


### PR DESCRIPTION
This is the 7.9 release of Red Hat Fuse, so we can fetch it from the GA
repository instead of the JBoss EA repository which seems to have issues
at the moment.