### PR TITLE
chore: use same version of jsoup in box connector

### DIFF
--- a/app/connector/box/pom.xml
+++ b/app/connector/box/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>value</artifactId>
             <classifier>annotations</classifier>
         </dependency>
+        <dependency>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+          <scope>runtime</scope>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/app/connector/email/pom.xml
+++ b/app/connector/email/pom.xml
@@ -49,11 +49,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.jsoup</groupId>
-        <artifactId>jsoup</artifactId>
-        <version>1.14.3</version>
-    </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3768,6 +3768,12 @@
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>org.jsoup</groupId>
+        <artifactId>jsoup</artifactId>
+        <version>1.14.3</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The version of jsoup in the email connector did not encompass the box
connector, this way we'll make sure that both versions are the same.

Ref. https://issues.redhat.com/browse/ENTESB-17765