### PR TITLE
[ENTESB-18911] UnsatisfiedDependencyException in integration with MongoDB connector

### DIFF
--- a/app/connector/mongodb/pom.xml
+++ b/app/connector/mongodb/pom.xml
@@ -42,7 +42,7 @@
       </dependency>
       <dependency>
         <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
+        <artifactId>mongodb-driver-legacy</artifactId>
         <version>${mongodb.version}</version>
       </dependency>
     </dependencies>

--- a/app/extension/bom/pom.xml
+++ b/app/extension/bom/pom.xml
@@ -33,7 +33,7 @@
     <camel.version>2.23.2.fuse-7_10_0-00020-redhat-00001</camel.version>
     <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
-    <mongodb.version>3.9.0</mongodb.version>
+    <mongodb.version>4.2.3</mongodb.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <netty.version>4.1.68.Final</netty.version>
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
@@ -121,7 +121,7 @@
       <!-- Overriden Spring boot BOM dependecies -->
       <dependency>
         <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
+        <artifactId>mongodb-driver-legacy</artifactId>
         <version>${mongodb.version}</version>
       </dependency>
 

--- a/app/integration/bom/pom.xml
+++ b/app/integration/bom/pom.xml
@@ -34,7 +34,7 @@
     <atlasmap.version>2.3.14</atlasmap.version>
     <jackson.version>2.11.2</jackson.version>
     <!-- any change to mongodb driver version, should be updated to parent pom.xml -->
-    <mongodb.version>3.12.7</mongodb.version>
+    <mongodb.version>4.2.3</mongodb.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <netty.version>4.1.68.Final</netty.version>
     <kubernetes.client.version>4.13.3</kubernetes.client.version>
@@ -126,7 +126,7 @@
       <!-- Overriden Spring boot BOM dependecies -->
       <dependency>
         <groupId>org.mongodb</groupId>
-        <artifactId>mongo-java-driver</artifactId>
+        <artifactId>mongodb-driver-legacy</artifactId>
         <version>${mongodb.version}</version>
       </dependency>
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -147,7 +147,7 @@
     <docker-java.version>3.2.12</docker-java.version>
     <citrus.version>2.8.0</citrus.version>
     <mockito.version>4.0.0</mockito.version>
-    <mongodb.version>3.12.7</mongodb.version>
+    <mongodb.version>4.2.3</mongodb.version>
     <libthrift.version>0.14.1</libthrift.version>
 
     <resteasy.version>4.6.0.Final</resteasy.version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-18911

Spring Boot 2.5.12 uses MongoDB 4.2.3
https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.12/spring-boot-dependencies-2.5.12.pom

This needs to be synchronized.