### PR TITLE
fix: exclude transitive opentracing dependencies

### DIFF
--- a/app/common/jaeger-spring-boot-starter/pom.xml
+++ b/app/common/jaeger-spring-boot-starter/pom.xml
@@ -77,6 +77,20 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spring-web-starter</artifactId>
       <version>${opentracing.spring.web.starter.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-18674