### PR TITLE
chore: release staging robustness

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -353,7 +353,21 @@
             <configuration>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <serverId>oss-sonatype-staging</serverId>
+              <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.sonatype.nexus</groupId>
+                <artifactId>nexus-client-core</artifactId>
+                <version>2.14.21-02</version>
+                <exclusions>
+                  <exclusion>
+                    <artifactId>plexus-utils</artifactId>
+                    <groupId>org.codehaus.plexus</groupId>
+                  </exclusion>
+                </exclusions>
+              </dependency>
+            </dependencies>
           </plugin>
 
           <plugin>


### PR DESCRIPTION
Increase the staging operation timeout from 5 to 15 minutes and use the
latest `nexus-client-core` version in an effort to increase the
robustness of the release.

[skip ci]