### PR TITLE
fix(sec): upgrade gopkg.in/yaml.v2 to 

### DIFF
--- a/install/operator/vendor/github.com/ghodss/yaml/go.mod
+++ b/install/operator/vendor/github.com/ghodss/yaml/go.mod
@@ -1,3 +1,7 @@
 module github.com/ghodss/yaml
 
-require gopkg.in/yaml.v2 v2.2.2
+go 1.19
+
+require gopkg.in/yaml.v2 v2.2.8
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect

--- a/install/operator/vendor/github.com/ghodss/yaml/go.sum
+++ b/install/operator/vendor/github.com/ghodss/yaml/go.sum
@@ -1,3 +1,5 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gopkg.in/yaml.v2 v2.2.2
- [CVE-2019-11254](https://www.oscs1024.com/hd/CVE-2019-11254)


### What did I do？
Upgrade gopkg.in/yaml.v2 from v2.2.2 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS