### PR TITLE
fix(ci): github.ref instead of default branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             backend:
               - 'app/(!(ui-react))**'


### PR DESCRIPTION
For release branches we end up computing changes between the default
branch and the change on the release branch. By having the `github.ref`
here the `dorny/paths-filter` looks at the most recent commit before the
push, and since we use merge commits that should amount to the changes
made on the pull request that was merged.