### PR TITLE
ENTESB-17078: Actions required on metadata bundle

### DIFF
--- a/install/operator/config/crd/bases/syndesis.io_syndesises.yaml
+++ b/install/operator/config/crd/bases/syndesis.io_syndesises.yaml
@@ -5443,6 +5443,7 @@ spec:
                 format: date-time
                 type: string
               phase:
+                description: The phase the operator has reached, eg. INSTALLED, STARTING
                 type: string
               reason:
                 type: string

--- a/install/operator/config/manifests/bases/syndesis.clusterserviceversion.yaml
+++ b/install/operator/config/manifests/bases/syndesis.clusterserviceversion.yaml
@@ -40,6 +40,42 @@ spec:
       - kind: Subscription
         name: ""
         version: operators.coreos.com/v1alpha1
+      specDescriptors:
+      - description: Optional add on features that can be enabled.
+        displayName: Addons
+        path: addons
+      statusDescriptors:
+      - description: Current description of where the installation or upgrade has
+          reached
+        displayName: Description
+        path: description
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      - description: A record of the time of the last upgrade failure
+        displayName: Upgrade Failure Time
+        path: lastUpgradeFailure
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The phase the operator has reached, eg. INSTALLED, STARTING
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Reason if the installation or upgrade failed
+        displayName: Reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase:reason
+      - description: A record of the number of times and upgrade has been attempted
+        displayName: Upgrade Attempts
+        path: upgradeAttempts
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: The currently installed version of Syndesis
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:text
       version: v1beta3
   description: |
     ### Syndesis operator

--- a/install/operator/config/scorecard/patches/olm.config.yaml
+++ b/install/operator/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:master
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,37 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:master
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.14.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/install/operator/config/vars/Makefile
+++ b/install/operator/config/vars/Makefile
@@ -7,7 +7,8 @@ DEFAULT_PREVIOUS_VERSION := 1.13.0
 DEFAULT_IMAGE := quay.io/syndesis/syndesis-operator
 DEFAULT_TAG := $(DEFAULT_VERSION:.0=)
 DEFAULT_NAMESPACE := syndesis
-DEFAULT_CHANNEL := $(DEFAULT_VERSION:.0=.x)
+DEFAULT_CHANNEL := latest
+DEFAULT_CHANNELS := $(DEFAULT_CHANNEL),candidate,stable,$(DEFAULT_VERSION:.0=.x)
 DEFAULT_CSV := manifests/bases/syndesis.clusterserviceversion.yaml
 BUNDLE_INFIX := bundle
 
@@ -29,7 +30,7 @@ NAMESPACE ?= $(DEFAULT_NAMESPACE)
 KUBE_USER ?= developer
 LEGACY ?= false
 
-CHANNELS ?= $(DEFAULT_CHANNEL)
+CHANNELS ?= $(DEFAULT_CHANNELS)
 # Default bundle image tag
 BUNDLE_IMG ?= $(IMAGE)-$(BUNDLE_INFIX):$(VERSION)
 # Options for 'bundle-build'

--- a/install/operator/pkg/apis/syndesis/v1beta3/syndesis_types.go
+++ b/install/operator/pkg/apis/syndesis/v1beta3/syndesis_types.go
@@ -44,6 +44,9 @@ type SyndesisSpec struct {
 	Components ComponentsSpec `json:"components,omitempty"`
 
 	// Optional add on features that can be enabled.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Addons"
 	Addons AddonsSpec `json:"addons,omitempty"`
 
 	// Force migration of CR to new version
@@ -63,15 +66,45 @@ type SyndesisSpec struct {
 // SyndesisStatus defines the observed state of Syndesis
 // +k8s:openapi-gen=true
 type SyndesisStatus struct {
-	Phase              SyndesisPhase        `json:"phase,omitempty"`
-	UpgradeAttempts    int                  `json:"upgradeAttempts,omitempty"`
-	LastUpgradeFailure *metav1.Time         `json:"lastUpgradeFailure,omitempty"`
-	ForceUpgrade       bool                 `json:"forceUpgrade,omitempty"`
-	Reason             SyndesisStatusReason `json:"reason,omitempty"`
-	Description        string               `json:"description,omitempty"`
-	Version            string               `json:"version,omitempty"`
-	TargetVersion      string               `json:"targetVersion,omitempty"`
-	Backup             BackupStatus         `json:"backup,omitempty"`
+	// The phase the operator has reached, eg. INSTALLED, STARTING
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Phase"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:io.kubernetes.phase"
+	Phase SyndesisPhase `json:"phase,omitempty"`
+	// A record of the number of times and upgrade has been attempted
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Upgrade Attempts"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text"
+	UpgradeAttempts int `json:"upgradeAttempts,omitempty"`
+	// A record of the time of the last upgrade failure
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Upgrade Failure Time"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text"
+	LastUpgradeFailure *metav1.Time `json:"lastUpgradeFailure,omitempty"`
+	ForceUpgrade       bool         `json:"forceUpgrade,omitempty"`
+	// Reason if the installation or upgrade failed
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Reason"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:io.kubernetes.phase:reason"
+	Reason SyndesisStatusReason `json:"reason,omitempty"`
+	// Current description of where the installation or upgrade has reached
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Description"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:io.kubernetes.phase:reason"
+	Description string `json:"description,omitempty"`
+	// The currently installed version of Syndesis
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="Version"
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text"
+	Version       string       `json:"version,omitempty"`
+	TargetVersion string       `json:"targetVersion,omitempty"`
+	Backup        BackupStatus `json:"backup,omitempty"`
 
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -247,11 +280,17 @@ type SchedulingSpec struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
+// Parameters for enabling additional optional features
 type AddonsSpec struct {
-	Jaeger    JaegerConfiguration    `json:"jaeger,omitempty"`
-	Ops       AddonSpec              `json:"ops,omitempty"`
-	Todo      AddonSpec              `json:"todo,omitempty"`
-	Knative   AddonSpec              `json:"knative,omitempty"`
+	// Should a jaeger implementation be installed for metric monitoring
+	Jaeger JaegerConfiguration `json:"jaeger,omitempty"`
+	// Should the Ops capability be installed
+	Ops AddonSpec `json:"ops,omitempty"`
+	// Should the example TODO integration be installed
+	Todo AddonSpec `json:"todo,omitempty"`
+	// Should the knative capability be installed
+	Knative AddonSpec `json:"knative,omitempty"`
+	// Should the Public API capability be installed
 	PublicApi PublicApiConfiguration `json:"publicApi,omitempty"`
 }
 

--- a/install/operator/pkg/generator/assets/install/cluster/syndesis.yml
+++ b/install/operator/pkg/generator/assets/install/cluster/syndesis.yml
@@ -5443,6 +5443,7 @@ spec:
                 format: date-time
                 type: string
               phase:
+                description: The phase the operator has reached, eg. INSTALLED, STARTING
                 type: string
               reason:
                 type: string


### PR DESCRIPTION
**Note: this is the 1.14.x version of #9873**

* Adds comments and marks required for documenting
  SpecDescriptors and StatusDescriptors in CSV, required
  for scorecard tests to pass

* Adds missing scorecard tests

* Adds extra channels to serve syndesis operator in
  accordance with operator-sdk naming conventions

* Adds latest channel for future use