### PR TITLE
fix: additional removal of skip=false for gpg [skip-ci]

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -333,9 +333,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -560,9 +560,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
-            <configuration>
-              <skip>false</skip>
-            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Followup on #9865 to allow skipping gpg signing in BOM files that don't
inherit from the parent POM.