### PR TITLE
Fix operator install with jaeger enabled, fail to install

### DIFF
--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -232,8 +232,7 @@ func (a *installAction) Execute(ctx context.Context, syndesis *synapi.Syndesis) 
 				continue
 			}
 		}
-
-		addonDir := "assets/addons/" + addonInfo.Name() + "/"
+		addonDir := "assets/addons/" + addonInfo.Name()
 		f, err := generator.Assets.Open(addonDir)
 		if err != nil {
 			a.log.Error(err, "Unsupported addon configured", "addon", addonInfo.Name())


### PR DESCRIPTION
Using embed.Open to read a directory causes error
https://github.com/syndesisio/syndesis/issues/9893