### PR TITLE
chore: remove references to jboss-ea repository

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -87,11 +87,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -103,11 +98,6 @@
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/extension/maven-plugin/src/it/with-data-shape-variants/pom.xml
+++ b/app/extension/maven-plugin/src/it/with-data-shape-variants/pom.xml
@@ -43,11 +43,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -59,11 +54,6 @@
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/extension/maven-plugin/src/it/with-data-shape/pom.xml
+++ b/app/extension/maven-plugin/src/it/with-data-shape/pom.xml
@@ -43,11 +43,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -59,11 +54,6 @@
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -90,11 +90,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -110,11 +105,6 @@
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/settings.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/settings.xml.mustache
@@ -56,18 +56,6 @@
             <updatePolicy>never</updatePolicy>
           </releases>
         </repository>
-        <repository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
@@ -86,18 +74,6 @@
           <id>redhat-ga</id>
           <name>Red Hat General Availability Repository</name>
           <url>https://maven.repository.redhat.com/ga/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
           <snapshots>
             <enabled>false</enabled>
           </snapshots>

--- a/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestConstants.java
+++ b/app/integration/project-generator/src/test/java/io/syndesis/integration/project/generator/TestConstants.java
@@ -42,7 +42,6 @@ final class TestConstants {
         MAVEN_PROPERTIES = new MavenProperties();
         MAVEN_PROPERTIES.addRepository("central", "https://repo.maven.apache.org/maven2/");
         MAVEN_PROPERTIES.addRepository("redhat-ga", "https://maven.repository.redhat.com/ga/");
-        MAVEN_PROPERTIES.addRepository("jboss-ea", "https://repository.jboss.org/nexus/content/groups/ea/");
 
         SYNDESIS_VERSION = ResourceBundle.getBundle("test").getString("syndesis.version");
         CAMEL_VERSION = ResourceBundle.getBundle("test").getString("camel.version");

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/shouldGenerateSettingsXml/settings.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/shouldGenerateSettingsXml/settings.xml
@@ -46,18 +46,6 @@
             <updatePolicy>never</updatePolicy>
           </releases>
         </repository>
-        <repository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
@@ -76,18 +64,6 @@
           <id>redhat-ga</id>
           <name>Red Hat General Availability Repository</name>
           <url>https://maven.repository.redhat.com/ga/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
           <snapshots>
             <enabled>false</enabled>
           </snapshots>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/shouldGenerateSettingsXmlWithMirror/settings.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/shouldGenerateSettingsXmlWithMirror/settings.xml
@@ -54,18 +54,6 @@
             <updatePolicy>never</updatePolicy>
           </releases>
         </repository>
-        <repository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
@@ -84,18 +72,6 @@
           <id>redhat-ga</id>
           <name>Red Hat General Availability Repository</name>
           <url>https://maven.repository.redhat.com/ga/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
           <snapshots>
             <enabled>false</enabled>
           </snapshots>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
@@ -33,11 +33,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>jboss-ea</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>redhat-ga</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -49,11 +44,6 @@
       <id>central</id>
       <name>central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>jboss-ea</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
@@ -33,11 +33,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>jboss-ea</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>redhat-ga</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -49,11 +44,6 @@
       <id>central</id>
       <name>central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>jboss-ea</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3814,11 +3814,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </repository>
-    <repository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
@@ -3830,11 +3825,6 @@
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
     </pluginRepository>
     <pluginRepository>
       <id>redhat-ga</id>

--- a/app/s2i/src/main/resources/settings.xml
+++ b/app/s2i/src/main/resources/settings.xml
@@ -56,18 +56,6 @@
           </releases>
         </repository>
         <repository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </repository>
-        <repository>
           <id>atlassian-public</id>
           <name>Atlassian Repository</name>
           <url>https://packages.atlassian.com/maven-external</url>
@@ -107,18 +95,6 @@
           <id>redhat-ga</id>
           <name>Red Hat General Availability Repository</name>
           <url>https://maven.repository.redhat.com/ga/</url>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-ea</id>
-          <name>JBoss Community Early Access Release Repository</name>
-          <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
           <snapshots>
             <enabled>false</enabled>
           </snapshots>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -59,11 +59,6 @@
       <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
-      <id>jboss-ea</id>
-      <name>JBoss Early Access</name>
-      <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
-    </pluginRepository>
-    <pluginRepository>
       <id>redhat-ga</id>
       <name>Red Hat General Availability Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>

--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -92,6 +92,5 @@ Syndesis:
                     Repositories:
                         central: "https://repo.maven.apache.org/maven2/"
                         repo-02-redhat-ga: "https://maven.repository.redhat.com/ga/"
-                        repo-03-jboss-ea: "https://repository.jboss.org/nexus/content/groups/ea/"
         AMQ:
             Image: "registry.access.redhat.com/jboss-amq-6/amq63-openshift:1.4"

--- a/tools/bin/commands/util/openshift_funcs
+++ b/tools/bin/commands/util/openshift_funcs
@@ -16,7 +16,7 @@ check_oc_version()
     set_gnugrep
 
     local test=$(oc version | $gnugrep -Eiv 'kubernetes|server' | $gnugrep -o '[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\?')
-    
+
     if [ -z "$test" ]; then
       echo "ERROR: 'Version of oc could not be found'"
       return
@@ -183,20 +183,7 @@ install_maven_mirror() {
 
     nexus_host=$(oc get routes nexus -o=jsonpath='{.spec.host}')
 
-    echo "Setting up jboss-ea and redhat-ga proxies..."
-
-    curl -X POST \
-        http://${nexus_host}/nexus/service/local/repositories \
-        -H 'authorization: Basic YWRtaW46YWRtaW4xMjM=' \
-        -H 'cache-control: no-cache' \
-        -H 'content-type: application/json' \
-        -d '{"data":{"repoType":"proxy","id":"jboss-ea","name":"JBoss Early Access","browseable":true,"indexable":true,
-        "notFoundCacheTTL":1440,"artifactMaxAge":-1,"metadataMaxAge":1440,"itemMaxAge":1440,"repoPolicy":"RELEASE",
-        "provider":"maven2","providerRole":"org.sonatype.nexus.proxy.repository.Repository","downloadRemoteIndexes":true,
-        "autoBlockActive":true,"fileTypeValidation":true,"exposed":true,"checksumPolicy":"WARN",
-        "remoteStorage":{"remoteStorageUrl":"https://repository.jboss.org/nexus/content/groups/ea/","authentication":null,
-        "connectionSettings":null}}}' \
-        >/dev/null 2>&1
+    echo "Setting up redhat-ga and atlassian proxy..."
 
     curl -X POST \
         http://${nexus_host}/nexus/service/local/repositories \
@@ -231,7 +218,7 @@ install_maven_mirror() {
         -H 'content-type: application/json' \
         -H 'postman-token: eaa6b07c-87ac-53c5-1ab6-aa585ae9ee3c' \
         -d '{"data":{"id":"public","name":"Public Repositories","format":"maven2","exposed":true,"provider":"maven2",
-        "repositories":[{"id":"releases"},{"id":"snapshots"},{"id":"thirdparty"},{"id":"central"},{"id":"jboss-ea"},
+        "repositories":[{"id":"releases"},{"id":"snapshots"},{"id":"thirdparty"},{"id":"central"},
         {"id":"redhat-ga"},{"id":"atlassian-public"}]}}' \
         >/dev/null 2>&1
 


### PR DESCRIPTION
With our usage of GA Fuse Camel version we no longer need to reference
JBoss EA repository, so this removes all references to it.