### PR TITLE
fix: accidental Tomcat inclusion

### DIFF
--- a/app/common/jaeger-spring-boot-starter/pom.xml
+++ b/app/common/jaeger-spring-boot-starter/pom.xml
@@ -29,6 +29,22 @@
   <name>Common :: Jaeger Spring Boot Starter</name>
   <packaging>jar</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>${libthrift.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -50,6 +66,11 @@
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
       <version>${opentracing.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -142,6 +142,7 @@
     <citrus.version>2.8.0</citrus.version>
     <mockito.version>3.8.0</mockito.version>
     <mongodb.version>3.9.0</mongodb.version>
+    <libthrift.version>0.14.1</libthrift.version>
 
     <resteasy.version>4.6.0.Final</resteasy.version>
     <resteasy-spring-boot-starter.version>4.8.0.Final</resteasy-spring-boot-starter.version>
@@ -3759,7 +3760,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.14.1</version>
+        <version>${libthrift.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.tomcat.embed</groupId>


### PR DESCRIPTION
In #9819 embedded Tomcat dependency sneaked in, which caused it to be
used instead of Undertow, but more importantly the integration failed to
start as the version that was brought in by libthrift was not compatible
with the version that the spring-boot-tomcat-starter expected.