### PR TITLE
doc update- remove data mapper note

### DIFF
--- a/doc/modules/connecting/proc-adding-amq-connection-finish.adoc
+++ b/doc/modules/connecting/proc-adding-amq-connection-finish.adoc
@@ -50,10 +50,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-amq-connection-middle.adoc
+++ b/doc/modules/connecting/proc-adding-amq-connection-middle.adoc
@@ -83,10 +83,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-amq-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-amq-connection-start.adoc
@@ -62,10 +62,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-amqp-connection-middle.adoc
+++ b/doc/modules/connecting/proc-adding-amqp-connection-middle.adoc
@@ -93,10 +93,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-amqp-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-amqp-connection-start.adoc
@@ -62,10 +62,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-dropbox-connection-finish.adoc
+++ b/doc/modules/connecting/proc-adding-dropbox-connection-finish.adoc
@@ -54,10 +54,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-dropbox-connection-middle.adoc
+++ b/doc/modules/connecting/proc-adding-dropbox-connection-middle.adoc
@@ -59,10 +59,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-dropbox-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-dropbox-connection-start.adoc
@@ -45,10 +45,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-ftp-finish-middle-connection.adoc
+++ b/doc/modules/connecting/proc-adding-ftp-finish-middle-connection.adoc
@@ -86,10 +86,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-ftp-start-connection.adoc
+++ b/doc/modules/connecting/proc-adding-ftp-start-connection.adoc
@@ -60,10 +60,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-http-connections.adoc
+++ b/doc/modules/connecting/proc-adding-http-connections.adoc
@@ -73,10 +73,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-irc-connection-receive.adoc
+++ b/doc/modules/connecting/proc-adding-irc-connection-receive.adoc
@@ -50,10 +50,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-irc-connection-send.adoc
+++ b/doc/modules/connecting/proc-adding-irc-connection-send.adoc
@@ -51,10 +51,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-kafka-connection-finish-middle.adoc
+++ b/doc/modules/connecting/proc-adding-kafka-connection-finish-middle.adoc
@@ -47,10 +47,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-kafka-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-kafka-connection-start.adoc
@@ -46,10 +46,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-mongodb-connections-read.adoc
+++ b/doc/modules/connecting/proc-adding-mongodb-connections-read.adoc
@@ -97,10 +97,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-mqtt-connection-finish-middle.adoc
+++ b/doc/modules/connecting/proc-adding-mqtt-connection-finish-middle.adoc
@@ -47,10 +47,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-mqtt-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-mqtt-connection-start.adoc
@@ -46,10 +46,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-s3-connection-finish.adoc
+++ b/doc/modules/connecting/proc-adding-s3-connection-finish.adoc
@@ -59,10 +59,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-s3-connection-middle.adoc
+++ b/doc/modules/connecting/proc-adding-s3-connection-middle.adoc
@@ -60,10 +60,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/connecting/proc-adding-s3-connection-start.adoc
+++ b/doc/modules/connecting/proc-adding-s3-connection-start.adoc
@@ -68,10 +68,6 @@ The document's file extension is `.xsd`.
 * *XML instance* is a document that contains XML data. The
 document's file extension is `.xml`. 
 * *CSV instance* is a document that contains comma-separated value (CSV) data. The document's file extension is `.csv`. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 
 . In the *Definition* input box, paste a definition that conforms to the
 schema type you selected. 

--- a/doc/modules/customizing/ref-how-to-specify-data-shapes.adoc
+++ b/doc/modules/customizing/ref-how-to-specify-data-shapes.adoc
@@ -115,10 +115,6 @@ the data shape's `specification` property. For example:
 ----
 
 * `csv-instance` indicates that the data type is represented by a CSV instance. 
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[]
 +
 When `kind` is set to `csv-instance`, specify a CSV instance as the value of
 the data shape's `specification` property. For example:

--- a/doc/modules/integrating-applications/proc-how-to-use-webhook.adoc
+++ b/doc/modules/integrating-applications/proc-how-to-use-webhook.adoc
@@ -47,10 +47,6 @@ have specified the output data shape in the request by passing a JSON
 instance, JSON schema, XML instance, XML schema, or CSV instance. If you did not, then when you add a Webhook connection as the start connection of an integration, 
 {prodname} prompts you to specify the output data type. If you do not,
 then the default Webhook connection output data type is in JSON format.  
-ifeval::["{location}" == "downstream"]
-+
-*Note* _Data Mapper support for CSV data is a Technology Preview feature only._
-endif::[] 
 
 .. Add any other steps that the integration needs.
 . Publish the integration and wait for it to be *Running*. 


### PR DESCRIPTION
This is in respect to Jira tticket FUSEDOC-4833. 
I have deleted the note "Data Mapper support for CSV data is a Technology Preview feature only." in all the committed upstream files. 
Could you please review them and merge the request?

Further, I can proceed to do the same changes in downstream after the merger.