### PR TITLE
fix(ci): checks workflow GITHUB_REF check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           DEFAULT_BRANCH=$(curl -s https://api.github.com/repos/syndesisio/syndesis |jq -r .default_branch)
           IS_DEFAULT_BRANCH=$(test "refs/heads/${DEFAULT_BRANCH}" == "${GITHUB_REF}" && echo true || echo false)
-          IS_RELEASE_BRANCH=$(echo "${GITHUB_REF}" | grep -q -e '^[0-9]\+\.[0-9]\+\.x' && echo true || echo false)
+          IS_RELEASE_BRANCH=$(echo "${GITHUB_REF}" | grep -q -e '^refs/heads/[0-9]\+\.[0-9]\+\.x' && echo true || echo false)
           echo "::set-output name=is-default-branch::${IS_DEFAULT_BRANCH}"
           echo "::set-output name=is-release-branch::${IS_RELEASE_BRANCH}"
   changes:


### PR DESCRIPTION
We need to check with the `$GITHUB_REF` that contains `refs/heads/`
prefix.