### PR TITLE
fix operator: link service account to secret token

### DIFF
--- a/install/operator/.lib.sh
+++ b/install/operator/.lib.sh
@@ -145,6 +145,7 @@ build_operator()
         done
         mkdir -p ./build/_output/bin
         cp ./dist/linux-amd64/syndesis-operator ./build/_output/bin/syndesis-operator
+        cp ./dist/linux-amd64/operator-init ./build/_output/bin/operator-init
 
     ;;
     "docker")

--- a/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
+++ b/install/operator/pkg/generator/assets/install/operator_deployment.yml.tmpl
@@ -8,7 +8,7 @@ metadata:
     # the template.spec.image property and point to
     # the syndesis-operator image stream.
     #
-    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"syndesis-operator:{{.Tag}}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"syndesis-operator\")].image"}]'
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"syndesis-operator:{{.Tag}}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"syndesis-operator\")].image"},{"from":{"kind":"ImageStreamTag","name":"syndesis-operator:{{.Tag}}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"operator-init\")].image"}]'
   {{end}}
   name: syndesis-operator
   labels:

--- a/install/operator/pkg/syndesis/olm/operator_conditions.go
+++ b/install/operator/pkg/syndesis/olm/operator_conditions.go
@@ -78,7 +78,7 @@ func getOperatorDeployment(ctx context.Context, clientTools *clienttools.ClientT
 		return nil, errs.New("Cannot find any labelled operator deployments")
 	}
 
-	opCondLog.V(synpkg.DEBUG_LOGGING_LVL).Info("Using Deployment: ", deployments.Items[0].Name)
+	opCondLog.V(synpkg.DEBUG_LOGGING_LVL).Info("Using Deployment: ", "name", deployments.Items[0].Name)
 	return &deployments.Items[0], nil
 }
 


### PR DESCRIPTION
* Openshift 4.11 is based on kubernetes 1.24, which introduced KEP-2799 which doesn't create the Secret (token) anymore, then the user should create the Secret (token) and link to the SA.
* fix build: copy operator-init binary
* fix ImageStream of operator-init for dev build in operator deployment
  yaml