### PR TITLE
fix: s2i dependency download

### DIFF
--- a/app/s2i/pom.xml
+++ b/app/s2i/pom.xml
@@ -381,7 +381,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
+                <goal>--batch-mode de.qaware.maven:go-offline-maven-plugin:1.2.7:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>
@@ -406,7 +406,7 @@
             </goals>
             <configuration>
               <goals>
-                <goal>--batch-mode -T3.0C de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies</goal>
+                <goal>--batch-mode de.qaware.maven:go-offline-maven-plugin:1.2.3:resolve-dependencies -DfailOnErrors=true</goal>
               </goals>
               <mergeUserSettings>true</mergeUserSettings>
               <projectsDirectory>${project.build.directory}/generated</projectsDirectory>

--- a/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
+++ b/app/server/builder/image-generator/src/main/java/io/syndesis/server/builder/image/generator/Application.java
@@ -196,7 +196,29 @@ public class Application implements ApplicationRunner {
         final GatheredDependencies deps = collectAllSteps();
 
         StringBuilder parentPom = new StringBuilder(5000);
-        parentPom.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://maven.apache.org/POM/4.0.0\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><modelVersion>4.0.0</modelVersion> <groupId>io.syndesis.integrations</groupId><artifactId>project</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging><modules>\n");
+        parentPom.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://maven.apache.org/POM/4.0.0\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"><modelVersion>4.0.0</modelVersion> <groupId>io.syndesis.integrations</groupId><artifactId>project</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging>\n");
+        final Map<String, String> repositories = mavenProperties.getRepositories();
+        // make sure we have these if they're not specified, the generated projects should
+        // have them, but the go-offline-maven-plugin needs them in the parent POM
+        repositories.put("central", "https://repo.maven.apache.org/maven2/");
+        repositories.put("redhat-ga", "https://maven.repository.redhat.com/ga/");
+        repositories.put("atlassian-public", "https://packages.atlassian.com/maven-external");
+        if (!repositories.isEmpty()) {
+            parentPom.append("<repositories>\n");
+            for (Map.Entry<String, String> repository : repositories.entrySet()) {
+                parentPom.append("<repository>\n<id>")
+                    .append(repository.getKey())
+                    .append("</id>\n")
+                    .append("<url>")
+                    .append(repository.getValue())
+                    .append("</url>\n")
+                    .append("<releases>\n<enabled>true</enabled>\n<updatePolicy>never</updatePolicy>\n</releases>\n<snapshots>\n<enabled>true</enabled>\n<updatePolicy>never</updatePolicy>\n</snapshots>\n</repository>");
+            }
+            parentPom.append("</repositories>\n");
+        }
+
+        parentPom.append("<modules>");
+
         int i = 0;
         for (final Step step : deps.steps) {
           final Integration integration = new Integration.Builder()


### PR DESCRIPTION
The `go-offline-maven-plugin` was invoked without specifying
`-DfailOnErrors=true`, so it could fail silently. The plugin also runs
against the parent POM, the modules are skipped, and the repository
configuration is read from the project, the provided settings file helps
with caching but if a repository is not defined in the parent POM it
will not be used.

These two things combined lead to the S2I image missing dependencies
that are not available on Maven central.

Since the plugin runs only for the parent POM it doesn't make much sense
to run it in parallel, so that was removed.

In the project generator application, the application used to generate
projects for dependency gathering the three repositories that we know
are required are set in addition to any repositories that could be
configured in the Spring configuration environment.