### PR TITLE
refactor(s2i): s2i tar.bz2 archive instead of zip

### DIFF
--- a/app/s2i/src/main/assembly/repository.xml
+++ b/app/s2i/src/main/assembly/repository.xml
@@ -20,7 +20,7 @@
 
   <id>m2</id>
   <formats>
-    <format>zip</format>
+    <format>tar.bz2</format>
   </formats>
 
   <includeBaseDirectory>false</includeBaseDirectory>


### PR DESCRIPTION
We could use the `tar.bz2` archive instead of `zip` as that is somewhat
easier to manage when building container images using `Dockerfile`
`ADD`.