### PR TITLE
Fix (ENTESB-18466): do not rely on product name for operator condition

### DIFF
--- a/install/operator/cmd/operator-init/main.go
+++ b/install/operator/cmd/operator-init/main.go
@@ -53,21 +53,13 @@ func main() {
 		fmt.Println("Info: Using POD_NAMESPACE: ", nm)
 	}
 
-	prodName, found := os.LookupEnv("PRODUCT_NAME")
-	if !found {
-		fmt.Println("Error: No PRODUCT_NAME has been set")
-		os.Exit(1)
-	} else {
-		fmt.Println("Info: Using PRODUCT_NAME: ", prodName)
-	}
-
-	if err := setUpgradeCondition(ctx, clientTools, nm, prodName); err != nil {
+	if err := setUpgradeCondition(ctx, clientTools, nm); err != nil {
 		fmt.Println(err, "Error occurred")
 		os.Exit(1)
 	}
 }
 
-func setUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientTools, nm string, prodName string) error {
+func setUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientTools, nm string) error {
 	found, err := hasSyndesis(ctx, clientTools, nm)
 	if err != nil {
 		return gerrors.Wrap(err, "Failed to get Syndesis resource")
@@ -84,7 +76,7 @@ func setUpgradeCondition(ctx context.Context, clientTools *clienttools.ClientToo
 		Reason:  "NotReady",
 		Message: "Disable any operator upgrade until reconciliation allows it",
 	}
-	if upgErr := olm.SetUpgradeCondition(ctx, clientTools, nm, prodName, state); upgErr != nil {
+	if upgErr := olm.SetUpgradeCondition(ctx, clientTools, nm, state); upgErr != nil {
 		return gerrors.Wrap(upgErr, "Failed to set the upgrade condition on the operator")
 	}
 

--- a/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
+++ b/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
@@ -83,8 +83,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: PRODUCT_NAME
-            value: {{.ProductName}}
       - command:
         - bash
         - -c

--- a/install/operator/pkg/syndesis/action/action.go
+++ b/install/operator/pkg/syndesis/action/action.go
@@ -36,7 +36,7 @@ var actionLog = logf.Log.WithName("action")
 
 type SyndesisOperatorAction interface {
 	CanExecute(syndesis *synapi.Syndesis) bool
-	Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error
+	Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error
 }
 
 // NewOperatorActions gives the default set of actions operator will perform

--- a/install/operator/pkg/syndesis/action/backup.go
+++ b/install/operator/pkg/syndesis/action/backup.go
@@ -49,7 +49,7 @@ func (a *backupAction) CanExecute(syndesis *synapi.Syndesis) bool {
 }
 
 // Schedule a cronjob for systematic backups
-func (a *backupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *backupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	entries := c.Entries()
 
 	if s := syndesis.Spec.Backup.Schedule; s != "" {

--- a/install/operator/pkg/syndesis/action/checkupdates.go
+++ b/install/operator/pkg/syndesis/action/checkupdates.go
@@ -32,7 +32,7 @@ func (a checkUpdatesAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseStartupFailed)
 }
 
-func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	if a.operatorVersion == "" {
 		a.operatorVersion = pkg.DefaultOperatorTag
 	}
@@ -41,7 +41,7 @@ func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndes
 		// Everything fine
 		return nil
 	} else {
-		return a.setPhaseToUpgrading(ctx, syndesis, operatorNamespace, productName)
+		return a.setPhaseToUpgrading(ctx, syndesis, operatorNamespace)
 	}
 }
 
@@ -50,7 +50,7 @@ func (a checkUpdatesAction) Execute(ctx context.Context, syndesis *synapi.Syndes
  * needed to avoid race conditions where k8s wasn't able to update or
  * kubernetes didn't change the object yet
  */
-func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) (err error) {
+func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) (err error) {
 
 	// Declare an upgradeable Condition as false if applicable
 	state := olm.ConditionState{
@@ -58,7 +58,7 @@ func (a checkUpdatesAction) setPhaseToUpgrading(ctx context.Context, syndesis *s
 		Reason:  "Upgrading",
 		Message: "Operator is upgrading the components",
 	}
-	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
+	err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
 	if err != nil {
 		a.log.Error(err, "Failed to set the upgrade condition on the operator")
 	}

--- a/install/operator/pkg/syndesis/action/initialize.go
+++ b/install/operator/pkg/syndesis/action/initialize.go
@@ -31,7 +31,7 @@ func (a *initializeAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseNotInstalled)
 }
 
-func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	list := synapi.SyndesisList{}
 	rtClient, _ := a.clientTools.RuntimeClient()
 	err := rtClient.List(ctx, &list, &client.ListOptions{Namespace: syndesis.Namespace})
@@ -54,7 +54,7 @@ func (a *initializeAction) Execute(ctx context.Context, syndesis *synapi.Syndesi
 			Reason:  "Initializing",
 			Message: "Operator is installing",
 		}
-		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
+		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
 		if err != nil {
 			a.log.Error(err, "Failed to set the upgrade condition on the operator")
 		}

--- a/install/operator/pkg/syndesis/action/install.go
+++ b/install/operator/pkg/syndesis/action/install.go
@@ -96,7 +96,7 @@ func (a *installAction) CanExecute(syndesis *synapi.Syndesis) bool {
 
 var kindsReportedNotAvailable = map[schema.GroupVersionKind]time.Time{}
 
-func (a *installAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *installAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	if syndesisPhaseIs(syndesis, synapi.SyndesisPhaseInstalling) {
 		a.log.Info("installing Syndesis resource", "name", syndesis.Name)
 	} else if syndesisPhaseIs(syndesis, synapi.SyndesisPhasePostUpgradeRun) {

--- a/install/operator/pkg/syndesis/action/pod_scheduling.go
+++ b/install/operator/pkg/syndesis/action/pod_scheduling.go
@@ -43,7 +43,7 @@ func (a *podSchedulingAction) CanExecute(syndesis *synapi.Syndesis) bool {
 	return canExecute
 }
 
-func (a *podSchedulingAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *podSchedulingAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	if a.updateIntegrationScheduling {
 		a.executeIntegrationScheduling(ctx, syndesis)
 	}

--- a/install/operator/pkg/syndesis/action/startup.go
+++ b/install/operator/pkg/syndesis/action/startup.go
@@ -33,7 +33,7 @@ func (a *startupAction) CanExecute(syndesis *synapi.Syndesis) bool {
 		synapi.SyndesisPhaseStartupFailed)
 }
 
-func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 
 	list := v1.DeploymentConfigList{
 		TypeMeta: metav1.TypeMeta{
@@ -78,7 +78,7 @@ func (a *startupAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, 
 			Reason:  "Started",
 			Message: "Operator and components have been successfully started",
 		}
-		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, productName, state)
+		err = olm.SetUpgradeCondition(ctx, a.clientTools, operatorNamespace, state)
 		if err != nil {
 			a.log.Error(err, "Failed to set the upgrade condition on the operator")
 		}

--- a/install/operator/pkg/syndesis/action/upgradebackoff.go
+++ b/install/operator/pkg/syndesis/action/upgradebackoff.go
@@ -33,7 +33,7 @@ func (a *upgradeBackoffAction) CanExecute(syndesis *synapi.Syndesis) bool {
 	return syndesisPhaseIs(syndesis, synapi.SyndesisPhaseUpgradeFailureBackoff)
 }
 
-func (a *upgradeBackoffAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string, productName string) error {
+func (a *upgradeBackoffAction) Execute(ctx context.Context, syndesis *synapi.Syndesis, operatorNamespace string) error {
 	rtClient, _ := a.clientTools.RuntimeClient()
 
 	// Check number of attempts to fail fast

--- a/install/operator/pkg/syndesis/olm/operator_conditions_test.go
+++ b/install/operator/pkg/syndesis/olm/operator_conditions_test.go
@@ -39,6 +39,7 @@ func deployment(name string, owner client.Object, namespace string) *appsv1.Depl
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
+			Labels:    map[string]string{"syndesis.io/app": "syndesis", "syndesis.io/type": "operator"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: owner.GetName(),
@@ -110,7 +111,7 @@ func TestConditions_GetOperationConditionName(t *testing.T) {
 	nsi := coreClient.Namespaces()
 	nsi.Create(context.TODO(), opsNS, metav1.CreateOptions{})
 
-	name, err := GetConditionName(context.TODO(), clientTools, testNS, confName)
+	name, err := GetConditionName(context.TODO(), clientTools, testNS)
 	assert.NoError(t, err)
 
 	assert.Equal(t, csvName, name)
@@ -165,6 +166,6 @@ func TestConditions_SetOperationCondition(t *testing.T) {
 		Reason:  "testing the turn off",
 	}
 
-	err = SetUpgradeCondition(context.TODO(), clientTools, testNS, confName, status)
+	err = SetUpgradeCondition(context.TODO(), clientTools, testNS, status)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
* Operator-init looks up the deployment name by filtering
  on labels. Avoids need to specify the product name