### PR TITLE
Dependency alignements

### DIFF
--- a/app/connector/http/pom.xml
+++ b/app/connector/http/pom.xml
@@ -31,18 +31,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
-        <classifier>tests</classifier>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http4</artifactId>
         <version>${camel.version}</version>

--- a/app/connector/odata-v2/pom.xml
+++ b/app/connector/odata-v2/pom.xml
@@ -66,18 +66,6 @@
       </dependency>
       <!-- Additional dependencies -->
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
-        <classifier>tests</classifier>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.8.7</version>

--- a/app/connector/odata/pom.xml
+++ b/app/connector/odata/pom.xml
@@ -35,18 +35,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
-        <classifier>tests</classifier>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.apache.olingo</groupId>
         <artifactId>odata-commons-api</artifactId>
         <version>${olingo.version}</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -73,6 +73,7 @@
     <org.apache.log4j.version>2.17.1</org.apache.log4j.version>
 
     <okhttp3.version>3.12.1</okhttp3.version>
+    <org.apache.httpclient.version>4.5.13</org.apache.httpclient.version>
     <tomcat.version>9.0.36</tomcat.version>
 
     <swagger.version>2.1.9</swagger.version>
@@ -3271,6 +3272,31 @@
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
         <version>${okhttp3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${org.apache.httpclient.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <classifier>tests</classifier>
+        <version>${org.apache.httpclient.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2863,6 +2863,18 @@
       </dependency>
 
       <dependency>
+        <groupId>com.github.java-json-tools</groupId>
+        <artifactId>jackson-coreutils</artifactId>
+        <version>2.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.java-json-tools</groupId>
+        <artifactId>msg-simple</artifactId>
+        <version>1.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.8.9</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -2869,6 +2869,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>1.3</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
         <version>4.2</version>


### PR DESCRIPTION
Downstream some of these dependencies will diverge and need to be realigned. This forces the dependency resolution from the parent's dependencyManagement. This includes:

* [chore(deps): dependency align httpclient](https://github.com/syndesisio/syndesis/commit/c6e875de5ee4f6076103ec1e0b5d5eb0b77444d9)

* [chore(deps): dependency align j2objc-annotations](https://github.com/syndesisio/syndesis/commit/e4a8f759e2b5414869d869512cbcd619c09b4ad6)

* [chore(deps): dependency align java-json-tools](https://github.com/syndesisio/syndesis/commit/89e3efcdb64ebaaded7cc0f83afff667a39ec6e0)

This resolves some of the issues like the issues mentioned in https://issues.redhat.com/browse/ENTESB-18674