### PR TITLE
[ENTESB-18911] UnsatisfiedDependencyException in integration with MongoDB connector

### DIFF
--- a/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
+++ b/app/integration/project-generator/src/main/resources/io/syndesis/integration/project/generator/templates/application.properties.mustache
@@ -31,6 +31,7 @@ camel.component.servlet.headerFilterStrategy-class-name=io.syndesis.connector.su
 spring.autoconfigure.exclude[0] = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 spring.autoconfigure.exclude[1] = org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
 spring.autoconfigure.exclude[2] = org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+spring.autoconfigure.exclude[3] = org.springframework.boot.actuate.autoconfigure.metrics.mongo.MongoMetricsAutoConfiguration
 
 {{#configuration.isActivityTracing}}
 # Jaeger/Opentracing

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application-tracing.properties
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application-tracing.properties
@@ -31,6 +31,7 @@ camel.component.servlet.headerFilterStrategy-class-name=io.syndesis.connector.su
 spring.autoconfigure.exclude[0] = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 spring.autoconfigure.exclude[1] = org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
 spring.autoconfigure.exclude[2] = org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+spring.autoconfigure.exclude[3] = org.springframework.boot.actuate.autoconfigure.metrics.mongo.MongoMetricsAutoConfiguration
 
 # Jaeger/Opentracing
 jaeger.service.name = test-integration

--- a/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application.properties
+++ b/app/integration/project-generator/src/test/resources/io/syndesis/integration/project/generator/testGenerateProject/application.properties
@@ -31,3 +31,4 @@ camel.component.servlet.headerFilterStrategy-class-name=io.syndesis.connector.su
 spring.autoconfigure.exclude[0] = org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 spring.autoconfigure.exclude[1] = org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
 spring.autoconfigure.exclude[2] = org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+spring.autoconfigure.exclude[3] = org.springframework.boot.actuate.autoconfigure.metrics.mongo.MongoMetricsAutoConfiguration

--- a/app/server/cli/src/main/resources/application.yml
+++ b/app/server/cli/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
     - org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration
     - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
     - org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+    - org.springframework.boot.actuate.autoconfigure.metrics.mongo.MongoMetricsAutoConfiguration
   cache:
     type: none
 logging:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-18911

Caused by autoconfiguration of MongoDB metrics - tries to use a class from MongoDB 4