### PR TITLE
fix(server): correct totalCount in ListResult

### DIFF
--- a/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/ListResult.java
@@ -35,7 +35,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = ListResult.Builder.class)
 @SuppressWarnings({"rawtypes", "varargs"})
 public interface ListResult<T> extends Iterable<T> {
-
     /**
      * Total.
      * @return The total count of entities available.
@@ -68,13 +67,27 @@ public interface ListResult<T> extends Iterable<T> {
         // accessible
     }
 
-    static <T> ListResult<T> of(Collection<T> items) {
+    static <T> ListResult<T> partial(final int totalCount, final Collection<T> items) {
+        return new Builder<T>().items(items).totalCount(totalCount).build();
+    }
+
+    @SafeVarargs
+    static <T> ListResult<T> partial(final int totalCount, T... items) {
+        return new Builder<T>().addItems(items).totalCount(totalCount).build();
+    }
+
+    static <T> ListResult<T> complete(final Collection<T> items) {
         return new Builder<T>().items(items).totalCount(items.size()).build();
     }
 
     @SafeVarargs
-    static <T> ListResult<T> of(T... items) {
+    static <T> ListResult<T> complete(T... items) {
         return new Builder<T>().addItems(items).totalCount(items.length).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> ListResult<T> empty() {
+        return Holder.EMPTY;
     }
 
     static <T> Collector<T, Builder<T>, Builder<T>> collector() {
@@ -84,4 +97,18 @@ public interface ListResult<T> extends Iterable<T> {
             b -> b.totalCount(b.build().getItems().size()));
     }
 
+}
+
+/**
+ * Required as initialization of ImmutableListResult from ListResult leads to
+ * cyclic dependency and the ImmutableListResult.validator uninitialized as the
+ * outcome.
+ */
+final class Holder {
+    @SuppressWarnings("rawtypes")
+    static final ListResult EMPTY = new ListResult.Builder<>().build();
+
+    private Holder() {
+        // prevent instantiation
+    }
 }

--- a/app/common/model/src/main/java/io/syndesis/common/model/TagFinder.java
+++ b/app/common/model/src/main/java/io/syndesis/common/model/TagFinder.java
@@ -38,7 +38,7 @@ public class TagFinder {
     }
 
     public ListResult<String> getResult() {
-        return ListResult.of(tags);
+        return ListResult.complete(tags);
     }
 
 }

--- a/app/common/model/src/test/java/io/syndesis/common/model/TagFinderTest.java
+++ b/app/common/model/src/test/java/io/syndesis/common/model/TagFinderTest.java
@@ -33,8 +33,8 @@ public class TagFinderTest {
             .addTag("tag3")
             .build();
         ListResult<String> allTags = new TagFinder()
-            .add(ListResult.of(integration))
-            .add(ListResult.of(connection))
+            .add(ListResult.complete(integration))
+            .add(ListResult.complete(connection))
             .getResult();
 
         Assertions.assertEquals( 3, allTags.getTotalCount());

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataAccessObject.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/DataAccessObject.java
@@ -68,10 +68,13 @@ public interface DataAccessObject<T extends WithId<T>> {
         if (operators == null) {
             return result;
         }
+
+        final int totalCount = result.getTotalCount();
         for (Function<ListResult<T>, ListResult<T>> operator : operators) {
             result = operator.apply(result);
         }
-        return result;
+
+        return ListResult.partial(totalCount, result.getItems());
     }
 
     /**

--- a/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/ReverseFilter.java
+++ b/app/server/dao/src/main/java/io/syndesis/server/dao/manager/operators/ReverseFilter.java
@@ -39,11 +39,11 @@ public final class ReverseFilter<T extends WithResourceId> implements Function<L
     public ListResult<T> apply(ListResult<T> result) {
         List<T> list = new ArrayList<>(result.getItems());
         Collections.reverse(list);
-        return ListResult.of(list);
+        return ListResult.partial(result.getTotalCount(), list);
     }
 
     @SuppressWarnings({"unchecked"})
     public static <T extends WithResourceId> ReverseFilter<T>getInstance() {
-        return (ReverseFilter<T>)INSTANCE;
+        return INSTANCE;
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectionHandler.java
@@ -128,7 +128,7 @@ public class ConnectionHandler
             overviews.add(builder.build());
         }
 
-        return ListResult.of(overviews);
+        return ListResult.partial(connectionResults.getTotalCount(), overviews);
     }
 
     @Override

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationHandler.java
@@ -188,8 +188,9 @@ public class IntegrationHandler extends BaseHandler implements Lister<Integratio
             new ReflectiveSorter<>(Integration.class, new SortOptionsFromQueryParams(uriInfo)),
             new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo)));
 
-        return ListResult.of(integrations.getItems().stream().map(integrationOverviewHelper::toCurrentIntegrationOverview)
-            .collect(Collectors.toList()));
+        final List<IntegrationOverview> items = integrations.getItems().stream().map(integrationOverviewHelper::toCurrentIntegrationOverview)
+            .collect(Collectors.toList());
+        return ListResult.partial(integrations.getTotalCount(), items);
     }
 
     @Override

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationIdFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationIdFilter.java
@@ -41,6 +41,6 @@ final class IntegrationIdFilter
         final List<IntegrationDeployment> filtered = list.getItems().stream()
             .filter(i -> i.getSpec().idEquals(integrationId)).collect(Collectors.toList());
 
-        return ListResult.of(filtered);
+        return ListResult.partial(list.getTotalCount(), filtered);
     }
 }

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthAppHandler.java
@@ -96,15 +96,17 @@ public class OAuthAppHandler {
     @Parameter(name = "per_page", in = ParameterIn.QUERY, schema = @Schema(type = "integer", defaultValue = "20"), description = "Number of records per page")
     @Parameter(name = "query", in = ParameterIn.QUERY, schema = @Schema(type = "string"), description = "The search query to filter results on")
     public ListResult<OAuthApp> list(@Context final UriInfo uriInfo) {
-        final List<Connector> oauthConnectors = dataMgr.fetchAll(Connector.class, //
+        final ListResult<Connector> all = dataMgr.fetchAll(Connector.class, //
             OAuthConnectorFilter.INSTANCE,
             new ReflectiveFilterer<>(Connector.class, new FilterOptionsFromQueryParams(uriInfo).getFilters()),
             new ReflectiveSorter<>(Connector.class, new SortOptionsFromQueryParams(uriInfo)),
-            new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo))).getItems();
+            new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo)));
+
+        final List<Connector> oauthConnectors = all.getItems();
 
         final List<OAuthApp> apps = oauthConnectors.stream().map(OAuthApp::fromConnector).collect(Collectors.toList());
 
-        return ListResult.of(apps);
+        return ListResult.partial(all.getTotalCount(), apps);
     }
 
     @PUT

--- a/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
+++ b/app/server/endpoint/src/main/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilter.java
@@ -35,7 +35,7 @@ final class OAuthConnectorFilter implements Function<ListResult<Connector>, List
         final List<Connector> oauthConnectors = result.getItems().stream()
             .filter(c -> c.propertyEntryTaggedWith(Credentials.CLIENT_ID_TAG).isPresent()).collect(Collectors.toList());
 
-        return ListResult.of(oauthConnectors);
+        return ListResult.partial(result.getTotalCount(), oauthConnectors);
     }
 
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/connection/ConnectorHandlerTest.java
@@ -124,7 +124,7 @@ public class ConnectorHandlerTest {
                 .icon("http://localhost:" + wiremock.port() + "/u/23079786")
                 .build();
             when(dataManager.fetch(Connector.class, "connector-id")).thenReturn(connector);
-            when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(Collections.emptyList()));
+            when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.empty());
 
             try (Response response = handler.getConnectorIcon("connector-id").get()) {
                 assertThat(response.getStatusInfo().getStatusCode()).as("Wrong status code").isEqualTo(Response.Status.OK.getStatusCode());
@@ -187,7 +187,7 @@ public class ConnectorHandlerTest {
         // verify predicates in listApiConnectors()
         when(dataManager.fetchAll(eq(Connector.class), any()))
             .then(a -> {
-                ListResult<Connector> result = ListResult.of(connectors);
+                ListResult<Connector> result = ListResult.complete(connectors);
                 final Object[] operators = a.getArguments();
                 for (int i = 1; i < operators.length; i++) {
                     @SuppressWarnings("unchecked")
@@ -200,7 +200,7 @@ public class ConnectorHandlerTest {
 
         // no integrations, 0 usage for all connectors
         when(dataManager.fetchAll(Integration.class))
-            .thenReturn(ListResult.of(Collections.emptyList()));
+            .thenReturn(ListResult.empty());
 
         final ListResult<Connector> result = handler.listApiConnectors(Arrays.asList("1", "2"), 1, 50);
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/external/PublicApiHandlerTest.java
@@ -100,7 +100,7 @@ public class PublicApiHandlerTest {
         final ArgumentCaptor<Function<ListResult<Integration>, ListResult<Integration>>[]> filter = ArgumentCaptor.forClass(filterVarArgsType);
 
         when(dataManager.fetchByPropertyValue(Environment.class, "name", "env")).thenReturn(Optional.of(env));
-        when(dataManager.fetchAll(eq(Integration.class), filter.capture())).thenReturn(ListResult.of(integration1, integration2));
+        when(dataManager.fetchAll(eq(Integration.class), filter.capture())).thenReturn(ListResult.complete(integration1, integration2));
 
         final StreamingOutput someStream = mock(StreamingOutput.class);
 
@@ -130,7 +130,7 @@ public class PublicApiHandlerTest {
         final Function<ListResult<Integration>, ListResult<Integration>> filterFunction = (Function<ListResult<Integration>, ListResult<Integration>>) (Object) filters
             .get(0);
 
-        assertThat(filterFunction.apply(ListResult.of(integration1, integration2, integration3))).isEqualTo(ListResult.of(integration1, integration2));
+        assertThat(filterFunction.apply(ListResult.complete(integration1, integration2, integration3))).isEqualTo(ListResult.partial(2, integration1, integration2));
 
         try (Response response = handler.exportResources("env", false, true)) {
             assertThat(response).isNotNull();
@@ -253,7 +253,7 @@ public class PublicApiHandlerTest {
             .putContinuousDeliveryState("different-env", new ContinuousDeliveryEnvironment.Builder().build())
             .build();
 
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integration1, integration2, integration3));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(integration1, integration2, integration3));
 
         final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
         // null's are not used
@@ -361,7 +361,7 @@ public class PublicApiHandlerTest {
     @Test
     public void testGetReleaseEnvironments() {
         final DataManager dataManager = mock(DataManager.class);
-        when(dataManager.fetchAll(Environment.class)).thenReturn(ListResult.of(newEnvironment("env1"), newEnvironment("env2")));
+        when(dataManager.fetchAll(Environment.class)).thenReturn(ListResult.complete(newEnvironment("env1"), newEnvironment("env2")));
 
         final EnvironmentHandler environmentHandler = new EnvironmentHandler(dataManager);
         // null's are not used

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandlerTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationDeploymentHandlerTest.java
@@ -87,7 +87,7 @@ public class IntegrationDeploymentHandlerTest {
         final ArgumentCaptor<Function<ListResult<IntegrationDeployment>, ListResult<IntegrationDeployment>>> args = ArgumentCaptor
             .forClass(Function.class);
         when(dataManager.fetchAll(eq(IntegrationDeployment.class), args.capture()))
-            .thenReturn(ListResult.of(deployment1, deployment2, deployment3));
+            .thenReturn(ListResult.complete(deployment1, deployment2, deployment3));
 
         final UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationIdFilterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationIdFilterTest.java
@@ -21,8 +21,6 @@ import io.syndesis.common.model.integration.IntegrationDeployment;
 
 import org.junit.jupiter.api.Test;
 
-import static java.util.Collections.emptyList;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IntegrationIdFilterTest {
@@ -39,22 +37,22 @@ public class IntegrationIdFilterTest {
 
     @Test
     public void shouldFilterEmptyResults() {
-        assertThat(filter.apply(ListResult.of(emptyList()))).isEmpty();
+        assertThat(filter.apply(ListResult.empty())).isEmpty();
     }
 
     @Test
     public void shouldFilterOutTrivialWantedDeployments() {
-        assertThat(filter.apply(ListResult.of(wanted))).containsOnly(wanted);
+        assertThat(filter.apply(ListResult.complete(wanted))).containsOnly(wanted);
     }
 
     @Test
     public void shouldFilterOutWantedDeployments() {
-        assertThat(filter.apply(ListResult.of(unwanted, wanted, unwanted))).containsOnly(wanted);
+        assertThat(filter.apply(ListResult.complete(unwanted, wanted, unwanted))).containsOnly(wanted);
     }
 
     @Test
     public void shouldFilterOutWantedDeploymentsNotFinding() {
-        assertThat(filter.apply(ListResult.of(unwanted, unwanted, unwanted))).isEmpty();
+        assertThat(filter.apply(ListResult.complete(unwanted, unwanted, unwanted))).isEmpty();
     }
 
 }

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelperTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/integration/IntegrationOverviewHelperTest.java
@@ -58,7 +58,7 @@ public class IntegrationOverviewHelperTest {
             .currentState(IntegrationDeploymentState.Published).id(INTEGRATION_DEPLOYMENT_ID).build();
 
         when(dataManager.fetchAll(eq(IntegrationDeployment.class),
-            any(), any())).thenReturn(ListResult.of(deployment));
+            any(), any())).thenReturn(ListResult.complete(deployment));
 
         when(exposueHelper.getManagementUrl(any())).thenReturn(null);
 
@@ -74,7 +74,7 @@ public class IntegrationOverviewHelperTest {
             .currentState(IntegrationDeploymentState.Published).id(INTEGRATION_DEPLOYMENT_ID).build();
 
         when(dataManager.fetchAll(eq(IntegrationDeployment.class),
-            any(), any())).thenReturn(ListResult.of(deployment));
+            any(), any())).thenReturn(ListResult.complete(deployment));
 
         when(exposueHelper.getManagementUrl(any())).thenReturn("https://3scale");
 
@@ -91,7 +91,7 @@ public class IntegrationOverviewHelperTest {
         Set<String> exposureMeans = Sets.newHashSet("ROUTE");
 
         when(dataManager.fetchAll(eq(IntegrationDeployment.class),
-            any(), any())).thenReturn(ListResult.of());
+            any(), any())).thenReturn(ListResult.empty());
 
         when(exposueHelper.getExposureMeans()).thenReturn(exposureMeans);
 
@@ -108,7 +108,7 @@ public class IntegrationOverviewHelperTest {
         Set<String> exposureMeans = Sets.newHashSet("ROUTE");
 
         when(dataManager.fetchAll(eq(IntegrationDeployment.class),
-            any(), any())).thenReturn(ListResult.of());
+            any(), any())).thenReturn(ListResult.empty());
 
         when(exposueHelper.getExposureMeans()).thenReturn(exposureMeans);
 

--- a/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilterTest.java
+++ b/app/server/endpoint/src/test/java/io/syndesis/server/endpoint/v1/handler/setup/OAuthConnectorFilterTest.java
@@ -35,7 +35,7 @@ public class OAuthConnectorFilterTest {
         final Connector connector3 = new Connector.Builder()
             .putProperty("clientId", new ConfigurationProperty.Builder().addTag(Credentials.CLIENT_ID_TAG).build()).build();
 
-        final ListResult<Connector> result = ListResult.of(connector1, connector2, connector3);
+        final ListResult<Connector> result = ListResult.complete(connector1, connector2, connector3);
 
         assertThat(OAuthConnectorFilter.INSTANCE.apply(result)).containsOnly(connector2, connector3);
     }

--- a/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/JsonDbDao.java
+++ b/app/server/jsondb/src/main/java/io/syndesis/server/jsondb/dao/JsonDbDao.java
@@ -111,9 +111,9 @@ public abstract class JsonDbDao<T extends WithId<T>> implements DataAccessObject
                 MapType mapType = typeFactory.constructMapType(LinkedHashMap.class, String.class, getType());
                 LinkedHashMap<String, T> map = reader.forType(mapType).readValue(json);
 
-                result = ListResult.of(map.values());
+                result = ListResult.complete(map.values());
             } else {
-                result = ListResult.of(Collections.<T>emptyList());
+                result = ListResult.empty();
             }
 
             if (operators == null) {

--- a/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
+++ b/app/server/update-controller/src/test/java/io/syndesis/server/update/controller/usage/UsageUpdateHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package io.syndesis.server.update.controller.usage;
 
-import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -100,7 +99,7 @@ public class UsageUpdateHandlerTest {
         final Integration usesC1andC2 = testIntegration().withFlowConnections(c1, c2).build();
         final Integration usesC2andC3 = testIntegration().withFlowConnections(c2, c3).build();
         final Integration usesC1andC2andC3 = testIntegration().withFlowConnections(c1, c2, c3).build();
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
 
         handler.processInternal(NOT_USED);
 
@@ -119,7 +118,7 @@ public class UsageUpdateHandlerTest {
         final Integration usesC1andC2 = testIntegration().withFlowStepsUsingConnections(c1, c2).build();
         final Integration usesC2andC3 = testIntegration().withFlowStepsUsingConnections(c2, c3).build();
         final Integration usesC1andC2andC3 = testIntegration().withFlowStepsUsingConnections(c1, c2, c3).build();
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
 
         handler.processInternal(NOT_USED);
 
@@ -138,7 +137,7 @@ public class UsageUpdateHandlerTest {
         final Integration usesC1andC2 = testIntegration().withFlowConnections(c1).withFlowStepsUsingConnections(c2).build();
         final Integration usesC2andC3 = testIntegration().withFlowStepsUsingConnections(c2, c3).build();
         final Integration usesC1andC2andC3 = testIntegration().withFlowConnections(c1, c2).withFlowStepsUsingConnections(c3).build();
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(usesC1, usesC1andC2, usesC2andC3, usesC1andC2andC3));
 
         handler.processInternal(NOT_USED);
 
@@ -153,13 +152,13 @@ public class UsageUpdateHandlerTest {
 
     @BeforeEach
     public void setupMocks() {
-        when(dataManager.fetchAll(Connection.class)).thenReturn(ListResult.of(c1, c2, c3));
-        when(dataManager.fetchAll(Extension.class)).thenReturn(ListResult.of(extension));
+        when(dataManager.fetchAll(Connection.class)).thenReturn(ListResult.complete(c1, c2, c3));
+        when(dataManager.fetchAll(Extension.class)).thenReturn(ListResult.complete(extension));
     }
 
     @Test
     public void shouldCountUsedExtensions() {
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithExtension));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(integrationWithExtension));
 
         handler.processInternal(NOT_USED);
 
@@ -172,7 +171,7 @@ public class UsageUpdateHandlerTest {
 
     @Test
     public void shouldCountUsedIntegrationDependencyLibrariesExtensions() {
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithDependencyLibraryExtension));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(integrationWithDependencyLibraryExtension));
 
         handler.processInternal(NOT_USED);
 
@@ -185,7 +184,7 @@ public class UsageUpdateHandlerTest {
 
     @Test
     public void shouldCountUsedFlowsDependencyLibrariesExtensions() {
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integrationWithFlowsDependencyLibraryExtension));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(integrationWithFlowsDependencyLibraryExtension));
 
         handler.processInternal(NOT_USED);
 
@@ -201,7 +200,7 @@ public class UsageUpdateHandlerTest {
         final Step stepWithoutConnection = new Step.Builder().build();
         final Integration integration = testIntegration().withFlowConnections(c1, c2).withFlowStepsUsingConnections(c1, c3)
             .addFlow(new Flow.Builder().addStep(stepWithoutConnection).build()).build();
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(integration));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(integration));
 
         handler.processInternal(NOT_USED);
 
@@ -217,7 +216,7 @@ public class UsageUpdateHandlerTest {
     @Test
     public void unusedConnectionsShouldHaveUseOfZero() {
         final Integration emptyIntegration = new Integration.Builder().build();
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(emptyIntegration, emptyIntegration));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.complete(emptyIntegration, emptyIntegration));
 
         handler.processInternal(NOT_USED);
 
@@ -229,7 +228,7 @@ public class UsageUpdateHandlerTest {
 
     @Test
     public void withNoIntegrationsConnectionUsageShouldBeZero() {
-        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.of(emptyList()));
+        when(dataManager.fetchAll(Integration.class)).thenReturn(ListResult.empty());
 
         handler.processInternal(NOT_USED);
 


### PR DESCRIPTION
When filters (e.g. pagination) are used the `totalCount` gets reset to
whatever the filter outcome size is (e.g. page size), and the initial
`totalCount` that reflects the number of available items is lost.

This refactors the `ListResult` to clearly support two cases: partial or
complete item set was provided; also for the existing filtering
operations partial case is used with the `totalCount` of the original
item set.