### PR TITLE
Use openshift oauthproxy 4.7

### DIFF
--- a/install/operator/build/conf/config.yaml
+++ b/install/operator/build/conf/config.yaml
@@ -29,7 +29,7 @@ Syndesis:
             DisableSarCheck: false
     Components:
         Oauth:
-            Image: "quay.io/openshift/origin-oauth-proxy:4.9"
+            Image: "quay.io/openshift/origin-oauth-proxy:4.7"
             DisableSarCheck: false
         UI:
             Image: "quay.io/syndesis/syndesis-ui:latest"


### PR DESCRIPTION
`openshift/origin-oauth-proxy:4.9` requires a [feature only available in openshift 4.9](https://docs.openshift.com/container-platform/4.9/authentication/configuring-internal-oauth.html#customizing-the-oauth-server-url_configuring-internal-oauth)
Otherwise it throws the following error in oauth-proxy pod
```
 oauthproxy.go:445: ErrorPage 500 Internal Error configmap "oauth-serving-cert" not found
```
`openshift/origin-oauth-proxy:4.7 ` allows to use syndesis in openshift 4.7