### PR TITLE
ENTESB-18466 - Reworking of operator conditions ensuring step upgrades

### DIFF
--- a/install/operator/build.sh
+++ b/install/operator/build.sh
@@ -45,7 +45,8 @@ fi
 BUILD_TIME=$(date +%Y-%m-%dT%H:%M:%S%z)
 
 if [ $OPERATOR_BUILD_MODE != "skip" ] ; then
-	LD_FLAGS=$(echo "-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorImage=${OPERATOR_IMAGE_NAME}" \
+	LD_FLAGS=$(echo "-s -w " \
+	  "-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorImage=${OPERATOR_IMAGE_NAME}" \
 		"-X github.com/syndesisio/syndesis/install/operator/pkg.DefaultOperatorTag=${OPERATOR_IMAGE_TAG}" \
 		"-X github.com/syndesisio/syndesis/install/operator/pkg.BuildDateTime=${BUILD_TIME}")
 	echo "LD_FLAGS: ${LD_FLAGS}"

--- a/install/operator/build/Dockerfile
+++ b/install/operator/build/Dockerfile
@@ -1,11 +1,13 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/syndesis-operator \
+    OPINIT=/usr/local/bin/operator-init \
     USER_UID=1001 \
     USER_NAME=operator
 
 # install operator binary
 COPY build/_output/bin/syndesis-operator ${OPERATOR}
+COPY build/_output/bin/operator-init ${OPINIT}
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 USER ${USER_UID}

--- a/install/operator/cmd/operator-init/main.go
+++ b/install/operator/cmd/operator-init/main.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	gerrors "github.com/pkg/errors"
+	synapis "github.com/syndesisio/syndesis/install/operator/pkg/apis"
+	synapi "github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1beta3"
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/clienttools"
+	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/olm"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func main() {
+	clientTools := &clienttools.ClientTools{}
+
+	//
+	// Ensure runtime client knows about syndesis apis
+	//
+	scheme := clientTools.GetScheme()
+	if err := synapis.AddToScheme(scheme); err != nil {
+		fmt.Println(err, "Error occurred")
+		os.Exit(1)
+	}
+
+	ctx := context.TODO()
+
+	nm, found := os.LookupEnv("POD_NAMESPACE")
+	if !found {
+		fmt.Println("Error: No POD_NAMESPACE has been set")
+		os.Exit(1)
+	} else {
+		fmt.Println("Info: Using POD_NAMESPACE: ", nm)
+	}
+
+	prodName, found := os.LookupEnv("PRODUCT_NAME")
+	if !found {
+		fmt.Println("Error: No PRODUCT_NAME has been set")
+		os.Exit(1)
+	} else {
+		fmt.Println("Info: Using PRODUCT_NAME: ", prodName)
+	}
+
+	if err := setUpgradeCondition(ctx, clientTools, nm, prodName); err != nil {
+		fmt.Println(err, "Error occurred")
+		os.Exit(1)
+	}
+}
+
+func setUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientTools, nm string, prodName string) error {
+	found, err := hasSyndesis(ctx, clientTools, nm)
+	if err != nil {
+		return gerrors.Wrap(err, "Failed to get Syndesis resource")
+	} else if !found {
+		fmt.Println("Info: No Syndesis Custom Resource. Upgrade disablement not required")
+		return nil
+	}
+
+	//
+	// Disable the upgrade until enabled
+	//
+	state := olm.ConditionState{
+		Status:  metav1.ConditionFalse,
+		Reason:  "NotReady",
+		Message: "Disable any operator upgrade until reconciliation allows it",
+	}
+	if upgErr := olm.SetUpgradeCondition(ctx, clientTools, nm, prodName, state); upgErr != nil {
+		return gerrors.Wrap(upgErr, "Failed to set the upgrade condition on the operator")
+	}
+
+	return nil
+}
+
+func hasSyndesis(ctx context.Context, clientTools *clienttools.ClientTools, nm string) (bool, error) {
+	synList := synapi.SyndesisList{}
+	rtclient, err := clientTools.RuntimeClient()
+	if err != nil {
+		return false, err
+	}
+
+	err = rtclient.List(ctx, &synList, &client.ListOptions{Namespace: nm})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return len(synList.Items) > 0, nil
+}

--- a/install/operator/config/manager/Makefile
+++ b/install/operator/config/manager/Makefile
@@ -6,6 +6,8 @@ USER_VAR := {KUBE_USER}
 TAG_VAR := {TAG}
 IMAGE_VAR := {IMAGE}
 DB_IMAGE_VAR := {DB_IMAGE}
+VERSION_VAR := {VERSION}
+PRODUCT_NAME_VAR := {PRODUCT_NAME}
 
 ROLENAME := syndesis-operator
 MANAGER_RESOURCE := ./manager.gen
@@ -42,6 +44,8 @@ sync:
 	sed -i 's/{{.Tag}}/$(TAG_VAR)/' $(MANAGER_RESOURCE).$(TMPL)
 	sed -i 's/{{.Image}}/$(IMAGE_VAR)/' $(MANAGER_RESOURCE).$(TMPL)
 	sed -i 's/{{.DatabaseImage}}/$(DB_IMAGE_VAR)/' $(MANAGER_RESOURCE).$(TMPL)
+	sed -i 's/{{.Version}}/$(VERSION_VAR)/' $(MANAGER_RESOURCE).$(TMPL)
+	sed -i 's/{{.ProductName}}/$(PRODUCT_NAME_VAR)/' $(MANAGER_RESOURCE).$(TMPL)
 	sed -i '/{{- \|{{else}}\|{{end}}\|^$$/d' $(MANAGER_RESOURCE).$(TMPL)
 # end-sync
 
@@ -52,4 +56,6 @@ init: sync
 		sed -i 's/$(TAG_VAR)/$(TAG)/' $${resource}.$(YAML); \
 		sed -i 's~$(IMAGE_VAR)~$(IMAGE)~' $${resource}.$(YAML); \
 		sed -i 's~$(DB_IMAGE_VAR)~$(DB_IMAGE)~' $${resource}.$(YAML); \
+		sed -i 's~$(VERSION_VAR)~$(VERSION:.0=)~' $${resource}.$(YAML); \
+		sed -i 's~$(PRODUCT_NAME_VAR)~$(PACKAGE:.0=)~' $${resource}.$(YAML); \
 	done

--- a/install/operator/pkg/cmd/internal/install/install.go
+++ b/install/operator/pkg/cmd/internal/install/install.go
@@ -46,6 +46,7 @@ type Install struct {
 	eject          string
 	image          string
 	tag            string
+	version        string
 	addons         string
 	customResource string
 	devSupport     bool
@@ -53,6 +54,7 @@ type Install struct {
 	apiServer      capabilities.ApiServerSpec
 	databaseImage  string
 	templateName   string
+	productName    string
 
 	// processing state
 	ejectedResources []unstructured.Unstructured
@@ -165,6 +167,8 @@ func (o *Install) before(_ *cobra.Command, args []string) (err error) {
 	config, err := configuration.GetProperties(o.Context, configuration.TemplateConfig, o.ClientTools(), &synapi.Syndesis{})
 	if err == nil {
 		o.databaseImage = config.Syndesis.Components.Database.Image
+		o.version = config.Version
+		o.productName = config.ProductName
 	}
 
 	return nil
@@ -210,7 +214,9 @@ type RenderScope struct {
 	Role          string
 	Kind          string
 	EnabledAddons []string
+	Version       string
 	DatabaseImage string
+	ProductName   string
 }
 
 func (o *Install) install(action string, resources []unstructured.Unstructured) error {
@@ -270,6 +276,8 @@ func (o *Install) render(fromFile string) ([]unstructured.Unstructured, error) {
 		Kind:          "Role",
 		EnabledAddons: addons,
 		DatabaseImage: o.databaseImage,
+		Version:       o.version,
+		ProductName:   o.productName,
 	})
 	return resources, err
 }

--- a/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
+++ b/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
@@ -74,6 +74,17 @@ spec:
         - name: syndesis-operator-data
           mountPath: /data
       initContainers:
+      - name: operator-init
+        image: {{.Image}}:{{.Tag}}
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/operator-init"]
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: PRODUCT_NAME
+            value: {{.ProductName}}
       - command:
         - bash
         - -c

--- a/install/operator/pkg/syndesis/action/action.go
+++ b/install/operator/pkg/syndesis/action/action.go
@@ -36,7 +36,7 @@ var actionLog = logf.Log.WithName("action")
 
 type SyndesisOperatorAction interface {
 	CanExecute(syndesis *synapi.Syndesis) bool
-	Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error
+	Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error
 }
 
 // NewOperatorActions gives the default set of actions operator will perform

--- a/install/operator/pkg/syndesis/action/backup.go
+++ b/install/operator/pkg/syndesis/action/backup.go
@@ -49,7 +49,7 @@ func (a *backupAction) CanExecute(syndesis *synapi.Syndesis) bool {
 }
 
 // Schedule a cronjob for systematic backups
-func (a *backupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *backupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	entries := c.Entries()
 
 	if s := syndesis.Spec.Backup.Schedule; s != "" {

--- a/install/operator/pkg/syndesis/action/checkupdates.go
+++ b/install/operator/pkg/syndesis/action/checkupdates.go
@@ -32,7 +32,7 @@ func (a checkUpdatesAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseStartupFailed)
 }
 
-func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	if a.operatorVersion == "" {
 		a.operatorVersion = pkg.DefaultOperatorTag
 	}
@@ -41,7 +41,7 @@ func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndes
 		// Everything fine
 		return nil
 	} else {
-		return a.setPhaseToUpgrading(ctx, syndesis, operatorNamespace)
+		return a.setPhaseToUpgrading(ctx, syndesis, operatorNamespace, productName)
 	}
 }
 
@@ -50,7 +50,7 @@ func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndes
  * needed to avoid race conditions where k8s wasn't able to update or
  * kubernetes didn't change the object yet
  */
-func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) (err error) {
+func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) (err error) {
 
 	// Declare an upgradeable Condition as false if applicable
 	state := olm.ConditionState{
@@ -58,7 +58,7 @@ func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *s
 		Reason:  "Upgrading",
 		Message: "Operator is upgrading the components",
 	}
-	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
+	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
 	if err != nil {
 		a.log.Error(err, "Failed to set the upgrade condition on the operator")
 	}

--- a/install/operator/pkg/syndesis/action/initialize.go
+++ b/install/operator/pkg/syndesis/action/initialize.go
@@ -31,7 +31,7 @@ func (a *initializeAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseNotInstalled)
 }
 
-func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	list := synapi.SyndesisList{}
 	rtClient, _ := a.clientTools.RuntimeClient()
 	err := rtClient.List(ctx, &list, &client.ListOptions{Namespace: syndesis.Namespace})
@@ -54,7 +54,7 @@ func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesi
 			Reason:  "Initializing",
 			Message: "Operator is installing",
 		}
-		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
+		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
 		if err != nil {
 			a.log.Error(err, "Failed to set the upgrade condition on the operator")
 		}

--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -96,7 +96,7 @@ func (a *installAction) CanExecute(syndesis *synapi.Syndesis) bool {
 
 var kindsReportedNotAvailable = map[schema.GroupVersionKind]time.Time{}
 
-func (a *installAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *installAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	if syndesisPhaseIs(syndesis, synapi.SyndesisPhaseInstalling) {
 		a.log.Info("installing Syndesis resource", "name", syndesis.Name)
 	} else if syndesisPhaseIs(syndesis, synapi.SyndesisPhasePostUpgradeRun) {

--- a/install/operator/pkg/syndesis/action/pod_scheduling.go
+++ b/install/operator/pkg/syndesis/action/pod_scheduling.go
@@ -43,7 +43,7 @@ func (a *podSchedulingAction) CanExecute(syndesis *synapi.Syndesis) bool {
 	return canExecute
 }
 
-func (a *podSchedulingAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *podSchedulingAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	if a.updateIntegrationScheduling {
 		a.executeIntegrationScheduling(ctx, syndesis)
 	}

--- a/install/operator/pkg/syndesis/action/startup.go
+++ b/install/operator/pkg/syndesis/action/startup.go
@@ -33,7 +33,7 @@ func (a *startupAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseStartupFailed)
 }
 
-func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 
 	list := v1.DeploymentConfigList{
 		TypeMeta: metav1.TypeMeta{
@@ -78,7 +78,7 @@ func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, 
 			Reason:  "Started",
 			Message: "Operator and components have been successfully started",
 		}
-		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
+		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
 		if err != nil {
 			a.log.Error(err, "Failed to set the upgrade condition on the operator")
 		}

--- a/install/operator/pkg/syndesis/action/upgrade.go
+++ b/install/operator/pkg/syndesis/action/upgrade.go
@@ -42,7 +42,7 @@ func (a *upgradeAction) CanExecute(syndesis *synapi.Syndesis) bool {
 	)
 }
 
-func (a *upgradeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *upgradeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	targetVersion := pkg.DefaultOperatorTag
 
 	if syndesis.Status.Phase == synapi.SyndesisPhaseUpgrading {
@@ -76,7 +76,7 @@ func (a *upgradeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, 
 	} else if syndesis.Status.Phase == synapi.SyndesisPhasePostUpgradeRunSucceed {
 		// We land here only if the install phase after upgrading finished correctly
 		a.log.Info("syndesis resource post upgrade ran successfully", "name", syndesis.Name, "previous version", syndesis.Status.Version, "target version", targetVersion)
-		return a.completeUpgrade(ctx, syndesis, targetVersion, operatorNamespace)
+		return a.completeUpgrade(ctx, syndesis, targetVersion, operatorNamespace, productName)
 	} else if syndesis.Status.Phase == synapi.SyndesisPhasePostUpgradeRun {
 		// If the first run of the install action failed, we land here. We need to retry
 		// this few times to consider the cases where install action return error due to
@@ -104,14 +104,14 @@ func (a *upgradeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, 
  * needed to avoid race conditions where k8s wasn't yet able to update or
  * kubernetes didn't change the object yet
  */
-func (a *upgradeAction) completeUpgrade(ctx context.Context, syndesis *synapi.Syndesis, newVersion string, operatorNamespace string) (err error) {
+func (a *upgradeAction) completeUpgrade(ctx context.Context, syndesis *synapi.Syndesis, newVersion string, operatorNamespace string, productName string) (err error) {
 	// Declare the operator upgradeable, if applicable
 	state := olm.ConditionState{
 		Status:  metav1.ConditionTrue,
 		Reason:  "CompletedUpgrade",
 		Message: "Operator component state has been upgraded",
 	}
-	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
+	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
 	if err != nil {
 		a.log.Error(err, "Failed to set the upgrade condition on the operator")
 	}

--- a/install/operator/pkg/syndesis/action/upgradebackoff.go
+++ b/install/operator/pkg/syndesis/action/upgradebackoff.go
@@ -33,7 +33,7 @@ func (a *upgradeBackoffAction) CanExecute(syndesis *synapi.Syndesis) bool {
 	return syndesisPhaseIs(syndesis, synapi.SyndesisPhaseUpgradeFailureBackoff)
 }
 
-func (a *upgradeBackoffAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
+func (a *upgradeBackoffAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
 	rtClient, _ := a.clientTools.RuntimeClient()
 
 	// Check number of attempts to fail fast

--- a/install/operator/pkg/syndesis/olm/csv.go
+++ b/install/operator/pkg/syndesis/olm/csv.go
@@ -178,6 +178,7 @@ func (c *csv) setVariables() {
 	c.config.ApiServer.EmbeddedProvider = true
 	c.config.ApiServer.OlmSupport = true
 	c.config.ApiServer.ConsoleLink = true
+	c.config.ProductName = "fuse-online"
 
 	// Dependant on whether it is community or productized
 	c.name = "fuse-online-operator"
@@ -189,6 +190,7 @@ func (c *csv) setVariables() {
 	c.provider = "Red Hat"
 
 	if !c.config.Productized {
+		c.config.ProductName = "syndesis"
 		c.name = "syndesis-operator"
 		c.displayName = "Syndesis"
 		c.support = "Syndesis"
@@ -425,6 +427,8 @@ func (c *csv) loadDeploymentFromTemplate() (r interface{}, err error) {
 		ExporterImage   string
 		DevSupport      bool
 		LogLevel        int
+		Version         string
+		ProductName     string
 	}{
 		Image:           c.image,
 		Tag:             c.tag,
@@ -441,6 +445,8 @@ func (c *csv) loadDeploymentFromTemplate() (r interface{}, err error) {
 		ExporterImage:   c.config.Syndesis.Components.Database.Exporter.Image,
 		DevSupport:      false, // Never be true in CSV generation - here for template compatibility
 		LogLevel:        0,     // Never to be more in CSV generation - here for template compatibility
+		Version:         c.version,
+		ProductName:     c.config.ProductName,
 	}
 
 	g, err := generator.Render("assets/install/operator_deployment.yml.tmpl", context)

--- a/install/operator/pkg/syndesis/olm/operator_conditions.go
+++ b/install/operator/pkg/syndesis/olm/operator_conditions.go
@@ -26,7 +26,6 @@ import (
 	synpkg "github.com/syndesisio/syndesis/install/operator/pkg"
 	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/capabilities"
 	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/clienttools"
-	"github.com/syndesisio/syndesis/install/operator/pkg/syndesis/configuration"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +46,7 @@ type ConditionState struct {
 	Message string
 }
 
-func GetConditionName(ctx context.Context, clientTools *clienttools.ClientTools, namespace string) (string, error) {
+func GetConditionName(ctx context.Context, clientTools *clienttools.ClientTools, namespace string, productName string) (string, error) {
 	opCondLog.V(synpkg.DEBUG_LOGGING_LVL).Info("Finding OLM Operator Condition")
 
 	apiSpec, err := capabilities.ApiCapabilities(clientTools)
@@ -73,11 +72,7 @@ func GetConditionName(ctx context.Context, clientTools *clienttools.ClientTools,
 	//
 	// deployment -> owned by CSV -> operator condition has the same name
 	//
-	configName, err := configuration.GetProductName(configuration.TemplateConfig)
-	if err != nil {
-		return "", errs.Wrap(err, "Failed to determine product name")
-	}
-	deploymentName := configName + "-operator"
+	deploymentName := productName + "-operator"
 
 	opCondLog.V(synpkg.DEBUG_LOGGING_LVL).Info("Finding Operator Deployment", "name", deploymentName)
 	deployment := &appsv1.Deployment{}
@@ -104,9 +99,9 @@ func GetConditionName(ctx context.Context, clientTools *clienttools.ClientTools,
 //
 // Creates the condition if it does not already exist
 //
-func SetUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientTools, namespace string, state ConditionState) error {
+func SetUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientTools, namespace string, productName string, state ConditionState) error {
 
-	conditionName, err := GetConditionName(ctx, clientTools, namespace)
+	conditionName, err := GetConditionName(ctx, clientTools, namespace, productName)
 	if err != nil {
 		return err
 	} else if conditionName == "" {

--- a/install/operator/pkg/syndesis/olm/operator_conditions_test.go
+++ b/install/operator/pkg/syndesis/olm/operator_conditions_test.go
@@ -110,7 +110,7 @@ func TestConditions_GetOperationConditionName(t *testing.T) {
 	nsi := coreClient.Namespaces()
 	nsi.Create(context.TODO(), opsNS, metav1.CreateOptions{})
 
-	name, err := GetConditionName(context.TODO(), clientTools, testNS)
+	name, err := GetConditionName(context.TODO(), clientTools, testNS, confName)
 	assert.NoError(t, err)
 
 	assert.Equal(t, csvName, name)
@@ -165,8 +165,6 @@ func TestConditions_SetOperationCondition(t *testing.T) {
 		Reason:  "testing the turn off",
 	}
 
-	err = SetUpgradeCondition(context.TODO(), clientTools, testNS, status)
+	err = SetUpgradeCondition(context.TODO(), clientTools, testNS, confName, status)
 	assert.NoError(t, err)
-
-	// assert.Equal(t,
 }


### PR DESCRIPTION

While performing a double upgrade, ie. 1.13.0 -> 1.14.0 -> 1.14.1, the reconcile function was never being called and hence the operatorcondition for delaying the operator upgrade was never applied. To workaround this a new init-container is executed in front of the operator container that calls a partner binary (operator-init). This binary sits in the same operator image so no need to build another image (just override the command).
operator-init detects existence of a Syndesis resource, and if present, applies the operatorcondition. Since this is an init-container, the operator has not even started so no race conditions and guranteed that the next upgrade just cannot start ahead of the operatorcondition being set.
Only when the reconciled has correctly processed the operands, done the upgrade etc., is the operatorcondition released, allowing the next operator to kick in.

The visual manifestation of this is that the 1.14.1 operator appears in the list of operators but remains pending.
