### PR TITLE
chore: allow gpg to be skipped

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -375,7 +375,6 @@
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <configuration>
-              <skip>false</skip>
               <gpgArguments>
                 <arg>--pinentry-mode</arg>
                 <arg>loopback</arg>


### PR DESCRIPTION
We should not set `skip` to `false` it prevents us from skipping gpg
signing when not needed using the `-Dgpg.skip=true`.