### PR TITLE
refactor(s2i): less permission changes

### DIFF
--- a/app/s2i/src/main/docker/Dockerfile
+++ b/app/s2i/src/main/docker/Dockerfile
@@ -2,19 +2,15 @@ FROM ${java.base.image}
 
 ENV AB_JOLOKIA_HTTPS="true"
 
-USER 0
 # Setting local+remote repositories needed for building the sample projects
-ADD maven/settings.xml /tmp/settings.xml
+ADD --chown=jboss:jboss maven/settings.xml /tmp/settings.xml
 
 # Copy over all local dependencies to docker maven repo
 # The integration expects all dependencies in /tmp/artifacts/m2
 # so you cannot change the location of the local repo!
-ADD maven/repository /tmp/artifacts/m2
-
-RUN chown -R 1000 /tmp/artifacts
+RUN mkdir -p /tmp/artifacts && chown jboss:jboss /tmp/artifacts
+ADD --chown=jboss:jboss maven/repository /tmp/artifacts/m2
 
 # Copy licenses
 RUN mkdir -p /opt/ipaas/
 ADD maven/licenses* /opt/ipaas/
-
-USER 1000

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/dockerfile/SyndesisDockerfileBuilder.java
@@ -29,9 +29,6 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
  */
 public class SyndesisDockerfileBuilder extends ImageFromDockerfile {
 
-    private static final String ROOT = "0";
-    private static final String JBOSS = "jboss";
-
     private String from;
     private String runCommand;
     private String projectSrc;
@@ -49,22 +46,10 @@ public class SyndesisDockerfileBuilder extends ImageFromDockerfile {
                 withFileFromPath(projectSrc, projectPath)
                 .withDockerfileFromBuilder(builder -> builder.from(from)
                     .env(envProperties)
-                    .user(ROOT)
                     .copy(projectSrc, projectDest)
-                    .run(fixGroupsCommand())
-                    .run(fixPermissionsCommand())
-                    .user(JBOSS)
                     .expose(SyndesisTestEnvironment.getDebugPort())
                     .cmd(runCommand)
                 .build());
-    }
-
-    private String[] fixGroupsCommand() {
-        return  new String [] { "chgrp", "-R", "0", projectDest };
-    }
-
-    private String[] fixPermissionsCommand() {
-        return new String [] { "chmod", "-R", "g=u", projectDest };
     }
 
     public SyndesisDockerfileBuilder from(String image, String tag) {

--- a/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
+++ b/app/test/test-support/src/main/java/io/syndesis/test/container/s2i/SyndesisS2iAssemblyContainer.java
@@ -42,10 +42,7 @@ public class SyndesisS2iAssemblyContainer extends GenericContainer<SyndesisS2iAs
         super(new ImageFromDockerfile(integrationName + "-s2i", true)
             .withFileFromPath(SRC_DIR, projectDir)
             .withDockerfileFromBuilder(builder -> builder.from(String.format("syndesis/syndesis-s2i:%s", imageTag))
-                .withStatement(new MultiArgsStatement("ADD", SRC_DIR, SRC_DIR))
-                .user("0")
-                .run("chown", "-R", "1000", SRC_DIR)
-                .user("1000")
+                .withStatement(new MultiArgsStatement("ADD --chown=jboss:jboss", SRC_DIR, SRC_DIR))
                 .cmd(S2I_ASSEMBLE_SCRIPT)
                 .build()));
 


### PR DESCRIPTION
We switch between UID `0` and `1000` and finally settle on `185/jboss`.
We don't need to do that at all if we start as UID `jboss` and make sure
all steps are performed as `jboss` user.
This makes it easier to maintain and less gymnastics is required to make
sure that the S2I build succeeds.
As noted on #8451, the `ADD --chown=...` syntax is not supported on
OpenShift 3.11.