### PR TITLE
fix: force newer Gson version

### DIFF
--- a/app/connector/odata-v2/pom.xml
+++ b/app/connector/odata-v2/pom.xml
@@ -101,6 +101,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.8.7</version>
+      </dependency>
 
       <!-- Test scoped dependencies -->
       <dependency>
@@ -223,6 +228,15 @@
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <classifier>annotations</classifier>
+    </dependency>
+
+    <!-- The version brought in by olingo-odata2-core is 2.4 for Spring
+         Boot Gson starter minimal version is 2.6, so we force the
+         version here -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
The Apache Olingo 2 depends on a version of Gson (2.4) that is too old
for the Spring Boot Gson starter which requires 2.6 or newer. This
change forces the version to the version brought in by Jaeger (2.8.7),
and it's the same version that was brought in by the now removed
`spring-boot-dependencies` BOM.

Ref. https://issues.redhat.com/browse/ENTESB-17885