### PR TITLE
 Upgrades Spring to 5.2.20

### DIFF
--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.2</atlasmap.version>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -173,6 +173,14 @@
         <type>pom</type>
       </dependency>
 
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Camel BOM for Spring-boot -->
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -178,6 +178,14 @@
         <type>pom</type>
       </dependency>
 
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- Camel BOM for Spring-boot -->
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <!-- we must ensure to have this version aligned with extension-bom and integration-bom -->
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.2</atlasmap.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -61,7 +61,7 @@
     <json-patch.version>1.13</json-patch.version>
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
 
-    <spring.version>5.2.15.RELEASE</spring.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
     <spring-social.version>1.1.6.RELEASE</spring-social.version>
     <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1576,6 +1576,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-boot-dependencies</artifactId>
         <version>${camel.version}</version>

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Locator.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Locator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.api.generator.soap.parser;
+
+import java.io.IOException;
+
+import javax.wsdl.xml.WSDLLocator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public final class Locator implements WSDLLocator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Locator.class);
+
+    private final InputSource baseInputSource;
+    private final String baseURI;
+    private String lastImportURI;
+
+    private final EntityResolver resolver = new Resolver();
+
+    public Locator(final String wsdlURL, final InputSource inputSource) {
+        baseURI = wsdlURL;
+        baseInputSource = inputSource;
+    }
+
+    @Override
+    public void close() {
+        // nothing to close
+    }
+
+    @Override
+    public InputSource getBaseInputSource() {
+        return baseInputSource;
+    }
+
+    @Override
+    public String getBaseURI() {
+        return baseURI;
+    }
+
+    @Override
+    public InputSource getImportInputSource(final String parentLocation, final String importLocation) {
+        lastImportURI = importLocation;
+        try {
+            return resolver.resolveEntity(null, importLocation);
+        } catch (SAXException | IOException e) {
+            LOG.warn("Unable to resolve: {} from {}, will use platform default", importLocation, parentLocation);
+            LOG.debug("The exception while resolving: {} from {} is", importLocation, parentLocation, e);
+
+            return new InputSource(importLocation);
+        }
+    }
+
+    @Override
+    public String getLatestImportURI() {
+        return lastImportURI;
+    }
+
+}

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Resolver.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/Resolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.syndesis.server.api.generator.soap.parser;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class Resolver implements EntityResolver {
+    @Override
+    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
+    public InputSource resolveEntity(final String publicId, final String systemId) {
+        final URI uri = parseUri(systemId);
+        if (uri == null) {
+            // default
+            return new InputSource(systemId);
+        }
+
+        final String key = (uri.getHost() + uri.getPath()).replace('/', '_').replaceAll("_$", "");
+
+        final String path = "/schema/" + key + ".xml";
+        // The stream gets passed via the InputSource, and we can only assume
+        // that the client will fetch it from there and make sure it is closed
+        final InputStream resource = Resolver.class.getResourceAsStream(path);
+        if (resource == null) {
+            // default
+            return new InputSource(systemId);
+        }
+
+        final InputSource inputSource = new InputSource();
+        inputSource.setByteStream(resource);
+        inputSource.setPublicId(publicId);
+        inputSource.setSystemId(systemId);
+
+        return inputSource;
+    }
+
+    static URI parseUri(final String given) {
+        if (given == null) {
+            return null;
+        }
+
+        try {
+            return URI.create(given);
+        } catch (final IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
+++ b/app/server/api-generator/src/main/java/io/syndesis/server/api/generator/soap/parser/SoapApiModelParser.java
@@ -116,7 +116,7 @@ public final class SoapApiModelParser {
 
             // parse WSDL to get model Definition
             final InputSource inputSource = new InputSource(condensedSpecification);
-            final Definition definition = getWsdlReader().readWSDL(wsdlURL, inputSource);
+            final Definition definition = getWsdlReader().readWSDL(new Locator(wsdlURL, inputSource));
 
             builder.model(definition);
             validateModel(definition, builder);

--- a/app/server/api-generator/src/main/resources/META-INF/jax-ws-catalog.xml
+++ b/app/server/api-generator/src/main/resources/META-INF/jax-ws-catalog.xml
@@ -1,0 +1,26 @@
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+	prefer="system">
+	<system systemId="http://schemas.xmlsoap.org/soap/encoding/"
+		uri="classpath:/schema/schemas.xmlsoap.org_soap_encoding.xml" />
+	<system systemId="https://schemas.xmlsoap.org/soap/encoding/"
+		uri="classpath:/schema/schemas.xmlsoap.org_soap_encoding.xml" />
+	<system systemId="http://schemas.xmlsoap.org/wsdl/"
+		uri="classpath:/schema/schemas.xmlsoap.org_wsdl.xml" />
+	<system systemId="https://schemas.xmlsoap.org/wsdl/"
+		uri="classpath:/schema/schemas.xmlsoap.org_wsdl.xml" />
+</catalog>

--- a/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_soap_encoding.xml
+++ b/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_soap_encoding.xml
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://schemas.xmlsoap.org/soap/encoding/">
+        
+ <xs:attribute name="root">
+   <xs:annotation>
+     <xs:documentation>
+	   'root' can be used to distinguish serialization roots from other
+       elements that are present in a serialization but are not roots of
+       a serialized value graph 
+	 </xs:documentation>
+   </xs:annotation>
+   <xs:simpleType>
+     <xs:restriction base="xs:boolean">
+	   <xs:pattern value="0|1"/>
+	 </xs:restriction>
+   </xs:simpleType>
+ </xs:attribute>
+
+  <xs:attributeGroup name="commonAttributes">
+    <xs:annotation>
+	  <xs:documentation>
+	    Attributes common to all elements that function as accessors or 
+        represent independent (multi-ref) values.  The href attribute is
+        intended to be used in a manner like CONREF.  That is, the element
+        content should be empty iff the href attribute appears
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:attribute name="id" type="xs:ID"/>
+    <xs:attribute name="href" type="xs:anyURI"/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:attributeGroup>
+
+  <!-- Global Attributes.  The following attributes are intended to be usable via qualified attribute names on any complex type referencing them. -->
+       
+  <!-- Array attributes. Needed to give the type and dimensions of an array's contents, and the offset for partially-transmitted arrays. -->
+   
+  <xs:simpleType name="arrayCoordinate">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+          
+  <xs:attribute name="arrayType" type="xs:string"/>
+  <xs:attribute name="offset" type="tns:arrayCoordinate"/>
+  
+  <xs:attributeGroup name="arrayAttributes">
+    <xs:attribute ref="tns:arrayType"/>
+    <xs:attribute ref="tns:offset"/>
+  </xs:attributeGroup>    
+  
+  <xs:attribute name="position" type="tns:arrayCoordinate"/> 
+  
+  <xs:attributeGroup name="arrayMemberAttributes">
+    <xs:attribute ref="tns:position"/>
+  </xs:attributeGroup>    
+
+  <xs:group name="Array">
+    <xs:sequence>
+      <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+	</xs:sequence>
+  </xs:group>
+
+  <xs:element name="Array" type="tns:Array"/>
+  <xs:complexType name="Array">
+    <xs:annotation>
+	  <xs:documentation>
+	   'Array' is a complex type for accessors identified by position 
+	  </xs:documentation>
+	</xs:annotation>
+    <xs:group ref="tns:Array" minOccurs="0"/>
+    <xs:attributeGroup ref="tns:arrayAttributes"/>
+    <xs:attributeGroup ref="tns:commonAttributes"/>
+  </xs:complexType> 
+
+  <!-- 'Struct' is a complex type for accessors identified by name. 
+       Constraint: No element may be have the same name as any other,
+       nor may any element have a maxOccurs > 1. -->
+   
+  <xs:element name="Struct" type="tns:Struct"/>
+
+  <xs:group name="Struct">
+    <xs:sequence>
+      <xs:any namespace="##any" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+	</xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="Struct">
+    <xs:group ref="tns:Struct" minOccurs="0"/>
+    <xs:attributeGroup ref="tns:commonAttributes"/>
+  </xs:complexType> 
+
+  <!-- 'Base64' can be used to serialize binary data using base64 encoding
+       as defined in RFC2045 but without the MIME line length limitation. -->
+
+  <xs:simpleType name="base64">
+    <xs:restriction base="xs:base64Binary"/>
+  </xs:simpleType>
+
+ <!-- Element declarations corresponding to each of the simple types in the 
+      XML Schemas Specification. -->
+
+  <xs:element name="duration" type="tns:duration"/>
+  <xs:complexType name="duration">
+    <xs:simpleContent>
+      <xs:extension base="xs:duration">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="dateTime" type="tns:dateTime"/>
+  <xs:complexType name="dateTime">
+    <xs:simpleContent>
+      <xs:extension base="xs:dateTime">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+
+
+  <xs:element name="NOTATION" type="tns:NOTATION"/>
+  <xs:complexType name="NOTATION">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+
+  <xs:element name="time" type="tns:time"/>
+  <xs:complexType name="time">
+    <xs:simpleContent>
+      <xs:extension base="xs:time">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="date" type="tns:date"/>
+  <xs:complexType name="date">
+    <xs:simpleContent>
+      <xs:extension base="xs:date">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gYearMonth" type="tns:gYearMonth"/>
+  <xs:complexType name="gYearMonth">
+    <xs:simpleContent>
+      <xs:extension base="xs:gYearMonth">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gYear" type="tns:gYear"/>
+  <xs:complexType name="gYear">
+    <xs:simpleContent>
+      <xs:extension base="xs:gYear">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gMonthDay" type="tns:gMonthDay"/>
+  <xs:complexType name="gMonthDay">
+    <xs:simpleContent>
+      <xs:extension base="xs:gMonthDay">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gDay" type="tns:gDay"/>
+  <xs:complexType name="gDay">
+    <xs:simpleContent>
+      <xs:extension base="xs:gDay">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="gMonth" type="tns:gMonth"/>
+  <xs:complexType name="gMonth">
+    <xs:simpleContent>
+      <xs:extension base="xs:gMonth">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:element name="boolean" type="tns:boolean"/>
+  <xs:complexType name="boolean">
+    <xs:simpleContent>
+      <xs:extension base="xs:boolean">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="base64Binary" type="tns:base64Binary"/>
+  <xs:complexType name="base64Binary">
+    <xs:simpleContent>
+      <xs:extension base="xs:base64Binary">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="hexBinary" type="tns:hexBinary"/>
+  <xs:complexType name="hexBinary">
+    <xs:simpleContent>
+     <xs:extension base="xs:hexBinary">
+       <xs:attributeGroup ref="tns:commonAttributes"/>
+     </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="float" type="tns:float"/>
+  <xs:complexType name="float">
+    <xs:simpleContent>
+      <xs:extension base="xs:float">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="double" type="tns:double"/>
+  <xs:complexType name="double">
+    <xs:simpleContent>
+      <xs:extension base="xs:double">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="anyURI" type="tns:anyURI"/>
+  <xs:complexType name="anyURI">
+    <xs:simpleContent>
+      <xs:extension base="xs:anyURI">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="QName" type="tns:QName"/>
+  <xs:complexType name="QName">
+    <xs:simpleContent>
+      <xs:extension base="xs:QName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  
+  <xs:element name="string" type="tns:string"/>
+  <xs:complexType name="string">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="normalizedString" type="tns:normalizedString"/>
+  <xs:complexType name="normalizedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:normalizedString">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="token" type="tns:token"/>
+  <xs:complexType name="token">
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="language" type="tns:language"/>
+  <xs:complexType name="language">
+    <xs:simpleContent>
+      <xs:extension base="xs:language">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="Name" type="tns:Name"/>
+  <xs:complexType name="Name">
+    <xs:simpleContent>
+      <xs:extension base="xs:Name">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NMTOKEN" type="tns:NMTOKEN"/>
+  <xs:complexType name="NMTOKEN">
+    <xs:simpleContent>
+      <xs:extension base="xs:NMTOKEN">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NCName" type="tns:NCName"/>
+  <xs:complexType name="NCName">
+    <xs:simpleContent>
+      <xs:extension base="xs:NCName">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="NMTOKENS" type="tns:NMTOKENS"/>
+  <xs:complexType name="NMTOKENS">
+    <xs:simpleContent>
+      <xs:extension base="xs:NMTOKENS">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ID" type="tns:ID"/>
+  <xs:complexType name="ID">
+    <xs:simpleContent>
+      <xs:extension base="xs:ID">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="IDREF" type="tns:IDREF"/>
+  <xs:complexType name="IDREF">
+    <xs:simpleContent>
+      <xs:extension base="xs:IDREF">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ENTITY" type="tns:ENTITY"/>
+  <xs:complexType name="ENTITY">
+    <xs:simpleContent>
+      <xs:extension base="xs:ENTITY">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="IDREFS" type="tns:IDREFS"/>
+  <xs:complexType name="IDREFS">
+    <xs:simpleContent>
+      <xs:extension base="xs:IDREFS">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="ENTITIES" type="tns:ENTITIES"/>
+  <xs:complexType name="ENTITIES">
+    <xs:simpleContent>
+      <xs:extension base="xs:ENTITIES">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="decimal" type="tns:decimal"/>
+  <xs:complexType name="decimal">
+    <xs:simpleContent>
+      <xs:extension base="xs:decimal">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="integer" type="tns:integer"/>
+  <xs:complexType name="integer">
+    <xs:simpleContent>
+      <xs:extension base="xs:integer">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="nonPositiveInteger" type="tns:nonPositiveInteger"/>
+  <xs:complexType name="nonPositiveInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonPositiveInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="negativeInteger" type="tns:negativeInteger"/>
+  <xs:complexType name="negativeInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:negativeInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="long" type="tns:long"/>
+  <xs:complexType name="long">
+    <xs:simpleContent>
+      <xs:extension base="xs:long">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="int" type="tns:int"/>
+  <xs:complexType name="int">
+    <xs:simpleContent>
+      <xs:extension base="xs:int">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="short" type="tns:short"/>
+  <xs:complexType name="short">
+    <xs:simpleContent>
+      <xs:extension base="xs:short">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="byte" type="tns:byte"/>
+  <xs:complexType name="byte">
+    <xs:simpleContent>
+      <xs:extension base="xs:byte">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="nonNegativeInteger" type="tns:nonNegativeInteger"/>
+  <xs:complexType name="nonNegativeInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:nonNegativeInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedLong" type="tns:unsignedLong"/>
+  <xs:complexType name="unsignedLong">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedLong">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedInt" type="tns:unsignedInt"/>
+  <xs:complexType name="unsignedInt">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedInt">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedShort" type="tns:unsignedShort"/>
+  <xs:complexType name="unsignedShort">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedShort">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="unsignedByte" type="tns:unsignedByte"/>
+  <xs:complexType name="unsignedByte">
+    <xs:simpleContent>
+      <xs:extension base="xs:unsignedByte">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="positiveInteger" type="tns:positiveInteger"/>
+  <xs:complexType name="positiveInteger">
+    <xs:simpleContent>
+      <xs:extension base="xs:positiveInteger">
+        <xs:attributeGroup ref="tns:commonAttributes"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="anyType"/>
+</xs:schema>

--- a/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_wsdl.xml
+++ b/app/server/api-generator/src/main/resources/schema/schemas.xmlsoap.org_wsdl.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (C) 2016 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://schemas.xmlsoap.org/wsdl/" elementFormDefault="qualified">
+   
+  <xs:complexType mixed="true" name="tDocumentation">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="tDocumented">
+    <xs:annotation>
+      <xs:documentation>
+      This type is extended by  component types to allow them to be documented
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="documentation" type="wsdl:tDocumentation" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+	 
+  <xs:complexType name="tExtensibleAttributesDocumented" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tDocumented">
+        <xs:annotation>
+          <xs:documentation>
+          This type is extended by component types to allow attributes from other namespaces to be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>    
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tExtensibleDocumented" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tDocumented">
+        <xs:annotation>
+          <xs:documentation>
+          This type is extended by component types to allow elements from other namespaces to be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="definitions" type="wsdl:tDefinitions">
+    <xs:key name="message">
+      <xs:selector xpath="wsdl:message"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="portType">
+      <xs:selector xpath="wsdl:portType"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="binding">
+      <xs:selector xpath="wsdl:binding"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="service">
+      <xs:selector xpath="wsdl:service"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="import">
+      <xs:selector xpath="wsdl:import"/>
+      <xs:field xpath="@namespace"/>
+    </xs:key>
+  </xs:element>
+
+  <xs:group name="anyTopLevelOptionalElement">
+    <xs:annotation>
+      <xs:documentation>
+      Any top level optional element allowed to appear more then once - any child of definitions element except wsdl:types. Any extensibility element is allowed in any place.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="import" type="wsdl:tImport"/>
+      <xs:element name="types" type="wsdl:tTypes"/>                     
+      <xs:element name="message" type="wsdl:tMessage">
+        <xs:unique name="part">
+          <xs:selector xpath="wsdl:part"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+      </xs:element>
+      <xs:element name="portType" type="wsdl:tPortType"/>
+      <xs:element name="binding" type="wsdl:tBinding"/>
+      <xs:element name="service" type="wsdl:tService">
+        <xs:unique name="port">
+          <xs:selector xpath="wsdl:port"/>
+          <xs:field xpath="@name"/>
+        </xs:unique>
+	  </xs:element>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="tDefinitions">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:group ref="wsdl:anyTopLevelOptionalElement" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="targetNamespace" type="xs:anyURI" use="optional"/>
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+   
+  <xs:complexType name="tImport">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="namespace" type="xs:anyURI" use="required"/>
+        <xs:attribute name="location" type="xs:anyURI" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+   
+  <xs:complexType name="tTypes">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented"/>
+    </xs:complexContent>   
+  </xs:complexType>
+     
+  <xs:complexType name="tMessage">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="part" type="wsdl:tPart" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+
+  <xs:complexType name="tPart">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="element" type="xs:QName" use="optional"/>
+        <xs:attribute name="type" type="xs:QName" use="optional"/>    
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+
+  <xs:complexType name="tPortType">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:sequence>
+          <xs:element name="operation" type="wsdl:tOperation" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+   
+  <xs:complexType name="tOperation">
+    <xs:complexContent>   
+      <xs:extension base="wsdl:tExtensibleDocumented">
+	    <xs:sequence>
+          <xs:choice>
+            <xs:group ref="wsdl:request-response-or-one-way-operation"/>
+            <xs:group ref="wsdl:solicit-response-or-notification-operation"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="parameterOrder" type="xs:NMTOKENS" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>   
+  </xs:complexType>
+    
+  <xs:group name="request-response-or-one-way-operation">
+    <xs:sequence>
+      <xs:element name="input" type="wsdl:tParam"/>
+	  <xs:sequence minOccurs="0">
+	    <xs:element name="output" type="wsdl:tParam"/>
+		<xs:element name="fault" type="wsdl:tFault" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:group name="solicit-response-or-notification-operation">
+    <xs:sequence>
+      <xs:element name="output" type="wsdl:tParam"/>
+	  <xs:sequence minOccurs="0">
+	    <xs:element name="input" type="wsdl:tParam"/>
+		<xs:element name="fault" type="wsdl:tFault" minOccurs="0" maxOccurs="unbounded"/>
+	  </xs:sequence>
+    </xs:sequence>
+  </xs:group>
+        
+  <xs:complexType name="tParam">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+        <xs:attribute name="message" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tFault">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleAttributesDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="message" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tBinding">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="operation" type="wsdl:tBindingOperation" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="type" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+    
+  <xs:complexType name="tBindingOperationMessage">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="tBindingOperationFault">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="tBindingOperation">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="input" type="wsdl:tBindingOperationMessage" minOccurs="0"/>
+          <xs:element name="output" type="wsdl:tBindingOperationMessage" minOccurs="0"/>
+          <xs:element name="fault" type="wsdl:tBindingOperationFault" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tService">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:sequence>
+          <xs:element name="port" type="wsdl:tPort" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+     
+  <xs:complexType name="tPort">
+    <xs:complexContent>
+      <xs:extension base="wsdl:tExtensibleDocumented">
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="binding" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:attribute name="arrayType" type="xs:string"/>
+  <xs:attribute name="required" type="xs:boolean"/>
+  <xs:complexType name="tExtensibilityElement" abstract="true">
+    <xs:attribute ref="wsdl:required" use="optional"/>
+  </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
Contains:
[chore(deps): spring-core from 5.2.15 to 5.2.20](https://github.com/syndesisio/syndesis/commit/41aa16b67f137eaa1ff2cc121479cefacb93ead2)

[fix(deps): force declared Spring Framework version](https://github.com/syndesisio/syndesis/commit/5ff8770721e008e8f491b9f17625786627fc03e0)

We can get different version of Spring Framework via Camel dependencies,
e.g. via `camel-spring`, even though we wish to be aligned with Camel
there are situations we might want a newer version (but compatible) of
Spring. This forces the declared version of Spring Framework by
importing the spring-framework-bom with the same version before the
Camel BOM, and that way solidifying the version of Spring Framework to
be used.

(cherry picked from commit d7e9e2178aa07898573cf13ef8e3a3b3b7256a67)

[fix(api-generator): don't load remote schemas](https://github.com/syndesisio/syndesis/commit/d204936d73c458198ad9cb3e51784bed8ec0e21d)

We should not reach out and load remote XML schemas from
schemas.xmlsoap.org.

Background: it seems that recently schemas.xmlsoap.org website
configured HTTP to HTTPS redirect and in doing so broke our WSDL parser
as it will try to fetch without following HTTP redirects. This results
in empty HTTP body that the parser tries to parse and fails with:

```
org.xml.sax.SAXParseException: Premature end of file.
```

To resolve this this stores the two identified XSD files locally and
sets the custom EntityResolver via a custom WSDLLocator to load those
instead. The same is done for the CXF schema parsing classes which can
load the catalog files from `META-INF/jax-ws-catalog.xml`.

(cherry picked from commit 800357b3a2dd7148acf92f3429e23bc029cbc18c)
