### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -33,7 +33,7 @@ jobs:
           RELEASE_TAGS=$(git tag --contains $(git rev-parse HEAD) | grep "^${BRANCH/.x/}") || true
           if [ -n "${RELEASE_TAGS}" ]; then
             echo The latest change was already included in a release, skipping release
-            echo ::set-output name=skip::true
+            echo "skip=true" >> $GITHUB_OUTPUT
           fi
       - name: Set up JDK ${{ matrix.java }}
         if: steps.should.outputs.skip != 'true'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


