### PR TITLE
fix(sec): upgrade github.com/docker/docker to 

### DIFF
--- a/install/operator/vendor/github.com/testcontainers/testcontainers-go/go.mod
+++ b/install/operator/vendor/github.com/testcontainers/testcontainers-go/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
-	github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661
+	github.com/docker/docker v23.0.3+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/gin-gonic/gin v1.5.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661
- [CVE-2015-3627](https://www.oscs1024.com/hd/CVE-2015-3627)


### What did I do？
Upgrade github.com/docker/docker from v0.7.3-0.20190506211059-b20a14b54661 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS