### PR TITLE
Upgrades Spring to 5.3.18 and Spring Boot to 2.5.12

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <spring.version>5.3.18</spring.version>
     <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
@@ -170,6 +171,14 @@
         <version>${org.apache.log4j.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Camel BOM for Spring-boot -->

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -30,7 +30,7 @@
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
     <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
-    <atlasmap.version>2.3.13</atlasmap.version>
+    <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <mongodb.version>3.9.0</mongodb.version>
     <jetty.version>9.4.43.v20210629</jetty.version>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
     <spring.version>5.3.18</spring.version>
-    <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
+    <spring-boot.version>2.5.12</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
-    <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
+    <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.13</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>

--- a/app/extension/maven-plugin/pom.xml
+++ b/app/extension/maven-plugin/pom.xml
@@ -338,6 +338,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/AbstractDependencyFilterMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/AbstractDependencyFilterMojo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
+import org.springframework.boot.maven.Exclude;
+import org.springframework.boot.maven.Include;
+import org.springframework.boot.maven.IncludeFilter;
+import org.springframework.boot.maven.MatchingGroupIdFilter;
+
+/**
+ * A base mojo filtering the dependencies of the project.
+ *
+ * @author Stephane Nicoll
+ * @author David Turanski
+ * @since 1.1.0
+ */
+public abstract class AbstractDependencyFilterMojo extends AbstractMojo {
+
+	/**
+	 * Collection of artifact definitions to include. The {@link Include} element defines
+	 * mandatory {@code groupId} and {@code artifactId} properties and an optional
+	 * mandatory {@code groupId} and {@code artifactId} properties and an optional
+	 * {@code classifier} property.
+	 * @since 1.2.0
+	 */
+	@Parameter(property = "spring-boot.includes")
+	private List<Include> includes;
+
+	/**
+	 * Collection of artifact definitions to exclude. The {@link Exclude} element defines
+	 * mandatory {@code groupId} and {@code artifactId} properties and an optional
+	 * {@code classifier} property.
+	 * @since 1.1.0
+	 */
+	@Parameter(property = "spring-boot.excludes")
+	private List<Exclude> excludes;
+
+	/**
+	 * Comma separated list of groupId names to exclude (exact match).
+	 * @since 1.1.0
+	 */
+	@Parameter(property = "spring-boot.excludeGroupIds", defaultValue = "")
+	private String excludeGroupIds;
+
+	protected void setExcludes(List<Exclude> excludes) {
+		this.excludes = excludes;
+	}
+
+	protected void setIncludes(List<Include> includes) {
+		this.includes = includes;
+	}
+
+	protected void setExcludeGroupIds(String excludeGroupIds) {
+		this.excludeGroupIds = excludeGroupIds;
+	}
+
+	protected Set<Artifact> filterDependencies(Set<Artifact> dependencies, FilterArtifacts filters)
+			throws MojoExecutionException {
+		try {
+			Set<Artifact> filtered = new LinkedHashSet<>(dependencies);
+			filtered.retainAll(filters.filter(dependencies));
+			return filtered;
+		}
+		catch (ArtifactFilterException ex) {
+			throw new MojoExecutionException(ex.getMessage(), ex);
+		}
+	}
+
+	/**
+	 * Return artifact filters configured for this MOJO.
+	 * @param additionalFilters optional additional filters to apply
+	 * @return the filters
+	 */
+	protected final FilterArtifacts getFilters(ArtifactsFilter... additionalFilters) {
+		FilterArtifacts filters = new FilterArtifacts();
+		for (ArtifactsFilter additionalFilter : additionalFilters) {
+			filters.addFilter(additionalFilter);
+		}
+		filters.addFilter(new MatchingGroupIdFilter(cleanFilterConfig(this.excludeGroupIds)));
+		if (this.includes != null && !this.includes.isEmpty()) {
+			filters.addFilter(new IncludeFilter(this.includes));
+		}
+		if (this.excludes != null && !this.excludes.isEmpty()) {
+			filters.addFilter(new org.springframework.boot.maven.ExcludeFilter(this.excludes));
+		}
+		filters.addFilter(new JarTypeFilter());
+		return filters;
+	}
+
+	private static String cleanFilterConfig(String content) {
+		if (content == null || content.trim().isEmpty()) {
+			return "";
+		}
+		StringBuilder cleaned = new StringBuilder();
+		StringTokenizer tokenizer = new StringTokenizer(content, ",");
+		while (tokenizer.hasMoreElements()) {
+			cleaned.append(tokenizer.nextToken().trim());
+			if (tokenizer.hasMoreElements()) {
+				cleaned.append(",");
+			}
+		}
+		return cleaned.toString();
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/AbstractPackagerMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/AbstractPackagerMojo.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.springframework.boot.loader.tools.Layout;
+import org.springframework.boot.loader.tools.LayoutFactory;
+import org.springframework.boot.loader.tools.Layouts.Expanded;
+import org.springframework.boot.loader.tools.Layouts.Jar;
+import org.springframework.boot.loader.tools.Layouts.None;
+import org.springframework.boot.loader.tools.Layouts.War;
+import org.springframework.boot.loader.tools.Libraries;
+import org.springframework.boot.loader.tools.Packager;
+import org.springframework.boot.loader.tools.layer.CustomLayers;
+import org.springframework.boot.maven.ArtifactsLibraries;
+import org.springframework.boot.maven.Layers;
+
+/**
+ * Abstract base class for classes that work with an {@link Packager}.
+ *
+ * @author Phillip Webb
+ * @author Scott Frederick
+ * @since 2.3.0
+ */
+@SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
+public abstract class AbstractPackagerMojo extends AbstractDependencyFilterMojo {
+
+	private static final org.springframework.boot.loader.tools.Layers IMPLICIT_LAYERS = org.springframework.boot.loader.tools.Layers.IMPLICIT;
+
+	/**
+	 * The Maven project.
+	 * @since 1.0.0
+	 */
+	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	protected MavenProject project;
+
+	/**
+	 * The Maven session.
+	 * @since 2.4.0
+	 */
+	@Parameter(defaultValue = "${session}", readonly = true, required = true)
+	protected MavenSession session;
+
+	/**
+	 * Maven project helper utils.
+	 * @since 1.0.0
+	 */
+	@Component
+	protected MavenProjectHelper projectHelper;
+
+	/**
+	 * The name of the main class. If not specified the first compiled class found that
+	 * contains a {@code main} method will be used.
+	 * @since 1.0.0
+	 */
+	@Parameter
+	private String mainClass;
+
+	/**
+	 * Exclude Spring Boot devtools from the repackaged archive.
+	 * @since 1.3.0
+	 */
+	@Parameter(property = "spring-boot.repackage.excludeDevtools", defaultValue = "true")
+	@SuppressWarnings("FieldCanBeFinal")
+	private boolean excludeDevtools = true;
+
+	/**
+	 * Include system scoped dependencies.
+	 * @since 1.4.0
+	 */
+	@Parameter(defaultValue = "false")
+	public boolean includeSystemScope;
+
+	/**
+	 * Layer configuration with options to disable layer creation, exclude layer tools
+	 * jar, and provide a custom layers configuration file.
+	 * @since 2.3.0
+	 */
+	@Parameter
+	private Layers layers;
+
+	/**
+	 * Return the type of archive that should be packaged by this MOJO.
+	 * @return {@code null}, indicating a layout type will be chosen based on the original
+	 * archive type
+	 */
+	protected LayoutType getLayout() {
+		return null;
+	}
+
+	/**
+	 * Return the layout factory that will be used to determine the {@link LayoutType} if
+	 * no explicit layout is set.
+	 * @return {@code null}, indicating a default layout factory will be chosen
+	 */
+	protected LayoutFactory getLayoutFactory() {
+		return null;
+	}
+
+	/**
+	 * Return a {@link Packager} configured for this MOJO.
+	 * @param <P> the packager type
+	 * @param supplier a packager supplier
+	 * @return a configured packager
+	 */
+	protected <P extends Packager> P getConfiguredPackager(Supplier<P> supplier) {
+		P packager = supplier.get();
+		packager.setLayoutFactory(getLayoutFactory());
+		packager.addMainClassTimeoutWarningListener(new LoggingMainClassTimeoutWarningListener(this::getLog));
+		packager.setMainClass(this.mainClass);
+		LayoutType layout = getLayout();
+		if (layout != null) {
+			getLog().info("Layout: " + layout);
+			packager.setLayout(layout.layout());
+		}
+		if (this.layers == null) {
+			packager.setLayers(IMPLICIT_LAYERS);
+		}
+		else if (this.layers.isEnabled()) {
+			packager.setLayers((this.layers.getConfiguration() != null)
+					? getCustomLayers(this.layers.getConfiguration()) : IMPLICIT_LAYERS);
+			packager.setIncludeRelevantJarModeJars(this.layers.isIncludeLayerTools());
+		}
+		return packager;
+	}
+
+	private static CustomLayers getCustomLayers(File configuration) {
+		try {
+			Document document = getDocumentIfAvailable(configuration);
+			return new CustomLayersProvider().getLayers(document);
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(
+					"Failed to process custom layers configuration " + configuration.getAbsolutePath(), ex);
+		}
+	}
+
+	private static Document getDocumentIfAvailable(File xmlFile) throws IOException, ParserConfigurationException, SAXException {
+		InputSource inputSource = new InputSource(new FileInputStream(xmlFile));
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder = factory.newDocumentBuilder();
+		return builder.parse(inputSource);
+	}
+
+	/**
+	 * Return {@link Libraries} that the packager can use.
+	 * @param unpacks any libraries that require unpack
+	 * @return the libraries to use
+	 * @throws MojoExecutionException on execution error
+	 */
+	protected final Libraries getLibraries(Collection<Dependency> unpacks) throws MojoExecutionException {
+		Set<Artifact> artifacts = this.project.getArtifacts();
+		Set<Artifact> includedArtifacts = filterDependencies(artifacts, getFilters(getAdditionalFilters()));
+		return new ArtifactsLibraries(artifacts, includedArtifacts, this.session.getProjects(), unpacks, getLog());
+	}
+
+	private ArtifactsFilter[] getAdditionalFilters() {
+		List<ArtifactsFilter> filters = new ArrayList<>();
+		if (this.excludeDevtools) {
+			ExcludeFilter filter = new ExcludeFilter("org.springframework.boot", "spring-boot-devtools");
+			filters.add(filter);
+		}
+		if (!this.includeSystemScope) {
+			filters.add(new ScopeFilter(null, Artifact.SCOPE_SYSTEM));
+		}
+		return filters.toArray(new ArtifactsFilter[0]);
+	}
+
+	/**
+	 * Return the source {@link Artifact} to repackage. If a classifier is specified and
+	 * an artifact with that classifier exists, it is used. Otherwise, the main artifact
+	 * is used.
+	 * @param classifier the artifact classifier
+	 * @return the source artifact to repackage
+	 */
+	protected Artifact getSourceArtifact(String classifier) {
+		Artifact sourceArtifact = getArtifact(classifier);
+		return (sourceArtifact != null) ? sourceArtifact : this.project.getArtifact();
+	}
+
+	private Artifact getArtifact(String classifier) {
+		if (classifier != null) {
+			for (Artifact attachedArtifact : this.project.getAttachedArtifacts()) {
+				if (classifier.equals(attachedArtifact.getClassifier()) && attachedArtifact.getFile() != null
+						&& attachedArtifact.getFile().isFile()) {
+					return attachedArtifact;
+				}
+			}
+		}
+		return null;
+	}
+
+	protected File getTargetFile(String finalName, String classifier, File targetDirectory) {
+		String classifierSuffix = (classifier != null) ? classifier.trim() : "";
+		if (!classifierSuffix.isEmpty() && !classifierSuffix.startsWith("-")) {
+			classifierSuffix = "-" + classifierSuffix;
+		}
+		if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {
+		    throw new UncheckedIOException("Unable to create directories: " + targetDirectory, new IOException());
+		}
+		return new File(targetDirectory,
+				finalName + classifierSuffix + "." + this.project.getArtifact().getArtifactHandler().getExtension());
+	}
+
+	/**
+	 * Archive layout types.
+	 */
+	public enum LayoutType {
+
+		/**
+		 * Jar Layout.
+		 */
+		JAR(new Jar()),
+
+		/**
+		 * War Layout.
+		 */
+		WAR(new War()),
+
+		/**
+		 * Zip Layout.
+		 */
+		ZIP(new Expanded()),
+
+		/**
+		 * Directory Layout.
+		 */
+		DIR(new Expanded()),
+
+		/**
+		 * No Layout.
+		 */
+		NONE(new None());
+
+	    @SuppressWarnings("ImmutableEnumChecker")
+		private final Layout layout;
+
+		LayoutType(Layout layout) {
+			this.layout = layout;
+		}
+
+		public Layout layout() {
+			return this.layout;
+		}
+
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/CustomLayersProvider.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/CustomLayersProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.springframework.boot.loader.tools.Layer;
+import org.springframework.boot.loader.tools.Library;
+import org.springframework.boot.loader.tools.layer.ApplicationContentFilter;
+import org.springframework.boot.loader.tools.layer.ContentFilter;
+import org.springframework.boot.loader.tools.layer.ContentSelector;
+import org.springframework.boot.loader.tools.layer.CustomLayers;
+import org.springframework.boot.loader.tools.layer.IncludeExcludeContentSelector;
+import org.springframework.boot.loader.tools.layer.LibraryContentFilter;
+
+/**
+ * Produces a {@link CustomLayers} based on the given {@link Document}.
+ *
+ * @author Madhura Bhave
+ * @author Phillip Webb
+ */
+class CustomLayersProvider {
+
+	CustomLayers getLayers(Document document) {
+		Element root = document.getDocumentElement();
+		List<ContentSelector<String>> applicationSelectors = getApplicationSelectors(root);
+		List<ContentSelector<Library>> librarySelectors = getLibrarySelectors(root);
+		List<Layer> layers = getLayers(root);
+		return new CustomLayers(layers, applicationSelectors, librarySelectors);
+	}
+
+	private static List<ContentSelector<String>> getApplicationSelectors(Element root) {
+		return getSelectors(root, "application", (element) -> getSelector(element, ApplicationContentFilter::new));
+	}
+
+	private static  List<ContentSelector<Library>> getLibrarySelectors(Element root) {
+		return getSelectors(root, "dependencies", (element) -> getLibrarySelector(element, LibraryContentFilter::new));
+	}
+
+	private static  List<Layer> getLayers(Element root) {
+		Element layerOrder = getChildElement(root, "layerOrder");
+		if (layerOrder == null) {
+			return Collections.emptyList();
+		}
+		return getChildNodeTextContent(layerOrder, "layer").stream().map(Layer::new).collect(Collectors.toList());
+	}
+
+	@SuppressWarnings("MixedMutabilityReturnType")
+	private static <T> List<ContentSelector<T>> getSelectors(Element root, String elementName,
+			Function<Element, ContentSelector<T>> selectorFactory) {
+		Element element = getChildElement(root, elementName);
+		if (element == null) {
+			return Collections.emptyList();
+		}
+		List<ContentSelector<T>> selectors = new ArrayList<>();
+		NodeList children = element.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node child = children.item(i);
+			if (child instanceof Element) {
+				ContentSelector<T> selector = selectorFactory.apply((Element) child);
+				selectors.add(selector);
+			}
+		}
+		return selectors;
+	}
+
+	private static <T> ContentSelector<T> getSelector(Element element, Function<String, ContentFilter<T>> filterFactory) {
+		Layer layer = new Layer(element.getAttribute("layer"));
+		List<String> includes = getChildNodeTextContent(element, "include");
+		List<String> excludes = getChildNodeTextContent(element, "exclude");
+		return new IncludeExcludeContentSelector<>(layer, includes, excludes, filterFactory);
+	}
+
+	private static <T> ContentSelector<Library> getLibrarySelector(Element element,
+			Function<String, ContentFilter<Library>> filterFactory) {
+		Layer layer = new Layer(element.getAttribute("layer"));
+		List<String> includes = getChildNodeTextContent(element, "include");
+		List<String> excludes = getChildNodeTextContent(element, "exclude");
+		Element includeModuleDependencies = getChildElement(element, "includeModuleDependencies");
+		Element excludeModuleDependencies = getChildElement(element, "excludeModuleDependencies");
+		List<ContentFilter<Library>> includeFilters = includes.stream().map(filterFactory).collect(Collectors.toList());
+		if (includeModuleDependencies != null) {
+			includeFilters = new ArrayList<>(includeFilters);
+			includeFilters.add(Library::isLocal);
+		}
+		List<ContentFilter<Library>> excludeFilters = excludes.stream().map(filterFactory).collect(Collectors.toList());
+		if (excludeModuleDependencies != null) {
+			excludeFilters = new ArrayList<>(excludeFilters);
+			excludeFilters.add(Library::isLocal);
+		}
+		return new IncludeExcludeContentSelector<>(layer, includeFilters, excludeFilters);
+	}
+
+	private static List<String> getChildNodeTextContent(Element element, String tagName) {
+		List<String> patterns = new ArrayList<>();
+		NodeList nodes = element.getElementsByTagName(tagName);
+		for (int i = 0; i < nodes.getLength(); i++) {
+			Node node = nodes.item(i);
+			if (node instanceof Element) {
+				patterns.add(node.getTextContent());
+			}
+		}
+		return patterns;
+	}
+
+	private static Element getChildElement(Element element, String tagName) {
+		NodeList nodes = element.getElementsByTagName(tagName);
+		if (nodes.getLength() == 0) {
+			return null;
+		}
+		if (nodes.getLength() > 1) {
+			throw new IllegalStateException("Multiple '" + tagName + "' nodes found");
+		}
+		return (Element) nodes.item(0);
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/FilterableDependency.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/FilterableDependency.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * A model for a dependency to include or exclude.
+ *
+ * @author Stephane Nicoll
+ * @author David Turanski
+ */
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
+abstract class FilterableDependency {
+
+	/**
+	 * The groupId of the artifact to exclude.
+	 */
+	@Parameter(required = true)
+	private String groupId;
+
+	/**
+	 * The artifactId of the artifact to exclude.
+	 */
+	@Parameter(required = true)
+	private String artifactId;
+
+	/**
+	 * The classifier of the artifact to exclude.
+	 */
+	@Parameter
+	private String classifier;
+
+	String getGroupId() {
+		return this.groupId;
+	}
+
+	void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	String getArtifactId() {
+		return this.artifactId;
+	}
+
+	void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	String getClassifier() {
+		return this.classifier;
+	}
+
+	void setClassifier(String classifier) {
+		this.classifier = classifier;
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/JarTypeFilter.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/JarTypeFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.apache.maven.artifact.Artifact;
+import org.springframework.boot.maven.DependencyFilter;
+
+/**
+ * A {@link DependencyFilter} that filters dependencies based on the jar type declared in
+ * their manifest.
+ *
+ * @author Andy Wilkinson
+ */
+class JarTypeFilter extends DependencyFilter {
+
+	private static final Set<String> EXCLUDED_JAR_TYPES = Collections
+			.unmodifiableSet(new HashSet<>(Arrays.asList("annotation-processor", "dependencies-starter")));
+
+	JarTypeFilter() {
+		super(Collections.emptyList());
+	}
+
+	@Override
+	protected boolean filter(Artifact artifact) {
+		try (JarFile jarFile = new JarFile(artifact.getFile())) {
+			Manifest manifest = jarFile.getManifest();
+			if (manifest != null) {
+				String jarType = manifest.getMainAttributes().getValue("Spring-Boot-Jar-Type");
+				if (jarType != null && EXCLUDED_JAR_TYPES.contains(jarType)) {
+					return true;
+				}
+			}
+		}
+		catch (IOException ignored) {
+			// Continue
+		}
+		return false;
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/LoggingMainClassTimeoutWarningListener.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/LoggingMainClassTimeoutWarningListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+import java.util.function.Supplier;
+
+import org.apache.maven.plugin.logging.Log;
+
+import org.springframework.boot.loader.tools.Packager.MainClassTimeoutWarningListener;
+
+/**
+ * {@link MainClassTimeoutWarningListener} backed by a supplied Maven {@link Log}.
+ *
+ * @author Phillip Webb
+ */
+class LoggingMainClassTimeoutWarningListener implements MainClassTimeoutWarningListener {
+
+	private final Supplier<Log> log;
+
+	LoggingMainClassTimeoutWarningListener(Supplier<Log> log) {
+		this.log = log;
+	}
+
+	@Override
+	public void handleTimeoutWarning(long duration, String mainMethod) {
+		this.log.get().warn("Searching for the main-class is taking some time, "
+				+ "consider using the mainClass configuration parameter");
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/RepackageMojo.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.extension.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.attribute.FileTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import org.springframework.boot.loader.tools.DefaultLaunchScript;
+import org.springframework.boot.loader.tools.LaunchScript;
+import org.springframework.boot.loader.tools.LayoutFactory;
+import org.springframework.boot.loader.tools.Libraries;
+import org.springframework.boot.loader.tools.Repackager;
+
+/**
+ * Repackage existing JAR and WAR archives so that they can be executed from the command
+ * line using {@literal java -jar}. With <code>layout=NONE</code> can also be used simply
+ * to package a JAR with nested dependencies (and no main class, so not executable).
+ *
+ * @author Phillip Webb
+ * @author Dave Syer
+ * @author Stephane Nicoll
+ * @author Björn Lindström
+ * @author Scott Frederick
+ * @since 1.0.0
+ */
+@Mojo(name = "repackage", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true, threadSafe = true,
+		requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+		requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class RepackageMojo extends AbstractPackagerMojo {
+
+	private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile("\\s+");
+
+	/**
+	 * Directory containing the generated archive.
+	 * @since 1.0.0
+	 */
+	@Parameter(defaultValue = "${project.build.directory}", required = true)
+	private File outputDirectory;
+
+	/**
+	 * Name of the generated archive.
+	 * @since 1.0.0
+	 */
+	@Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+	private String finalName;
+
+	/**
+	 * Skip the execution.
+	 * @since 1.2.0
+	 */
+	@Parameter(property = "spring-boot.repackage.skip", defaultValue = "false")
+	private boolean skip;
+
+	/**
+	 * Classifier to add to the repackaged archive. If not given, the main artifact will
+	 * be replaced by the repackaged archive. If given, the classifier will also be used
+	 * to determine the source archive to repackage: if an artifact with that classifier
+	 * already exists, it will be used as source and replaced. If no such artifact exists,
+	 * the main artifact will be used as source and the repackaged archive will be
+	 * attached as a supplemental artifact with that classifier. Attaching the artifact
+	 * allows to deploy it alongside to the original one, see <a href=
+	 * "https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploying-with-classifiers.html"
+	 * >the Maven documentation for more details</a>.
+	 * @since 1.0.0
+	 */
+	@Parameter
+	private String classifier;
+
+	/**
+	 * Attach the repackaged archive to be installed into your local Maven repository or
+	 * deployed to a remote repository. If no classifier has been configured, it will
+	 * replace the normal jar. If a {@code classifier} has been configured such that the
+	 * normal jar and the repackaged jar are different, it will be attached alongside the
+	 * normal jar. When the property is set to {@code false}, the repackaged archive will
+	 * not be installed or deployed.
+	 * @since 1.4.0
+	 */
+	@Parameter(defaultValue = "true")
+	@SuppressWarnings("FieldCanBeFinal")
+	private boolean attach = true;
+
+	/**
+	 * A list of the libraries that must be unpacked from fat jars in order to run.
+	 * Specify each library as a {@code <dependency>} with a {@code <groupId>} and a
+	 * {@code <artifactId>} and they will be unpacked at runtime.
+	 * @since 1.1.0
+	 */
+	@Parameter
+	private List<Dependency> requiresUnpack;
+
+	/**
+	 * Make a fully executable jar for *nix machines by prepending a launch script to the
+	 * jar.
+	 * <p>
+	 * Currently, some tools do not accept this format so you may not always be able to
+	 * use this technique. For example, {@code jar -xf} may silently fail to extract a jar
+	 * or war that has been made fully-executable. It is recommended that you only enable
+	 * this option if you intend to execute it directly, rather than running it with
+	 * {@code java -jar} or deploying it to a servlet container.
+	 * @since 1.3.0
+	 */
+	@Parameter(defaultValue = "false")
+	private boolean executable;
+
+	/**
+	 * The embedded launch script to prepend to the front of the jar if it is fully
+	 * executable. If not specified the 'Spring Boot' default script will be used.
+	 * @since 1.3.0
+	 */
+	@Parameter
+	private File embeddedLaunchScript;
+
+	/**
+	 * Properties that should be expanded in the embedded launch script.
+	 * @since 1.3.0
+	 */
+	@Parameter
+	private Properties embeddedLaunchScriptProperties;
+
+	/**
+	 * Timestamp for reproducible output archive entries, either formatted as ISO 8601
+	 * (<code>yyyy-MM-dd'T'HH:mm:ssXXX</code>) or an {@code int} representing seconds
+	 * since the epoch.
+	 * @since 2.3.0
+	 */
+	@Parameter(defaultValue = "${project.build.outputTimestamp}")
+	private String outputTimestamp;
+
+	/**
+	 * The type of archive (which corresponds to how the dependencies are laid out inside
+	 * it). Possible values are {@code JAR}, {@code WAR}, {@code ZIP}, {@code DIR},
+	 * {@code NONE}. Defaults to a guess based on the archive type.
+	 * @since 1.0.0
+	 */
+	@Parameter(property = "spring-boot.repackage.layout")
+	private LayoutType layout;
+
+	/**
+	 * The layout factory that will be used to create the executable archive if no
+	 * explicit layout is set. Alternative layouts implementations can be provided by 3rd
+	 * parties.
+	 * @since 1.5.0
+	 */
+	@Parameter
+	private LayoutFactory layoutFactory;
+
+	/**
+	 * Return the type of archive that should be packaged by this MOJO.
+	 * @return the value of the {@code layout} parameter, or {@code null} if the parameter
+	 * is not provided
+	 */
+	@Override
+	protected LayoutType getLayout() {
+		return this.layout;
+	}
+
+	/**
+	 * Return the layout factory that will be used to determine the
+	 * {@link AbstractPackagerMojo.LayoutType} if no explicit layout is set.
+	 * @return the value of the {@code layoutFactory} parameter, or {@code null} if the
+	 * parameter is not provided
+	 */
+	@Override
+	protected LayoutFactory getLayoutFactory() {
+		return this.layoutFactory;
+	}
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if ("pom".equals(project.getPackaging())) {
+			getLog().debug("repackage goal could not be applied to pom project.");
+			return;
+		}
+		if (this.skip) {
+			getLog().debug("skipping repackaging as per configuration.");
+			return;
+		}
+		repackage();
+	}
+
+	private void repackage() throws MojoExecutionException {
+		Artifact source = getSourceArtifact(this.classifier);
+		File target = getTargetFile(this.finalName, this.classifier, this.outputDirectory);
+		Repackager repackager = getRepackager(source.getFile());
+		Libraries libraries = getLibraries(this.requiresUnpack);
+		try {
+			LaunchScript launchScript = getLaunchScript();
+			repackager.repackage(target, libraries, launchScript, parseOutputTimestamp());
+		}
+		catch (IOException ex) {
+			throw new MojoExecutionException(ex.getMessage(), ex);
+		}
+		updateArtifact(source, target, repackager.getBackupFile());
+	}
+
+	private FileTime parseOutputTimestamp() {
+		// Maven ignore a single-character timestamp as it is "useful to override a full
+		// value during pom inheritance"
+		if (this.outputTimestamp == null || this.outputTimestamp.length() < 2) {
+			return null;
+		}
+		return FileTime.from(getOutputTimestampEpochSeconds(), TimeUnit.SECONDS);
+	}
+
+	private long getOutputTimestampEpochSeconds() {
+		try {
+			return Long.parseLong(this.outputTimestamp);
+		}
+		catch (NumberFormatException ex) {
+			return OffsetDateTime.parse(this.outputTimestamp).toInstant().getEpochSecond();
+		}
+	}
+
+	private Repackager getRepackager(File source) {
+		return getConfiguredPackager(() -> new Repackager(source));
+	}
+
+	private LaunchScript getLaunchScript() throws IOException {
+		if (this.executable || this.embeddedLaunchScript != null) {
+			return new DefaultLaunchScript(this.embeddedLaunchScript, buildLaunchScriptProperties());
+		}
+		return null;
+	}
+
+	private Properties buildLaunchScriptProperties() {
+		Properties properties = new Properties();
+		if (this.embeddedLaunchScriptProperties != null) {
+			properties.putAll(this.embeddedLaunchScriptProperties);
+		}
+		putIfMissing(properties, "initInfoProvides", this.project.getArtifactId());
+		putIfMissing(properties, "initInfoShortDescription", this.project.getName(), this.project.getArtifactId());
+		putIfMissing(properties, "initInfoDescription", removeLineBreaks(this.project.getDescription()),
+				this.project.getName(), this.project.getArtifactId());
+		return properties;
+	}
+
+	private static String removeLineBreaks(String description) {
+		return (description != null) ? WHITE_SPACE_PATTERN.matcher(description).replaceAll(" ") : null;
+	}
+
+	private static void putIfMissing(Properties properties, String key, String... valueCandidates) {
+		if (!properties.containsKey(key)) {
+			for (String candidate : valueCandidates) {
+				if (candidate != null && !candidate.isEmpty()) {
+					properties.put(key, candidate);
+					return;
+				}
+			}
+		}
+	}
+
+	private void updateArtifact(Artifact source, File target, File original) {
+		if (this.attach) {
+			attachArtifact(source, target);
+		}
+		else if (source.getFile().equals(target) && original.exists()) {
+			String artifactId = (this.classifier != null) ? "artifact with classifier " + this.classifier
+					: "main artifact";
+			getLog().info(String.format("Updating %s %s to %s", artifactId, source.getFile(), original));
+			source.setFile(original);
+		}
+		else if (this.classifier != null) {
+			getLog().info("Creating repackaged archive " + target + " with classifier " + this.classifier);
+		}
+	}
+
+	private void attachArtifact(Artifact source, File target) {
+		if (this.classifier != null && !source.getFile().equals(target)) {
+			getLog().info("Attaching repackaged archive " + target + " with classifier " + this.classifier);
+			this.projectHelper.attachArtifact(this.project, this.project.getPackaging(), this.classifier, target);
+		}
+		else {
+			String artifactId = (this.classifier != null) ? "artifact with classifier " + this.classifier
+					: "main artifact";
+			getLog().info("Replacing " + artifactId + " with repackaged archive");
+			source.setFile(target);
+		}
+	}
+
+}

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/SupportMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
 import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
-import org.springframework.boot.maven.RepackageMojo;
 
 /**
  * Base Mojo Support class to provide helper methods from the specialized Mojos

--- a/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/layout/ModuleLayoutFactory.java
+++ b/app/extension/maven-plugin/src/main/java/io/syndesis/extension/maven/plugin/layout/ModuleLayoutFactory.java
@@ -47,7 +47,7 @@ public class ModuleLayoutFactory implements LayoutFactory {
             }
 
             @Override
-            public String getLibraryDestination(String libraryName, LibraryScope scope) {
+            public String getLibraryLocation(String libraryName, LibraryScope scope) {
                 if (!filterDestinationScopes || LIB_DESTINATION_SCOPES.contains(scope)) {
                     return "lib/";
                 }

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
-    <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
+    <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <spring.version>5.3.18</spring.version>
     <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
@@ -175,6 +176,14 @@
         <version>${org.apache.log4j.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Camel BOM for Spring-boot -->

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
     <spring.version>5.3.18</spring.version>
-    <spring-boot.version>2.5.12.RELEASE</spring-boot.version>
+    <spring-boot.version>2.5.12</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>

--- a/app/meta/pom.xml
+++ b/app/meta/pom.xml
@@ -127,6 +127,11 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
 
@@ -154,6 +159,11 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
 
     <dependency>
@@ -481,6 +491,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -528,6 +550,26 @@
             <ignoredResourcePattern>org/jboss/resteasy/client/jaxrs/i18n/Messages.i18n_xx.properties</ignoredResourcePattern>
           </ignoredResourcePatterns>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <additionalClasspathElements>
+                <!-- workaround suggested in https://github.com/spring-projects/spring-boot/issues/6254 -->
+                <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+              </additionalClasspathElements>
+              <reuseForks>true</reuseForks>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/app/meta/src/main/resources/application.yml
+++ b/app/meta/src/main/resources/application.yml
@@ -55,6 +55,15 @@ spring:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
       - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
       - org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.metrics.mongo.MongoMetricsAutoConfiguration
+      - org.springframework.boot.autoconfigure.gson.GsonAutoConfiguration
+      - org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfiguration
+      - org.springframework.boot.autoconfigure.netty.NettyAutoConfiguration
+      - org.springframework.boot.autoconfigure.sql.init.SqlInitializationAutoConfiguration
+      - org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration
+      - org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration
+      - org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
+
 io:
   syndesis:
     connector:

--- a/app/meta/src/main/resources/application.yml
+++ b/app/meta/src/main/resources/application.yml
@@ -29,6 +29,9 @@ management:
         request:
           autotime:
             enabled: false
+    export:
+      prometheus:
+        enabled: true
   endpoints:
     web:
       base-path: /

--- a/app/meta/src/test/java/io/syndesis/connector/meta/ConnectorEndpointIT.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/ConnectorEndpointIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.meta;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.common.model.DataShapeKinds;
+import io.syndesis.connector.support.verifier.api.MetadataRetrieval;
+import io.syndesis.connector.support.verifier.api.PropertyPair;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+
+import org.apache.camel.CamelContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.main.banner-mode = off",
+        "debug = true"
+    })
+public class ConnectorEndpointIT {
+
+    @MockBean(name = "test-connector-adapter")
+    private MetadataRetrieval adapter;
+
+    private final TestRestTemplate api;
+
+    @Autowired
+    public ConnectorEndpointIT(final TestRestTemplate api, final ObjectMapper objectMapper) {
+        this.api = api;
+        objectMapper.addMixIn(SyndesisMetadata.class, SyndesisMetadataDeserializer.class);
+        objectMapper.addMixIn(PropertyPair.class, PropertyPairDeserializer.class);
+    }
+
+    @Test
+    void shouldFetchActionMetadata() {
+        final Map<String, Object> configuredProperties = new HashMap<>();
+        configuredProperties.put("p1", "v1");
+
+        final Map<String, List<PropertyPair>> properties = new HashMap<>();
+        properties.put("prop1", Arrays.asList(new PropertyPair("val1", "Value 1"), new PropertyPair("val2", "Value 2")));
+
+        final SyndesisMetadata expected = new SyndesisMetadata(properties, new DataShape.Builder().kind(DataShapeKinds.JAVA).build(),
+            new DataShape.Builder().kind(DataShapeKinds.JSON_INSTANCE).build());
+        when(adapter.fetch(any(CamelContext.class), eq("test-connector"), eq("action1"), eq(configuredProperties))).thenReturn(expected);
+
+        final SyndesisMetadata metadata = api.postForObject("/api/v1/connectors/test-connector/actions/action1", configuredProperties,
+            SyndesisMetadata.class);
+
+        assertThat(metadata).isEqualToComparingFieldByField(expected);
+    }
+
+    @Test
+    void shouldFetchConnectorPropertiesMetadata() {
+        final Map<String, Object> configuredProperties = new HashMap<>();
+        configuredProperties.put("p1", "v1");
+
+        final Map<String, List<PropertyPair>> properties = new HashMap<>();
+        properties.put("prop1", Arrays.asList(new PropertyPair("val1", "Value 1"), new PropertyPair("val2", "Value 2")));
+
+        final SyndesisMetadata expected = new SyndesisMetadata(properties, new DataShape.Builder().kind(DataShapeKinds.JAVA).build(),
+            new DataShape.Builder().kind(DataShapeKinds.JSON_INSTANCE).build());
+        when(adapter.fetchProperties(any(CamelContext.class), eq("test-connector"), eq(configuredProperties))).thenReturn(expected);
+
+        final SyndesisMetadata metadata = api.postForObject("/api/v1/connectors/test-connector/properties/meta", configuredProperties,
+            SyndesisMetadata.class);
+
+        assertThat(metadata).isEqualToComparingFieldByField(expected);
+    }
+
+}

--- a/app/meta/src/test/java/io/syndesis/connector/meta/MetaIT.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/MetaIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.meta;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.LocalHostUriTemplateHandler;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.env.Environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.main.banner-mode = off",
+        "debug = true"
+    })
+public class MetaIT {
+
+    private final TestRestTemplate api;
+
+    private final TestRestTemplate management;
+
+    @Autowired
+    public MetaIT(final Environment environment, final TestRestTemplate api, final RestTemplateBuilder builder) {
+        this.api = api;
+        management = new TestRestTemplate(builder.uriTemplateHandler(new LocalHostUriTemplateHandler(environment) {
+            @Override
+            public String getRootUri() {
+                final String port = environment.getProperty("local.management.port");
+                return "http://localhost:" + port;
+            }
+        }));
+    }
+
+    @Test
+    void shouldExportPrometheusMetrics() {
+        final String prom = management.getForObject("/metrics", String.class);
+
+        assertThat(prom).contains("process_uptime_seconds");
+    }
+
+    @Test
+    void shouldServeHealthEndpoint() {
+        final String health = management.getForObject("/health", String.class);
+
+        assertThat(health).isEqualTo("{\"status\":\"UP\"}");
+    }
+
+    @Test
+    void shouldServeOpenAPI() {
+        final String openapi = api.getForObject("/api/v1/openapi.json", String.class);
+
+        assertThat(openapi).contains("Syndesis Meta Service");
+    }
+}

--- a/app/meta/src/test/java/io/syndesis/connector/meta/PropertyPairDeserializer.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/PropertyPairDeserializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.meta;
+
+import java.io.IOException;
+
+import io.syndesis.connector.support.verifier.api.PropertyPair;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(using = PropertyPairDeserializer.class)
+public final class PropertyPairDeserializer extends JsonDeserializer<PropertyPair> {
+
+    @Override
+    public PropertyPair deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        final TreeNode nodes = p.readValueAsTree();
+
+        return new PropertyPair(((JsonNode) nodes.path("value")).asText(), ((JsonNode) nodes.get("displayValue")).asText());
+    }
+
+}

--- a/app/meta/src/test/java/io/syndesis/connector/meta/SyndesisMetadataDeserializer.java
+++ b/app/meta/src/test/java/io/syndesis/connector/meta/SyndesisMetadataDeserializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.connector.meta;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import io.syndesis.common.model.DataShape;
+import io.syndesis.connector.support.verifier.api.PropertyPair;
+import io.syndesis.connector.support.verifier.api.SyndesisMetadata;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(using = SyndesisMetadataDeserializer.class)
+public final class SyndesisMetadataDeserializer extends JsonDeserializer<SyndesisMetadata> {
+
+    private static final TypeReference<Map<String, List<PropertyPair>>> PROPERTIES_TYPE = new TypeReference<Map<String, List<PropertyPair>>>() {
+    };
+
+    @Override
+    public SyndesisMetadata deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        Map<String, List<PropertyPair>> properties = null;
+        DataShape inputShape = null;
+        DataShape outputShape = null;
+
+        while (p.nextToken() != JsonToken.END_OBJECT) {
+            if (p.currentToken() == JsonToken.FIELD_NAME) {
+                switch (p.getCurrentName()) {
+                case "properties":
+                    p.nextToken();
+                    properties = p.readValueAs(PROPERTIES_TYPE);
+                    break;
+                case "inputShape":
+                    p.nextToken();
+                    inputShape = p.readValueAs(DataShape.class);
+                    break;
+                case "outputShape":
+                    p.nextToken();
+                    outputShape = p.readValueAs(DataShape.class);
+                    break;
+                }
+            }
+        }
+
+        return new SyndesisMetadata(properties, inputShape, outputShape);
+    }
+}

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -63,7 +63,7 @@
     <json-patch.version>1.13</json-patch.version>
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
 
-    <spring.version>5.3.15</spring.version>
+    <spring.version>5.3.18</spring.version>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1580,6 +1580,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-boot-dependencies</artifactId>
         <version>${camel.version}</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -64,7 +64,7 @@
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
 
     <spring.version>5.3.18</spring.version>
-    <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
+    <spring-boot.version>2.5.12</spring-boot.version>
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
     <!-- When updating spring-cloud version, you should update spring-cloud-starter-zipkin dependency below -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -3355,6 +3355,18 @@
         <version>${kafka-clients.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.netflix.hystrix</groupId>
+        <artifactId>hystrix-core</artifactId>
+        <version>1.5.18</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <!-- ========================================== -->
 
       <!-- === Atlasmap -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -68,7 +68,7 @@
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
     <!-- When updating spring-cloud version, you should update spring-cloud-starter-zipkin dependency below -->
-    <spring-cloud.version>Hoxton.SR12</spring-cloud.version>
+    <spring-cloud.version>2020.0.4</spring-cloud.version>
     <spring-security.version>5.3.9.RELEASE</spring-security.version>
     <org.apache.log4j.version>2.17.1</org.apache.log4j.version>
 

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Locator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Locator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.api.generator.soap.parser;
+
+import java.io.IOException;
+
+import javax.wsdl.xml.WSDLLocator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public final class Locator implements WSDLLocator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Locator.class);
+
+    private final InputSource baseInputSource;
+    private final String baseURI;
+    private String lastImportURI;
+
+    private final EntityResolver resolver = new Resolver();
+
+    public Locator(final String wsdlURL, final InputSource inputSource) {
+        baseURI = wsdlURL;
+        baseInputSource = inputSource;
+    }
+
+    @Override
+    public void close() {
+        // nothing to close
+    }
+
+    @Override
+    public InputSource getBaseInputSource() {
+        return baseInputSource;
+    }
+
+    @Override
+    public String getBaseURI() {
+        return baseURI;
+    }
+
+    @Override
+    public InputSource getImportInputSource(final String parentLocation, final String importLocation) {
+        lastImportURI = importLocation;
+        try {
+            return resolver.resolveEntity(null, importLocation);
+        } catch (SAXException | IOException e) {
+            LOG.warn("Unable to resolve: {} from {}, will use platform default", importLocation, parentLocation);
+            LOG.debug("The exception while resolving: {} from {} is", importLocation, parentLocation, e);
+
+            return new InputSource(importLocation);
+        }
+    }
+
+    @Override
+    public String getLatestImportURI() {
+        return lastImportURI;
+    }
+
+}

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Resolver.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Resolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.api.generator.soap.parser;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class Resolver implements EntityResolver {
+    @Override
+    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
+    public InputSource resolveEntity(final String publicId, final String systemId) {
+        final URI uri = parseUri(systemId);
+        if (uri == null) {
+            // default
+            return new InputSource(systemId);
+        }
+
+        final String key = (uri.getHost() + uri.getPath()).replace('/', '_').replaceAll("_$", "");
+
+        final String path = "/schema/" + key + ".xml";
+        // The stream gets passed via the InputSource, and we can only assume
+        // that the client will fetch it from there and make sure it is closed
+        final InputStream resource = Resolver.class.getResourceAsStream(path);
+        if (resource == null) {
+            // default
+            return new InputSource(systemId);
+        }
+
+        final InputSource inputSource = new InputSource();
+        inputSource.setByteStream(resource);
+        inputSource.setPublicId(publicId);
+        inputSource.setSystemId(systemId);
+
+        return inputSource;
+    }
+
+    static URI parseUri(final String given) {
+        if (given == null) {
+            return null;
+        }
+
+        try {
+            return URI.create(given);
+        } catch (final IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -116,7 +116,7 @@ public final class SoapApiModelParser {
 
             // parse WSDL to get model Definition
             final InputSource inputSource = new InputSource(condensedSpecification);
-            final Definition definition = getWsdlReader().readWSDL(wsdlURL, inputSource);
+            final Definition definition = getWsdlReader().readWSDL(new Locator(wsdlURL, inputSource));
 
             builder.model(definition);
             validateModel(definition, builder);

--- a/app/server/api-generator/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/app/server/api-generator/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,0 +1,26 @@
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+	prefer="system">
+	<system systemId="http://schemas.xmlsoap.org/soap/encoding/"
+		uri="classpath:/schema/schemas.xmlsoap.org_soap_encoding.xml" />
+	<system systemId="https://schemas.xmlsoap.org/soap/encoding/"
+		uri="classpath:/schema/schemas.xmlsoap.org_soap_encoding.xml" />
+	<system systemId="http://schemas.xmlsoap.org/wsdl/"
+		uri="classpath:/schema/schemas.xmlsoap.org_wsdl.xml" />
+	<system systemId="https://schemas.xmlsoap.org/wsdl/"
+		uri="classpath:/schema/schemas.xmlsoap.org_wsdl.xml" />
+</catalog>

--- a/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_soap_encoding.xml
+++ b/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_soap_encoding.xml
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://schemas.xmlsoap.org/soap/encoding/">
+        
+ <xs:attribute name="root">
+   <xs:annotation>
+     <xs:documentation>
+	   'root' can be used to distinguish serialization roots from other
+       elements that are present in a serialization but are not roots of
+       a serialized value graph 
+	 </xs:documentation>
+   </xs:annotation>
+   <xs:simpleType>
+     <xs:restriction base="xs:boolean">
+	   <xs:pattern value="0|1"/>
+	 </xs:restriction>
+   </xs:simpleType>
+ </xs:attribute>
+
+  <xs:attributeGroup name="commonAttributes">
+    <xs:annotation>
+	  <xs:documentation>
+	    Attributes common to all elements that function as accessors or 
+        represent independent (multi-ref) values.  The href attribute is
+        intended to be used in a manner like CONREF.  That is, the element
+        content should be empty iff the href attribute appears
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="href" type="xs:anyURI"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:attributeGroup>
+
+  <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them. -->
+       
+  <!-- Array attributes. Needed to give the type and dimensions of an array's contents, and the offset for partially-transmitted arrays. -->
+   
+  <xs:simpleType name="arrayCoordinate">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+          
+  <xs:attribute name="arrayType" type="xs:string"/>
+  <xs:attribute name="offset" type="tns:arrayCoordinate"/>
+  
+  <xs:attributeGroup name="arrayAttributes">
+    <xs:attribute ref="tns:arrayType"/>
+    <xs:attribute ref="tns:offset"/>
+  </xs:attributeGroup>    
+  
+  <xs:attribute name="position" type="tns:arrayCoordinate"/> 
+  
+  <xs:attributeGroup name="arrayMemberAttributes">
+    <xs:attribute ref="tns:position"/>
+  </xs:attributeGroup>    
+
+  <xs:group name="Array">
+    <xs:sequence>
+      <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+	</xs:sequence>
+  </xs:group>
+
+  <xs:element name="Array" type="tns:Array"/>
+  <xs:complexType name="Array">
+    <xs:annotation>
+	  <xs:documentation>
+	   'Array' is a complex type for accessors identified by position 
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:group ref="tns:Array" minOccurs="0"/>
+    <xs:attributeGroup ref="tns:arrayAttributes"/>
+    <xs:attributeGroup ref="tns:commonAttributes"/>
+  </xs:complexType> 
+
+  <!-- 'Struct' is a complex type for accessors identified by name. 
+       Constraint: No element may be have the same name as any other,
+       nor may any element have a maxOccurs > 1. -->
+   
+  <xs:element name="Struct" type="tns:Struct"/>
+
+  <xs:group name="Struct">
+    <xs:sequence>
+      <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+	</xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="Struct">
+    <xs:group ref="tns:Struct" minOccurs="0"/>
+    <xs:attributeGroup ref="tns:commonAttributes"/>
+  </xs:complexType> 
+
+  <!-- 'Base64' can be used to serialize binary data using base64 encoding
+       as defined in RFC2045 but without the MIME line length limitation. -->
+
+  <xs:simpleType name="base64">
+    <xs:restriction base="xs:base64Binary"/>
+  </xs:simpleType>
+
+ <!-- Element declarations corresponding to each of the simple types in the 
+      XML Schemas Specification. -->
+
+  <xs:element name="duration" type="tns:duration"/>
+  <xs:complexType name="duration">
+    <xs:simpleContent>
+      <xs:extension base="xs:duration">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="dateTime" type="tns:dateTime"/>
+  <xs:complexType name="dateTime">
+    <xs:simpleContent>
+      <xs:extension base="xs:dateTime">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+
+
+  <xs:element name="NOTATION" type="tns:NOTATION"/>
+  <xs:complexType name="NOTATION">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+
+  <xs:element name="time" type="tns:time"/>
+  <xs:complexType name="time">
+    <xs:simpleContent>
+      <xs:extension base="xs:time">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="date" type="tns:date"/>
+  <xs:complexType name="date">
+    <xs:simpleContent>
+      <xs:extension base="xs:date">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gYearMonth" type="tns:gYearMonth"/>
+  <xs:complexType name="gYearMonth">
+    <xs:simpleContent>
+      <xs:extension base="xs:gYearMonth">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gYear" type="tns:gYear"/>
+  <xs:complexType name="gYear">
+    <xs:simpleContent>
+      <xs:extension base="xs:gYear">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gMonthDay" type="tns:gMonthDay"/>
+  <xs:complexType name="gMonthDay">
+    <xs:simpleContent>
+      <xs:extension base="xs:gMonthDay">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gDay" type="tns:gDay"/>
+  <xs:complexType name="gDay">
+    <xs:simpleContent>
+      <xs:extension base="xs:gDay">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gMonth" type="tns:gMonth"/>
+  <xs:complexType name="gMonth">
+    <xs:simpleContent>
+      <xs:extension base="xs:gMonth">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:element name="boolean" type="tns:boolean"/>
+  <xs:complexType name="boolean">
+    <xs:simpleContent>
+      <xs:extension base="xs:boolean">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="base64Binary" type="tns:base64Binary"/>
+  <xs:complexType name="base64Binary">
+    <xs:simpleContent>
+      <xs:extension base="xs:base64Binary">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="hexBinary" type="tns:hexBinary"/>
+  <xs:complexType name="hexBinary">
+    <xs:simpleContent>
+     <xs:extension base="xs:hexBinary">
+       <xs:attributeGroup ref="tns:commonAttributes"/>
+     </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="float" type="tns:float"/>
+  <xs:complexType name="float">
+    <xs:simpleContent>
+      <xs:extension base="xs:float">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="double" type="tns:double"/>
+  <xs:complexType name="double">
+    <xs:simpleContent>
+      <xs:extension base="xs:double">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="anyURI" type="tns:anyURI"/>
+  <xs:complexType name="anyURI">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="QName" type="tns:QName"/>
+  <xs:complexType name="QName">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  
+  <xs:element name="string" type="tns:string"/>
+  <xs:complexType name="string">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="normalizedString" type="tns:normalizedString"/>
+  <xs:complexType name="normalizedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:normalizedString">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="token" type="tns:token"/>
+  <xs:complexType name="token">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="language" type="tns:language"/>
+  <xs:complexType name="language">
+    <xs:simpleContent>
+      <xs:extension base="xs:language">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="Name" type="tns:Name"/>
+  <xs:complexType name="Name">
+    <xs:simpleContent>
+      <xs:extension base="xs:Name">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NMTOKEN" type="tns:NMTOKEN"/>
+  <xs:complexType name="NMTOKEN">
+    <xs:simpleContent>
+      <xs:extension base="xs:NMTOKEN">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NCName" type="tns:NCName"/>
+  <xs:complexType name="NCName">
+    <xs:simpleContent>
+      <xs:extension base="xs:NCName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NMTOKENS" type="tns:NMTOKENS"/>
+  <xs:complexType name="NMTOKENS">
+    <xs:simpleContent>
+      <xs:extension base="xs:NMTOKENS">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ID" type="tns:ID"/>
+  <xs:complexType name="ID">
+    <xs:simpleContent>
+      <xs:extension base="xs:ID">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="IDREF" type="tns:IDREF"/>
+  <xs:complexType name="IDREF">
+    <xs:simpleContent>
+      <xs:extension base="xs:IDREF">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ENTITY" type="tns:ENTITY"/>
+  <xs:complexType name="ENTITY">
+    <xs:simpleContent>
+      <xs:extension base="xs:ENTITY">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="IDREFS" type="tns:IDREFS"/>
+  <xs:complexType name="IDREFS">
+    <xs:simpleContent>
+      <xs:extension base="xs:IDREFS">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ENTITIES" type="tns:ENTITIES"/>
+  <xs:complexType name="ENTITIES">
+    <xs:simpleContent>
+      <xs:extension base="xs:ENTITIES">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="decimal" type="tns:decimal"/>
+  <xs:complexType name="decimal">
+    <xs:simpleContent>
+      <xs:extension base="xs:decimal">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="integer" type="tns:integer"/>
+  <xs:complexType name="integer">
+    <xs:simpleContent>
+      <xs:extension base="xs:integer">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="nonPositiveInteger" type="tns:nonPositiveInteger"/>
+  <xs:complexType name="nonPositiveInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonPositiveInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="negativeInteger" type="tns:negativeInteger"/>
+  <xs:complexType name="negativeInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:negativeInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="long" type="tns:long"/>
+  <xs:complexType name="long">
+    <xs:simpleContent>
+      <xs:extension base="xs:long">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="int" type="tns:int"/>
+  <xs:complexType name="int">
+    <xs:simpleContent>
+      <xs:extension base="xs:int">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="short" type="tns:short"/>
+  <xs:complexType name="short">
+    <xs:simpleContent>
+      <xs:extension base="xs:short">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="byte" type="tns:byte"/>
+  <xs:complexType name="byte">
+    <xs:simpleContent>
+      <xs:extension base="xs:byte">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="nonNegativeInteger" type="tns:nonNegativeInteger"/>
+  <xs:complexType name="nonNegativeInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedLong" type="tns:unsignedLong"/>
+  <xs:complexType name="unsignedLong">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedLong">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedInt" type="tns:unsignedInt"/>
+  <xs:complexType name="unsignedInt">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedInt">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedShort" type="tns:unsignedShort"/>
+  <xs:complexType name="unsignedShort">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedShort">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedByte" type="tns:unsignedByte"/>
+  <xs:complexType name="unsignedByte">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedByte">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="positiveInteger" type="tns:positiveInteger"/>
+  <xs:complexType name="positiveInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:positiveInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="anyType"/>
+</xs:schema>

--- a/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_wsdl.xml
+++ b/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_wsdl.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://schemas.xmlsoap.org/wsdl/" elementFormDefault="qualified">
+   
+  <xs:complexType mixed="true" name="tDocumentation">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="tDocumented">
+    <xs:annotation>
+      <xs:documentation>
+      This type is extended by  component types to allow them to be documented
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="documentation" type="wsdl:tDocumentation" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+	 
+  <xs:complexType name="tExtensibleAttributesDocumented" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tDocumented">
+        <xs:annotation>
+          <xs:documentation>
+          This type is extended by component types to allow attributes from other namespaces to be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>    
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tExtensibleDocumented" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tDocumented">
+        <xs:annotation>
+          <xs:documentation>
+          This type is extended by component types to allow elements from other namespaces to be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="definitions" type="wsdl:tDefinitions">
+    <xs:key name="message">
+      <xs:selector xpath="wsdl:message"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="portType">
+      <xs:selector xpath="wsdl:portType"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="binding">
+      <xs:selector xpath="wsdl:binding"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="service">
+      <xs:selector xpath="wsdl:service"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="import">
+      <xs:selector xpath="wsdl:import"/>
+      <xs:field xpath="@namespace"/>
+    </xs:key>
+  </xs:element>
+
+  <xs:group name="anyTopLevelOptionalElement">
+    <xs:annotation>
+      <xs:documentation>
+      Any top level optional element allowed to appear more then once - any child of definitions element except wsdl:types. Any extensibility element is allowed in any place.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="import" type="wsdl:tImport"/>
+      <xs:element name="types" type="wsdl:tTypes"/>                     
+      <xs:element name="message" type="wsdl:tMessage">
+        <xs:unique name="part">
+          <xs:selector xpath="wsdl:part"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+      </xs:element>
+      <xs:element name="portType" type="wsdl:tPortType"/>
+      <xs:element name="binding" type="wsdl:tBinding"/>
+      <xs:element name="service" type="wsdl:tService">
+        <xs:unique name="port">
+          <xs:selector xpath="wsdl:port"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+	  </xs:element>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="tDefinitions">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:group ref="wsdl:anyTopLevelOptionalElement" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="targetNamespace" type="xs:anyURI" use="optional"/>
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+   
+  <xs:complexType name="tImport">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="namespace" type="xs:anyURI" use="required"/>
+        <xs:attribute name="location" type="xs:anyURI" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+   
+  <xs:complexType name="tTypes">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented"/>
+    </xs:complexContent>   
+  </xs:complexType>
+     
+  <xs:complexType name="tMessage">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="part" type="wsdl:tPart" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+
+  <xs:complexType name="tPart">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="element" type="xs:QName" use="optional"/>
+        <xs:attribute name="type" type="xs:QName" use="optional"/>    
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+
+  <xs:complexType name="tPortType">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:sequence>
+          <xs:element name="operation" type="wsdl:tOperation" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+   
+  <xs:complexType name="tOperation">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented">
+	    <xs:sequence>
+          <xs:choice>
+            <xs:group ref="wsdl:request-response-or-one-way-operation"/>
+            <xs:group ref="wsdl:solicit-response-or-notification-operation"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="parameterOrder" type="xs:NMTOKENS" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+    
+  <xs:group name="request-response-or-one-way-operation">
+    <xs:sequence>
+      <xs:element name="input" type="wsdl:tParam"/>
+	  <xs:sequence minOccurs="0">
+	    <xs:element name="output" type="wsdl:tParam"/>
+		<xs:element name="fault" type="wsdl:tFault" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="solicit-response-or-notification-operation">
+    <xs:sequence>
+      <xs:element name="output" type="wsdl:tParam"/>
+	  <xs:sequence minOccurs="0">
+	    <xs:element name="input" type="wsdl:tParam"/>
+		<xs:element name="fault" type="wsdl:tFault" minOccurs="0" maxOccurs="unbounded"/>
+	  </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+        
+  <xs:complexType name="tParam">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+        <xs:attribute name="message" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tFault">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="message" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tBinding">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="operation" type="wsdl:tBindingOperation" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="type" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+    
+  <xs:complexType name="tBindingOperationMessage">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="tBindingOperationFault">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tBindingOperation">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="input" type="wsdl:tBindingOperationMessage" minOccurs="0"/>
+          <xs:element name="output" type="wsdl:tBindingOperationMessage" minOccurs="0"/>
+          <xs:element name="fault" type="wsdl:tBindingOperationFault" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tService">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="port" type="wsdl:tPort" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tPort">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="binding" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:attribute name="arrayType" type="xs:string"/>
+  <xs:attribute name="required" type="xs:boolean"/>
+  <xs:complexType name="tExtensibilityElement" abstract="true">
+    <xs:attribute ref="wsdl:required" use="optional"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/app/server/runtime/pom.xml
+++ b/app/server/runtime/pom.xml
@@ -483,6 +483,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+        <version>2.0.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.bouncycastle</groupId>
@@ -762,6 +763,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+      <version>1.1.10.RELEASE</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -776,6 +778,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-security</artifactId>
+      <version>2.2.5.RELEASE</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/app/server/runtime/src/main/resources/application.yml
+++ b/app/server/runtime/src/main/resources/application.yml
@@ -42,6 +42,9 @@ management:
     db:
       enabled: false
   metrics:
+    export:
+      prometheus:
+        enabled: true
     web:
       server:
         request:

--- a/app/server/runtime/src/test/java/io/syndesis/server/runtime/KubernetesClientITCase.java
+++ b/app/server/runtime/src/test/java/io/syndesis/server/runtime/KubernetesClientITCase.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,6 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
     },
     properties = {
         "spring.main.banner-mode = off"
+    }
+)
+@ActiveProfiles("test")
+@ContextConfiguration(
+    classes = {
+        Application.class
     }
 )
 public class KubernetesClientITCase {

--- a/app/server/runtime/src/test/resources/application-test.yml
+++ b/app/server/runtime/src/test/resources/application-test.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+debug: true
+
 encrypt:
   key: da39a3ee5e6b4b0d3255bfef95601890afd80709
 
@@ -39,6 +41,10 @@ github:
 management:
   server:
     port: -1
+  metrics:
+    export:
+      prometheus:
+        enabled: true
   health:
     db:
       enabled: false


### PR DESCRIPTION
Upgrading Spring alone would not have been an issue, upgrading Spring Boot seems to have been a bigger issue. One issue unrelated to Spring upgrades is that the WSDL stack we use seems to fetch and parse remote XML schemas without following HTTP redirects, so I've added local cache for those.

Here are the results of that:

[fix(extension): don't use removed method](https://github.com/syndesisio/syndesis/commit/c51c578ff24f173d4ada318becb54450e5fb491d)

The method `Layout::getLibraryDestination` was renamed to `Layout::getLibraryLocation`.

[fix(api-generator): don't load remote schemas](https://github.com/syndesisio/syndesis/commit/800357b3a2dd7148acf92f3429e23bc029cbc18c)

We should not reach out and load remote XML schemas from
schemas.xmlsoap.org.

Background: it seems that recently schemas.xmlsoap.org website
configured HTTP to HTTPS redirect and in doing so broke our WSDL parser
as it will try to fetch without following HTTP redirects. This results
in empty HTTP body that the parser tries to parse and fails with:

```
org.xml.sax.SAXParseException: Premature end of file.
```

To resolve this this stores the two identified XSD files locally and
sets the custom EntityResolver via a custom WSDLLocator to load those
instead. The same is done for the CXF schema parsing classes which can
load the catalog files from `META-INF/jax-ws-catalog.xml`.

[fix(deps): missing javax.annotation.Nullable](https://github.com/syndesisio/syndesis/commit/e3180d7084e6e694f0274308236e464b56d45622)


Seems that some dependency was pulling this in, but it is not pulling it in any more after Spring/Spring Boot upgrade. This adds it to prevent a compile error.

[fix(extension): compile issues Spring Boot upgrade](https://github.com/syndesisio/syndesis/commit/e836abe3ba3893ffb376caffab118a06b771e9d9)

The `AbstractDependencyFilterMojo:filterDependencies` method that we override has become `final`, so this copies and repackages `AbstractDependencyFilterMojo` and all of the code that is referenced from it in a package private/protected way so we can compile the plugin. 

The Spring Boot code included here is ASF licensed, so it should be okay.

Some code quality/style checks changes were required.

[fix(deps): upgrade to Spring Cloud 2020.0.4](https://github.com/syndesisio/syndesis/commit/94722040e53326c22b09fff835af2f95bf61b84b)

Upgrades to the next version after Hoxton.SR12, as Hoxton.SR12 was not compatible with Spring Boot 2.5.x.

[fix(deps): declare hystrix-core version](https://github.com/syndesisio/syndesis/commit/b208a2f26ecfcf4341f35cba386f2d25cb7a5910)

I think Spring Cloud was declaring it and then dropped it from the release we need to upgrade to, so we need to declare it here instead.

[fix(deps): add missing dependency verisions](https://github.com/syndesisio/syndesis/commit/00175b065bd84e73ef2b779414c93e7277b763fd)

Upgrading to Spring Cloud we lost some of the versions declared here, I picked to the best of my ability the versions, there could be a better selection.

[fix(server): enable prometheus export](https://github.com/syndesisio/syndesis/commit/21dba005288794b7d48ee88d7aaaa2bff5ba8b7a)

It is no longer by default on if Prometheus exporter classes are detected on the classpath, we need to enable it explicitly.

Also adds the `debug=true` to the to the server integration tests so we can tell why a bean wasn't introduced into the context.

[fix(server): adapt KubernetesClient test](https://github.com/syndesisio/syndesis/commit/cf843b2a147650d682de55e509e3cefc238dbba9)

Seems that we need to explicitly load the `Application` configuration, otherwise Spring Boot auto-configuration doesn't kick in.