### PR TITLE
refactor: remove templating-maven-plugin

### DIFF
--- a/app/connector/pom.xml
+++ b/app/connector/pom.xml
@@ -121,20 +121,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>templating-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>filter-sources</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1367,12 +1367,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>templating-maven-plugin</artifactId>
-          <version>1.0.0</version>
-        </plugin>
-
-        <plugin>
           <groupId>io.syndesis.connector</groupId>
           <artifactId>connector-support-maven-plugin</artifactId>
           <version>${project.version}</version>


### PR DESCRIPTION
I can't find a reason for this plugin to be configured, it relies on a
directory `src/main/java-templates` to exist, and no Maven project has
it.