### PR TITLE
chore: enforce and converge dependencies

### DIFF
--- a/app/connector/amqp/pom.xml
+++ b/app/connector/amqp/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.qpid</groupId>
       <artifactId>qpid-jms-client</artifactId>
-      <version>0.54.0</version>
+      <version>0.54.0.redhat-00001</version>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>

--- a/app/connector/box/pom.xml
+++ b/app/connector/box/pom.xml
@@ -28,7 +28,7 @@
     <name>Connector :: Box</name>
 
     <properties>
-        <box-java-sdk-version>2.32.0</box-java-sdk-version>
+        <box-java-sdk-version>2.31.0</box-java-sdk-version>
     </properties>
 
     <dependencies>

--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -33,7 +33,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.10</version>
+        <version>4.5.13</version>
         <classifier>tests</classifier>
         <exclusions>
           <exclusion>

--- a/app/connector/jira/pom.xml
+++ b/app/connector/jira/pom.xml
@@ -29,8 +29,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <!-- The 5.1.0 version uses an old guava 20 version incompatible with the default guava set on syndesis -->
-        <atlassian-jira-rest-java-client-version>5.1.6</atlassian-jira-rest-java-client-version>
+        <atlassian-jira-rest-java-client-version>5.1.6.redhat-00001</atlassian-jira-rest-java-client-version>
         <atlassian-util-concurrent-version>4.0.1</atlassian-util-concurrent-version>
     </properties>
 

--- a/app/connector/odata-v2/pom.xml
+++ b/app/connector/odata-v2/pom.xml
@@ -28,42 +28,18 @@
   <name>Connector :: OData V2</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <olingoVersion>2.0.11</olingoVersion>
-    <!-- To be removed once CAMEL-13006 has been integrated into fuse release of camel-olingo2 component -->
-    <schemeName>olingo2</schemeName>
-    <componentName>Olingo2</componentName>
-    <componentPackage>org.apache.camel.component.olingo2</componentPackage>
-    <maven.exe.file.extension />
-    <camel.osgi.export.pkg>${componentPackage}</camel.osgi.export.pkg>
-    <componentPackage>org.apache.camel.component.olingo2</componentPackage>
-    <outPackage>org.apache.camel.component.olingo2.internal</outPackage>
-    <camel.osgi.private.pkg>${outPackage}</camel.osgi.private.pkg>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <!-- Apache Olingo Library dependencies -->
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>olingo-odata2-api</artifactId>
-        <version>${olingoVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.olingo</groupId>
-        <artifactId>olingo-odata2-core</artifactId>
-        <version>${olingoVersion}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>${olingo2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>olingo-odata2-client-api</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -74,7 +50,7 @@
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>olingo-odata2-client-core</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo2.version}</version>
         <exclusions>
           <exclusion>
             <groupId>junit</groupId>
@@ -92,7 +68,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.10</version>
+        <version>4.5.13</version>
         <classifier>tests</classifier>
         <exclusions>
           <exclusion>
@@ -125,19 +101,19 @@
         <artifactId>olingo-odata2-api-annotation</artifactId>
         <groupId>org.apache.olingo</groupId>
         <type>jar</type>
-        <version>${olingoVersion}</version>
+        <version>${olingo2.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>olingo-odata2-annotation-processor-api</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo2.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>olingo-odata2-annotation-processor-core</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo2.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -29,7 +29,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <olingoVersion>4.8.0</olingoVersion>
+    <olingo.version>4.8.0</olingo.version>
   </properties>
 
   <dependencyManagement>
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.10</version>
+        <version>4.5.13</version>
         <classifier>tests</classifier>
         <exclusions>
           <exclusion>
@@ -49,32 +49,32 @@
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-commons-api</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-client-core</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-client-api</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-server-api</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-commons-core</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-server-core</artifactId>
-        <version>${olingoVersion}</version>
+        <version>${olingo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/app/connector/slack/pom.xml
+++ b/app/connector/slack/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1.redhat-1</version>
         <exclusions>
           <exclusion>
           <groupId>junit</groupId>

--- a/app/connector/soap/pom.xml
+++ b/app/connector/soap/pom.xml
@@ -95,11 +95,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.wss4j</groupId>
-      <artifactId>wss4j-ws-security-common</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
@@ -111,6 +106,17 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-bindings-soap</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.santuario</groupId>
+      <artifactId>xmlsec</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.wss4j</groupId>
+      <artifactId>wss4j-ws-security-common</artifactId>
     </dependency>
 
     <dependency>

--- a/app/connector/support/maven-plugin/pom.xml
+++ b/app/connector/support/maven-plugin/pom.xml
@@ -29,6 +29,26 @@
   <name>Connector :: Support :: Maven Plugin</name>
   <packaging>maven-plugin</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>2.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-classworlds</artifactId>
+        <version>2.6.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/app/connector/twitter/pom.xml
+++ b/app/connector/twitter/pom.xml
@@ -28,7 +28,7 @@
     <name>Connector :: Twitter</name>
 
     <properties>
-        <twitter4j-version>4.0.7</twitter4j-version>
+        <twitter4j-version>4.0.7.redhat-00002</twitter4j-version>
     </properties>
 
     <dependencyManagement>

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -28,6 +28,10 @@
   <name>Extension :: Maven Plugin</name>
   <packaging>maven-plugin</packaging>
 
+  <properties>
+    <maven.resolver.version>1.6.3</maven.resolver.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -121,6 +125,46 @@
             <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-resolver-provider</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-repository-metadata</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-impl</artifactId>
+        <version>${maven.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-spi</artifactId>
+        <version>${maven.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-util</artifactId>
+        <version>${maven.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-provider-api</artifactId>
+        <version>3.4.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-interpolation</artifactId>
+        <version>1.26</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
+++ b/app/integration/runtime/src/test/java/io/syndesis/integration/runtime/handlers/LogStepHandlerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class LogStepHandlerTest {
 
@@ -120,7 +120,7 @@ public class LogStepHandlerTest {
 
         assertThat(handler.handle(step, route, NOT_USED, "1", "2")).isEmpty();
 
-        verifyZeroInteractions(route);
+        verifyNoInteractions(route);
     }
 
     @Test

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -57,7 +57,7 @@
 
     <hibernate.validator.version>6.0.22.Final</hibernate.validator.version>
 
-    <jackson.version>2.11.2</jackson.version>
+    <jackson.version>2.12.6</jackson.version>
     <json-patch.version>1.13</json-patch.version>
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
 
@@ -81,7 +81,7 @@
     <arquillian.version>1.4.0.Final</arquillian.version>
     <arquillian.cube.version>1.18.2</arquillian.cube.version>
 
-    <maven.version>3.8.1</maven.version>
+    <maven.version>3.8.3</maven.version>
 
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <errorprone.version>2.7.1</errorprone.version>
@@ -100,7 +100,9 @@
 
     <!-- CXF version, to be kept in sync with the one referenced by camel version above -->
     <cxf.version>3.3.6.fuse-7_10_0-00022-redhat-00001</cxf.version>
-    <wss4j.version>2.2.2</wss4j.version>
+    <wss4j.version>2.4.0</wss4j.version>
+
+    <olingo2.version>2.0.11</olingo2.version>
 
     <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
     <basepom.test.fork-count>1</basepom.test.fork-count>
@@ -136,13 +138,12 @@
     <mailapi.version>1.6.4</mailapi.version>
     <json-schema-core.version>1.2.14</json-schema-core.version>
     <json-schema-validator.version>2.2.14</json-schema-validator.version>
-    <junit-jupiter.version>5.7.1</junit-jupiter.version>
-    <powermock.version>2.0.4</powermock.version>
+    <junit-jupiter.version>5.8.1</junit-jupiter.version>
+    <powermock.version>2.0.9</powermock.version>
     <testcontainers.version>1.16.3</testcontainers.version>
     <docker-java.version>3.2.12</docker-java.version>
     <citrus.version>2.8.0</citrus.version>
-    <mockito.version>3.8.0</mockito.version>
-    <!-- any change to mongodb driver version, should be updated to integration-bom/pom.xml -->
+    <mockito.version>4.0.0</mockito.version>
     <mongodb.version>3.12.7</mongodb.version>
     <libthrift.version>0.14.1</libthrift.version>
 
@@ -164,7 +165,7 @@
     <google-api-client-version>1.22.0</google-api-client-version>
     <kafka-clients.version>2.5.0</kafka-clients.version>
     <netty.version>4.1.68.Final</netty.version>
-    <net.jqwik.version>1.5.1</net.jqwik.version>
+    <net.jqwik.version>1.6.0</net.jqwik.version>
     <io.github.zregvart.junit-github-reporter.version>0.4.0</io.github.zregvart.junit-github-reporter.version>
     <io.strimzi.kafka.oauth.version>0.7.2</io.strimzi.kafka.oauth.version>
     <bouncycastle.version>1.69</bouncycastle.version>
@@ -1152,6 +1153,7 @@
               <!-- Multiple Teiid JARs share the same classes, not sure if anything can be done about that -->
               <ignoredClassPattern>^org\.teiid\..*$</ignoredClassPattern>
               <ignoredClassPattern>^org\.json\.JSONString$</ignoredClassPattern>
+              <ignoredClassPattern>META-INF.versions.11.module-info</ignoredClassPattern>
             </ignoredClassPatterns>
             <exceptions>
               <exception>
@@ -1519,6 +1521,7 @@
               <message>camel-test brings in junit:junit</message>
               <searchTransitive>false</searchTransitive>
             </bannedDependencies>
+            <dependencyConvergence />
           </rules>
         </configuration>
         <executions>
@@ -1903,6 +1906,36 @@
             <artifactId>bcprov-jdk15on</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.neethi</groupId>
+        <artifactId>neethi</artifactId>
+        <version>3.2.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.santuario</groupId>
+        <artifactId>xmlsec</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.olingo</groupId>
+        <artifactId>olingo-odata2-core</artifactId>
+        <version>${olingo2.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.olingo</groupId>
+        <artifactId>olingo-odata2-api</artifactId>
+        <version>${olingo2.version}</version>
       </dependency>
 
       <!-- ::::::::::: rest :::::::::::: -->
@@ -2552,6 +2585,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.wildfly.common</groupId>
+        <artifactId>wildfly-common</artifactId>
+        <version>1.5.2.Final</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.xnio</groupId>
         <artifactId>xnio-nio</artifactId>
         <version>${org.jboss.xnio.version}</version>
@@ -3047,6 +3086,10 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>mailapi</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>net.sf.jopt-simple</groupId>
+            <artifactId>jopt-simple</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -3230,6 +3273,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
@@ -3284,6 +3333,12 @@
         <artifactId>awaitility</artifactId>
         <version>4.1.1</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.10.1.redhat-00001</version>
       </dependency>
 
       <dependency>
@@ -3496,16 +3551,22 @@
       </dependency>
 
       <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-standalone</artifactId>
-        <version>2.25.1</version>
+        <version>2.27.2</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
-        <version>2.25.1</version>
+        <version>2.27.2</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -3525,6 +3586,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>net.sf.jopt-simple</groupId>
+            <artifactId>jopt-simple</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -3535,7 +3600,19 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>3.19.0</version>
+      </dependency>
+
       <!-- Micrometer -->
+      <dependency>
+        <groupId>org.hdrhistogram</groupId>
+        <artifactId>HdrHistogram</artifactId>
+        <version>2.1.12</version>
+      </dependency>
+
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>

--- a/app/server/api-generator/pom.xml
+++ b/app/server/api-generator/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.apache.ws.xmlschema</groupId>
       <artifactId>xmlschema-core</artifactId>
-      <version>2.2.5</version>
+      <version>2.2.5.redhat-00001</version>
     </dependency>
 
     <dependency>

--- a/app/server/cli/pom.xml
+++ b/app/server/cli/pom.xml
@@ -60,6 +60,37 @@
         <artifactId>tomcat-jdbc</artifactId>
         <version>${tomcat.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.kakawait</groupId>
+        <artifactId>picocli-spring-boot-starter</artifactId>
+        <version>0.2.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.kakawait</groupId>
+        <artifactId>picocli-spring-boot-autoconfigure</artifactId>
+        <version>0.2.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli</artifactId>
+        <version>4.0.4</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -129,13 +160,11 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>4.0.4</version>
     </dependency>
 
     <dependency>
       <groupId>com.kakawait</groupId>
       <artifactId>picocli-spring-boot-autoconfigure</artifactId>
-      <version>0.2.0</version>
     </dependency>
 
     <dependency>
@@ -169,7 +198,6 @@
     <dependency>
       <groupId>com.kakawait</groupId>
       <artifactId>picocli-spring-boot-starter</artifactId>
-      <version>0.2.0</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionActionHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.server.endpoint.v1.handler.connection;
 
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.Arrays;
@@ -38,7 +37,6 @@ import io.syndesis.server.endpoint.v1.dto.Meta;
 import io.syndesis.server.endpoint.v1.dto.MetaData;
 import io.syndesis.server.verifier.MetadataConfigurationProperties;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -129,10 +127,6 @@ public class ConnectionActionHandlerTest {
 
     @Test
     public void shouldAddMetaAndSetStatusToBadRequestIfMetaCallFails() {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        final Class<Entity<Map<String, Object>>> entityType = (Class) Entity.class;
-        ArgumentCaptor.forClass(entityType);
-
         // simulates fallback return
         final DynamicActionMetadata fallback = new DynamicActionMetadata.Builder().build();
         when(metadataCommand.execute()).thenReturn(fallback);
@@ -213,10 +207,6 @@ public class ConnectionActionHandlerTest {
 
     @Test
     public void shouldProvideActionDefinition() {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        final Class<Entity<Map<String, Object>>> entityType = (Class) Entity.class;
-        ArgumentCaptor.forClass(entityType);
-
         final DynamicActionMetadata suggestions = new DynamicActionMetadata.Builder()
             .putProperty("sObjectName", Arrays.asList(DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Account", "Account"),
                 DynamicActionMetadata.ActionPropertySuggestion.Builder.of("Contact", "Contact")))
@@ -246,10 +236,6 @@ public class ConnectionActionHandlerTest {
 
     @Test
     public void shouldSetInoutOutputShapesToAnyIfMetadataCallFails() {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        final Class<Entity<Map<String, Object>>> entityType = (Class) Entity.class;
-        ArgumentCaptor.forClass(entityType);
-
         // simulates fallback return
         final DynamicActionMetadata fallback = new DynamicActionMetadata.Builder().build();
         when(metadataCommand.execute()).thenReturn(fallback);

--- a/app/test/integration-test/pom.xml
+++ b/app/test/integration-test/pom.xml
@@ -200,7 +200,6 @@
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
-      <version>2.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -429,7 +428,7 @@
         <groupId>org.basepom.maven</groupId>
         <artifactId>duplicate-finder-maven-plugin</artifactId>
         <configuration>
-          <ignoredClassPatterns>
+          <ignoredClassPatterns combine.children="append">
             <ignoredClassPattern>org.w3._2001.xmlschema.Adapter[12]</ignoredClassPattern>
             <!--
               Jakarta project shipped activation com.sun.activation:jakarta.activation-api:1.2.1
@@ -439,7 +438,7 @@
             <ignoredClassPattern>^javax\.activation\..*$</ignoredClassPattern>
             <ignoredClassPattern>^META-INF\.versions\.9\.module-info$</ignoredClassPattern>
           </ignoredClassPatterns>
-          <ignoredResourcePatterns>
+          <ignoredResourcePatterns combine.children="append">
             <ignoredResourcePattern>binding.xjb</ignoredResourcePattern>
             <ignore>saml2-xacml2-profile.xml</ignore>
             <ignore>com/consol/citrus/schema/citrus-config.xsd</ignore>


### PR DESCRIPTION
This enforces the dependency convergence via Maven Enforcer rule and
converges the dependencies to a single version. In cases this meant
removing a Syndesis-declared dependency, upgrading or (rarely)
downgrading a dependency.

Going forward this will fail the build in case non-converged
dependencies are found and hopefully solve dependency issues as they're
introduced.