### PR TITLE
fix: declare spring-boot-starter version

### DIFF
--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/pom.xml.mustache
@@ -89,6 +89,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>\${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>\${spring-boot.version}</version>
       <exclusions>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/pom.xml
@@ -95,6 +95,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>\${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>\${spring-boot.version}</version>
       <exclusions>

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateTemplateStepProjectDependencies/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>\${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <version>\${spring-boot.version}</version>
       <exclusions>


### PR DESCRIPTION
When we removed import of `spring-boot-dependencies` BOM we lost the
declaration, among others, of `spring-boot-starter` version. This is not
an issue for integrations built with provided set of connectors/steps,
but it could be an issue with extensions that could declare it as a
dependency.

Ref. https://issues.redhat.com/browse/ENTESB-17890