### PR TITLE
chore: compiler version in integration project

### DIFF
--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
@@ -123,6 +123,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@dep.plugin.compiler.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/redhat/pom.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/redhat/pom.xml.mustache
@@ -95,6 +95,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
@@ -129,6 +129,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/redhat/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/redhat/pom.xml
@@ -97,6 +97,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
@@ -125,6 +125,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/redhat/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/redhat/pom.xml
@@ -93,6 +93,14 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>


### PR DESCRIPTION
By setting the explicit version for the Maven compiler plugin in the
integration project POM via the Project generator, we make sure that the
corrupt `org.apache.maven:maven-tooling:1.0:jar` file is not downloaded
and present in the repository cache.

Ref. https://issues.redhat.com/browse/ENTESB-17847